### PR TITLE
fix: show episodes for ONA/OVA anime, not just TV type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -45,7 +45,7 @@ const TRANSLATION_TYPES = [
 
 const tvEpisodes = computed(() => {
   if (!anime.value) return []
-  return anime.value.episodes.filter(ep => ep.episodeType === 'tv' && ep.isActive === 1)
+  return anime.value.episodes.filter(ep => ep.episodeType !== 'preview' && ep.isActive === 1)
 })
 
 const PAGE_SIZE = 30


### PR DESCRIPTION
## Summary

- The `tvEpisodes` filter in `AnimeDetailView.vue` was hardcoded to `episodeType === 'tv'`, causing anime classified as ONA, OVA, movie, etc. to show zero episodes
- Fixed by filtering out only `'preview'` (trailer) episodes instead, so all active episode types are shown
- Bumped version to 2.2.1

## Root cause

Searching for **Guimi Zhi Zhu: Xiaochou Pian** returned no episodes because the API returns `episodeType: 'ona'` for its episodes — the old filter excluded everything that wasn't `'tv'`.

## Test plan

- [ ] Search for "Guimi Zhi Zhu: Xiaochou Pian" — episodes should now appear
- [ ] Verify regular TV anime (e.g. any `episodeType: 'tv'` series) still shows episodes correctly
- [ ] Verify trailer/preview episodes are still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)