### PR TITLE
feat: show friends' Shikimori status on anime page

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,6 +11,11 @@ export default defineConfig({
   },
   renderer: {
     root: resolve('src/renderer'),
+    resolve: {
+      alias: {
+        'anime4k-webgpu': resolve('node_modules/anime4k-webgpu')
+      }
+    },
     build: {
       rollupOptions: {
         input: resolve('src/renderer/index.html')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1085,6 +1085,13 @@ function registerIpcHandlers(): void {
     }
   )
 
+  ipcMain.handle('shikimori:get-friends-rates', async (_event, malId: number) => {
+    const accessToken = await shikimori.ensureFreshToken(store)
+    const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
+    if (!user) throw new Error('Not logged in to Shikimori')
+    return shikimori.getFriendsRatesForAnime(accessToken, user.id, malId)
+  })
+
   ipcMain.handle('shikimori:get-anime-rates', async (_event, status?: string) => {
     const accessToken = await shikimori.ensureFreshToken(store)
     const user = store.get('shikimoriUser') as shikimori.ShikiUser | null

--- a/src/main/shikimori.ts
+++ b/src/main/shikimori.ts
@@ -206,6 +206,78 @@ export async function updateUserRate(
   return response.json() as Promise<ShikiUserRate>
 }
 
+export interface ShikiFriend {
+  id: number
+  nickname: string
+  avatar: string
+}
+
+export interface ShikiFriendRate {
+  nickname: string
+  avatar: string
+  status: ShikiUserRateStatus
+  score: number
+  episodes: number
+}
+
+export async function getFriends(accessToken: string, userId: number): Promise<ShikiFriend[]> {
+  const response = await shikiFetch(`/api/users/${userId}/friends?limit=100`, {
+    headers: authHeaders(accessToken)
+  })
+  return response.json() as Promise<ShikiFriend[]>
+}
+
+async function getFriendRateForAnime(
+  accessToken: string,
+  friend: ShikiFriend,
+  malId: number
+): Promise<ShikiFriendRate | null> {
+  const params = new URLSearchParams({ limit: '5000', censored: 'true' })
+  const response = await shikiFetch(`/api/users/${friend.id}/anime_rates?${params}`, {
+    headers: authHeaders(accessToken)
+  })
+  const rates = (await response.json()) as ShikiAnimeRateEntry[]
+  const rate = rates.find((r) => r.anime.id === malId)
+  if (!rate) return null
+  return {
+    nickname: friend.nickname,
+    avatar: friend.avatar,
+    status: rate.status,
+    score: rate.score,
+    episodes: rate.episodes
+  }
+}
+
+export async function getFriendsRatesForAnime(
+  accessToken: string,
+  userId: number,
+  malId: number
+): Promise<ShikiFriendRate[]> {
+  const friends = await getFriends(accessToken, userId)
+  if (friends.length === 0) return []
+
+  const CONCURRENCY = 2
+  const results: ShikiFriendRate[] = []
+
+  for (let i = 0; i < friends.length; i += CONCURRENCY) {
+    const batch = friends.slice(i, i + CONCURRENCY)
+    const rates = await Promise.all(
+      batch.map(async (friend) => {
+        try {
+          return await getFriendRateForAnime(accessToken, friend, malId)
+        } catch {
+          return null
+        }
+      })
+    )
+    for (const r of rates) {
+      if (r) results.push(r)
+    }
+  }
+
+  return results
+}
+
 export async function getUserAnimeRates(
   accessToken: string,
   userId: number,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -78,6 +78,7 @@ interface Api {
   shikimoriGetUser: () => Promise<ShikiUser | null>
   shikimoriGetRate: (malId: number) => Promise<ShikiUserRate | null>
   shikimoriUpdateRate: (malId: number, episodes: number, status: ShikiUserRateStatus, score: number) => Promise<ShikiUserRate>
+  shikimoriGetFriendsRates: (malId: number) => Promise<ShikiFriendRate[]>
   shikimoriGetAnimeRates: (status?: string) => Promise<ShikiAnimeRateEntry[]>
 
   // Updates
@@ -237,6 +238,14 @@ interface ShikiAnimeRateEntry {
   }
   shikiAnime: ShikiAnimeInfo
   smotretAnime: AnimeSearchResult | null
+}
+
+interface ShikiFriendRate {
+  nickname: string
+  avatar: string
+  status: ShikiUserRateStatus
+  score: number
+  episodes: number
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -103,6 +103,8 @@ const api = {
   shikimoriGetRate: (malId: number) => ipcRenderer.invoke('shikimori:get-rate', malId),
   shikimoriUpdateRate: (malId: number, episodes: number, status: string, score: number) =>
     ipcRenderer.invoke('shikimori:update-rate', malId, episodes, status, score),
+  shikimoriGetFriendsRates: (malId: number) =>
+    ipcRenderer.invoke('shikimori:get-friends-rates', malId) as Promise<ShikiFriendRate[]>,
   shikimoriGetAnimeRates: (status?: string) =>
     ipcRenderer.invoke('shikimori:get-anime-rates', status) as Promise<ShikiAnimeRateEntry[]>,
 

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -36,6 +36,25 @@ const shikiLoading = ref(false)
 const shikiSaving = ref(false)
 const shikiError = ref('')
 
+// Friends state
+const friendsRates = ref<ShikiFriendRate[]>([])
+const friendsLoading = ref(false)
+const friendsCollapsed = ref(false)
+
+const friendsSummary = computed(() => {
+  const counts = new Map<string, number>()
+  for (const r of friendsRates.value) {
+    counts.set(r.status, (counts.get(r.status) || 0) + 1)
+  }
+  const labels: Record<string, string> = {
+    watching: 'watching', completed: 'completed', planned: 'planned',
+    on_hold: 'on hold', dropped: 'dropped', rewatching: 'rewatching'
+  }
+  return [...counts.entries()]
+    .map(([status, count]) => `${count} ${labels[status] || status}`)
+    .join(' \u00b7 ')
+})
+
 const playerMode = ref<'system' | 'builtin'>('system')
 
 const TRANSLATION_TYPES = [
@@ -243,6 +262,16 @@ onMounted(async () => {
       console.error('Failed to load Shikimori rate:', err)
     } finally {
       shikiLoading.value = false
+    }
+
+    // Load friends' rates
+    friendsLoading.value = true
+    try {
+      friendsRates.value = await window.api.shikimoriGetFriendsRates(anime.value.myAnimeListId)
+    } catch (err) {
+      console.error('Failed to load friends rates:', err)
+    } finally {
+      friendsLoading.value = false
     }
   }
 })
@@ -673,6 +702,38 @@ function typeChip(type: string): { short: string; color: string } {
           </button>
         </div>
         <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
+      </div>
+
+      <div v-if="shikiUser && anime.myAnimeListId" class="friends-panel">
+        <div class="friends-header" @click="friendsCollapsed = !friendsCollapsed">
+          <div class="friends-header-left">
+            <svg
+              class="friends-chevron"
+              :class="{ collapsed: friendsCollapsed }"
+              viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6"/>
+            </svg>
+            <span class="friends-label">Friends</span>
+          </div>
+          <span v-if="!friendsLoading && friendsRates.length > 0" class="friends-summary">{{ friendsSummary }}</span>
+          <span v-if="friendsLoading" class="friends-summary">Loading...</span>
+        </div>
+        <div v-if="!friendsCollapsed" class="friends-body">
+          <div v-if="friendsLoading" class="friends-loading">Loading friends...</div>
+          <div v-else-if="friendsRates.length === 0" class="friends-empty">None of your friends have watched this anime</div>
+          <div v-else class="friends-list">
+            <div v-for="friend in friendsRates" :key="friend.nickname" class="friend-row">
+              <img :src="friend.avatar" class="friend-avatar" />
+              <span class="friend-name">{{ friend.nickname }}</span>
+              <span class="friend-status-badge" :class="'status-' + friend.status">
+                {{ { planned: 'Planned', watching: 'Watching', rewatching: 'Rewatching', completed: 'Completed', on_hold: 'On Hold', dropped: 'Dropped' }[friend.status] }}
+              </span>
+              <span class="friend-score">{{ friend.score > 0 ? friend.score + '/10' : '—' }}</span>
+              <span class="friend-episodes">{{ friend.episodes > 0 ? 'ep ' + friend.episodes + (anime.numberOfEpisodes ? '/' + anime.numberOfEpisodes : '') : '' }}</span>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="controls">
@@ -1382,5 +1443,112 @@ function typeChip(type: string): { short: string; color: string } {
   margin-top: 8px;
   font-size: 0.8rem;
   color: #e94560;
+}
+
+.friends-panel {
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.friends-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.friends-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.friends-chevron {
+  color: #a0a0b8;
+  transition: transform 0.15s;
+}
+
+.friends-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.friends-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.friends-summary {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.friends-body {
+  margin-top: 10px;
+}
+
+.friends-loading,
+.friends-empty {
+  font-size: 0.85rem;
+  color: #6a6a8a;
+}
+
+.friends-list {
+  display: grid;
+  grid-template-columns: 24px minmax(80px, auto) auto auto auto;
+  gap: 8px 12px;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.friend-row {
+  display: contents;
+}
+
+.friend-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.friend-name {
+  color: #e0e0e0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.friend-status-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.status-watching { background-color: #27ae601a; color: #6ab04c; }
+.status-completed { background-color: #3498db1a; color: #3498db; }
+.status-planned { background-color: #9b59b61a; color: #9b59b6; }
+.status-on_hold { background-color: #f39c121a; color: #f39c12; }
+.status-dropped { background-color: #e945601a; color: #e94560; }
+.status-rewatching { background-color: #1abc9c1a; color: #1abc9c; }
+
+.friend-score {
+  color: #f39c12;
+  font-size: 0.8rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.friend-episodes {
+  color: #6a6a8a;
+  font-size: 0.8rem;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
## Summary
- Add a **Friends** panel on the anime detail page showing Shikimori friends' status for the current anime
- Each friend row displays: avatar, nickname, color-coded status badge (Watching/Completed/Dropped/etc.), score, and episode progress
- Panel is expanded by default with a collapsible chevron toggle; summary line visible in header (e.g. "2 completed")
- Grid layout ensures columns align neatly across all friend rows
- Fix `anime4k-webgpu` vite resolve alias for dev mode

## Screenshot

<img width="989" height="747" alt="pr_screenshot" src="https://github.com/user-attachments/assets/f6ab6154-90e7-42c5-874a-c28e3f6e0f47" />

## Changes
- `src/main/shikimori.ts` — add `getFriends()`, `getFriendsRatesForAnime()`, and related interfaces
- `src/main/index.ts` — add `shikimori:get-friends-rates` IPC handler
- `src/preload/index.ts` + `index.d.ts` — expose new IPC + `ShikiFriendRate` type
- `src/renderer/src/components/AnimeDetailView.vue` — friends panel UI with grid layout and status badges
- `electron.vite.config.ts` — add resolve alias for `anime4k-webgpu`

## Test plan
- [x] Log in to Shikimori, open an anime that friends also have — verify friends panel with correct data
- [x] Verify panel is expanded by default, clicking header collapses/expands
- [x] Verify summary line shows correct counts
- [x] Verify columns align across rows (name, status, score, episodes)
- [x] Open an anime no friends have — verify "None of your friends have watched this anime"
- [x] Log out of Shikimori — verify friends panel is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)