### PR TITLE
feat: stabilize anime detail view loading layout

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -198,6 +198,16 @@ Actions per episode:
   Folder   --> shell.showItemInFolder(path)   cross-platform file explorer
   Delete   --> fs.unlink .mkv, .mp4, .ass     also cleans episode metadata
   Cancel   --> cancelByEpisode(animeName, episodeLabel)  cancel queued/active download
+
+File scan cache (session-level, in-memory):
+  fileCheckCache: Map<animeName, fullScanResult>
+  - First call per anime: full readdirSync, result cached
+  - Subsequent calls: return cached result, trigger async background rescan
+  - Background rescan uses fsPromises.readdir; if results differ, updates cache
+    and pushes file:episodes-changed IPC to renderer
+  - Cache invalidated on: file:delete-episode, onEpisodeComplete, onMergeComplete
+  - Cache cleared entirely on: storage:move-to-cold
+  - file:open verifies existence; if missing, invalidates cache + returns error
 ```
 
 ### Library
@@ -262,10 +272,11 @@ LibraryView shows both with indicators:
 | `update:install` | invoke | Quit and install downloaded update |
 | `update:status` | send | Update check/download progress and status |
 | `cache-get-poster` | invoke | Get base64-encoded cached poster for offline anime |
-| `file:check-episodes` | invoke | Check which episodes exist on disk (returns array of files per episode with author tags) |
-| `file:open` | invoke | Open file with default app |
+| `file:check-episodes` | invoke | Check which episodes exist on disk (session-cached, triggers background rescan on cache hit) |
+| `file:episodes-changed` | send | Background rescan detected file changes, pushes updated results to renderer |
+| `file:open` | invoke | Open file with default app (verifies existence, returns error + invalidates cache if missing) |
 | `file:show-in-folder` | invoke | Reveal file in explorer |
-| `file:delete-episode` | invoke | Delete episode files for specific translation or all versions |
+| `file:delete-episode` | invoke | Delete episode files for specific translation or all versions (invalidates file scan cache) |
 | `shikimori:get-auth-url` | invoke | Get Shikimori OAuth authorize URL |
 | `shikimori:exchange-code` | invoke | Exchange OAuth code for tokens, fetch user |
 | `shikimori:logout` | invoke | Clear Shikimori credentials and user |

--- a/TODO.md
+++ b/TODO.md
@@ -34,21 +34,21 @@
 
 ---
 
-## 1. Stabilize Anime Detail View Layout During Loading
+## ~~1. Stabilize Anime Detail View Layout During Loading~~
 
-**Priority:** Medium | **Effort:** Medium
+~~**Priority:** Medium | **Effort:** Medium~~
 
-The anime detail page "jumps" as different sections load asynchronously — episodes appear, then file status shifts badges, then Shikimori/Friends panels pop in and push everything down. The page should show an overall spinner until the episode list + file status are ready, then show compact spinner rows for Shikimori/Friends that haven't resolved yet.
+~~The anime detail page "jumps" as different sections load asynchronously — episodes appear, then file status shifts badges, then Shikimori/Friends panels pop in and push everything down. The page should show an overall spinner until the episode list + file status are ready, then show compact spinner rows for Shikimori/Friends that haven't resolved yet.~~
 
-Additionally, `file:check-episodes` does a full `readdirSync` on every page load even though we already know what files were downloaded. We should cache file scan results in the main process for the session and only do a background rescan, verifying files exist on open rather than on every mount.
+~~Additionally, `file:check-episodes` does a full `readdirSync` on every page load even though we already know what files were downloaded. We should cache file scan results in the main process for the session and only do a background rescan, verifying files exist on open rather than on every mount.~~
 
-**Plan:**
-1. **Overall loading state:** In `AnimeDetailView.vue`, keep the existing `loading` spinner visible until both `loadPageEpisodes()` and `checkFileStatus()` complete. Currently `loading` is set to `false` after `getAnime()` returns (line ~259), before episodes or files are loaded — move it after `checkFileStatus()` so the episode list, controls, pagination, and file badges all appear together instead of popping in one by one.
-2. **Compact spinner rows for Shikimori/Friends:** The Shikimori panel (`shiki-panel`) and Friends panel (`friends-panel`) load async via `loadShikimoriData()`. They already show "Loading..." text, but the panels themselves (`v-if="shikiUser && anime.myAnimeListId"`) only appear after `shikiUser` resolves. Reserve the panels immediately (show them with a spinner row as soon as `anime.myAnimeListId` exists) rather than waiting for `shikiUser`. After `loadShikimoriData` resolves, replace spinner with controls or hide the panel if not logged in.
-3. **Session-level file scan cache in main process:** Add an in-memory `Map<string, ...>` in `main/index.ts` (keyed by `animeName`) that caches the result of `file:check-episodes`. On first call per anime per session, do the full directory scan and cache. On subsequent calls, return the cached result immediately. Invalidate the cache entry when files change: after `file:delete-episode`, after download completion (in `downloadedEpisodesSet`), and after `storage:move-to-cold`.
-4. **Verify file on open:** In the `file:open` handler, check `fs.existsSync(filePath)` before calling `shell.openPath`. If the file is gone (e.g., user deleted externally), invalidate the cache for that anime and return an error so the renderer can refresh file status and show a message.
-5. **Background rescan:** After returning the cached result, optionally queue a background async rescan (using `fsPromises.readdir`) that updates the cache. If results differ from the cached version, send an IPC event to the renderer so it can refresh badges without a full page jump.
-6. **Files:** `src/main/index.ts` (file scan cache, IPC handlers), `src/renderer/src/components/AnimeDetailView.vue` (loading state, panel placeholders).
+~~**Plan:**~~
+~~1. **Overall loading state:** In `AnimeDetailView.vue`, keep the existing `loading` spinner visible until both `loadPageEpisodes()` and `checkFileStatus()` complete. Currently `loading` is set to `false` after `getAnime()` returns (line ~259), before episodes or files are loaded — move it after `checkFileStatus()` so the episode list, controls, pagination, and file badges all appear together instead of popping in one by one.~~
+~~2. **Compact spinner rows for Shikimori/Friends:** The Shikimori panel (`shiki-panel`) and Friends panel (`friends-panel`) load async via `loadShikimoriData()`. They already show "Loading..." text, but the panels themselves (`v-if="shikiUser && anime.myAnimeListId"`) only appear after `shikiUser` resolves. Reserve the panels immediately (show them with a spinner row as soon as `anime.myAnimeListId` exists) rather than waiting for `shikiUser`. After `loadShikimoriData` resolves, replace spinner with controls or hide the panel if not logged in.~~
+~~3. **Session-level file scan cache in main process:** Add an in-memory `Map<string, ...>` in `main/index.ts` (keyed by `animeName`) that caches the result of `file:check-episodes`. On first call per anime per session, do the full directory scan and cache. On subsequent calls, return the cached result immediately. Invalidate the cache entry when files change: after `file:delete-episode`, after download completion (in `downloadedEpisodesSet`), and after `storage:move-to-cold`.~~
+~~4. **Verify file on open:** In the `file:open` handler, check `fs.existsSync(filePath)` before calling `shell.openPath`. If the file is gone (e.g., user deleted externally), invalidate the cache for that anime and return an error so the renderer can refresh file status and show a message.~~
+~~5. **Background rescan:** After returning the cached result, optionally queue a background async rescan (using `fsPromises.readdir`) that updates the cache. If results differ from the cached version, send an IPC event to the renderer so it can refresh badges without a full page jump.~~
+~~6. **Files:** `src/main/index.ts` (file scan cache, IPC handlers), `src/renderer/src/components/AnimeDetailView.vue` (loading state, panel placeholders).~~
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -80,6 +80,151 @@ function isDownloadedAnime(animeId: number): boolean {
   return !!downloaded[String(animeId)]
 }
 
+type FileCheckResult = Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>
+const fileCheckCache = new Map<string, FileCheckResult>()
+
+function scanEpisodeFiles(animeName: string): FileCheckResult {
+  const animeDirName = sanitizeFilename(animeName)
+  const dirsToCheck = [getDownloadDir()]
+  if (isAdvancedStorage()) {
+    const coldDir = getColdStorageDir()
+    if (coldDir) dirsToCheck.push(coldDir)
+  }
+
+  const result: FileCheckResult = {}
+
+  for (const dir of dirsToCheck) {
+    const animeDir = path.join(dir, animeDirName)
+    if (!fs.existsSync(animeDir)) continue
+
+    let files: string[]
+    try { files = fs.readdirSync(animeDir) } catch { continue }
+
+    for (const file of files) {
+      const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
+      if (match) {
+        const base = match[1]
+        const author = match[2]
+        const ext = match[3] as 'mkv' | 'mp4'
+        if (!result[base]) result[base] = []
+        const existing = result[base].find(e => e.author === author)
+        if (existing) {
+          existing.type = ext
+          existing.filePath = path.join(animeDir, file)
+        } else {
+          result[base].push({ type: ext, filePath: path.join(animeDir, file), author })
+        }
+        continue
+      }
+
+      const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
+      if (legacyMatch) {
+        const base = legacyMatch[1]
+        const ext = legacyMatch[2] as 'mkv' | 'mp4'
+        if (!result[base]) result[base] = []
+        const hasAuthorVersion = result[base].some(e => e.author)
+        if (!hasAuthorVersion || !result[base].some(e => !e.author)) {
+          const existing = result[base].find(e => !e.author)
+          if (existing) {
+            existing.type = ext
+            existing.filePath = path.join(animeDir, file)
+          } else {
+            result[base].push({ type: ext, filePath: path.join(animeDir, file) })
+          }
+        }
+      }
+    }
+  }
+  return result
+}
+
+function filterScanResult(fullResult: FileCheckResult, animeName: string, episodeInts: string[]): FileCheckResult {
+  const baseMap = new Map<string, string>()
+  for (const epInt of episodeInts) {
+    const padded = epInt.padStart(2, '0')
+    const base = sanitizeFilename(`${animeName} - ${padded}`)
+    baseMap.set(base, epInt)
+  }
+
+  const filtered: FileCheckResult = {}
+  for (const [base, files] of Object.entries(fullResult)) {
+    const epInt = baseMap.get(base)
+    if (epInt) {
+      filtered[epInt] = files
+    }
+  }
+  return filtered
+}
+
+async function backgroundRescan(animeName: string): Promise<void> {
+  const animeDirName = sanitizeFilename(animeName)
+  const dirsToCheck = [getDownloadDir()]
+  if (isAdvancedStorage()) {
+    const coldDir = getColdStorageDir()
+    if (coldDir) dirsToCheck.push(coldDir)
+  }
+
+  const result: FileCheckResult = {}
+
+  for (const dir of dirsToCheck) {
+    const animeDir = path.join(dir, animeDirName)
+    let files: string[]
+    try { files = await fsPromises.readdir(animeDir) } catch { continue }
+
+    for (const file of files) {
+      const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
+      if (match) {
+        const base = match[1]
+        const author = match[2]
+        const ext = match[3] as 'mkv' | 'mp4'
+        if (!result[base]) result[base] = []
+        const existing = result[base].find(e => e.author === author)
+        if (existing) {
+          existing.type = ext
+          existing.filePath = path.join(animeDir, file)
+        } else {
+          result[base].push({ type: ext, filePath: path.join(animeDir, file), author })
+        }
+        continue
+      }
+
+      const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
+      if (legacyMatch) {
+        const base = legacyMatch[1]
+        const ext = legacyMatch[2] as 'mkv' | 'mp4'
+        if (!result[base]) result[base] = []
+        const hasAuthorVersion = result[base].some(e => e.author)
+        if (!hasAuthorVersion || !result[base].some(e => !e.author)) {
+          const existing = result[base].find(e => !e.author)
+          if (existing) {
+            existing.type = ext
+            existing.filePath = path.join(animeDir, file)
+          } else {
+            result[base].push({ type: ext, filePath: path.join(animeDir, file) })
+          }
+        }
+      }
+    }
+  }
+
+  const cached = fileCheckCache.get(animeName)
+  const normalize = (r: FileCheckResult) => {
+    const sorted: FileCheckResult = {}
+    for (const key of Object.keys(r).sort()) {
+      sorted[key] = [...r[key]].sort((a, b) => (a.author || '').localeCompare(b.author || ''))
+    }
+    return sorted
+  }
+  const newJson = JSON.stringify(normalize(result))
+  const cachedJson = cached ? JSON.stringify(normalize(cached)) : ''
+  if (newJson !== cachedJson) {
+    fileCheckCache.set(animeName, result)
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send('file:episodes-changed', animeName, result)
+    }
+  }
+}
+
 function getCacheEntry(animeId: number): AnimeCacheEntry | null {
   const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
   return cache[String(animeId)] || null
@@ -877,82 +1022,28 @@ function registerIpcHandlers(): void {
 
   // File management handlers
   ipcMain.handle('file:check-episodes', (_event, animeName: string, episodeInts: string[]) => {
-    const animeDirName = sanitizeFilename(animeName)
-    const dirsToCheck = [getDownloadDir()]
-    if (isAdvancedStorage()) {
-      const coldDir = getColdStorageDir()
-      if (coldDir) dirsToCheck.push(coldDir)
+    const cached = fileCheckCache.get(animeName)
+    if (cached) {
+      backgroundRescan(animeName).catch(err => console.error('Background rescan failed:', err))
+      return filterScanResult(cached, animeName, episodeInts)
     }
 
-    // Result: per-episode map of translationId -> file info, plus a legacy entry for old filenames
-    const result: Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]> = {}
-
-    // Build set of base names we're looking for
-    const baseMap = new Map<string, string>() // base -> episodeInt
-    for (const epInt of episodeInts) {
-      const padded = epInt.padStart(2, '0')
-      const base = sanitizeFilename(`${animeName} - ${padded}`)
-      baseMap.set(base, epInt)
-    }
-
-    for (const dir of dirsToCheck) {
-      const animeDir = path.join(dir, animeDirName)
-      if (!fs.existsSync(animeDir)) continue
-
-      // First check for new [Author] tagged files by listing directory
-      let files: string[]
-      try { files = fs.readdirSync(animeDir) } catch { continue }
-
-      for (const file of files) {
-        // Match pattern: {base} [Author].{mkv|mp4}
-        const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
-        if (match) {
-          const base = match[1]
-          const author = match[2]
-          const ext = match[3] as 'mkv' | 'mp4'
-          const epInt = baseMap.get(base)
-          if (epInt) {
-            if (!result[epInt]) result[epInt] = []
-            // Avoid duplicate entries (cold storage takes priority)
-            const existing = result[epInt].find(e => e.author === author)
-            if (existing) {
-              // Replace with cold storage version
-              existing.type = ext
-              existing.filePath = path.join(animeDir, file)
-            } else {
-              result[epInt].push({ type: ext, filePath: path.join(animeDir, file), author })
-            }
-          }
-          continue
-        }
-
-        // Legacy filenames (no author tag): {base}.{mkv|mp4}
-        const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
-        if (legacyMatch) {
-          const base = legacyMatch[1]
-          const ext = legacyMatch[2] as 'mkv' | 'mp4'
-          const epInt = baseMap.get(base)
-          if (epInt) {
-            if (!result[epInt]) result[epInt] = []
-            // Only add legacy if no author-tagged version exists with same base
-            const hasAuthorVersion = result[epInt].some(e => e.author)
-            if (!hasAuthorVersion || !result[epInt].some(e => !e.author)) {
-              const existing = result[epInt].find(e => !e.author)
-              if (existing) {
-                existing.type = ext
-                existing.filePath = path.join(animeDir, file)
-              } else {
-                result[epInt].push({ type: ext, filePath: path.join(animeDir, file) })
-              }
-            }
-          }
-        }
-      }
-    }
-    return result
+    const fullResult = scanEpisodeFiles(animeName)
+    fileCheckCache.set(animeName, fullResult)
+    return filterScanResult(fullResult, animeName, episodeInts)
   })
 
   ipcMain.handle('file:open', async (_event, filePath: string) => {
+    if (!fs.existsSync(filePath)) {
+      const animeDirName = path.basename(path.dirname(filePath))
+      for (const [key] of fileCheckCache) {
+        if (sanitizeFilename(key) === animeDirName) {
+          fileCheckCache.delete(key)
+          break
+        }
+      }
+      return 'File not found'
+    }
     return shell.openPath(filePath)
   })
 
@@ -961,6 +1052,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('file:delete-episode', (_event, animeName: string, episodeInt: string, animeId?: number, translationId?: number) => {
+    fileCheckCache.delete(animeName)
     const animeDirName = sanitizeFilename(animeName)
     const dirsToCheck = [getDownloadDir()]
     if (isAdvancedStorage()) {
@@ -1066,6 +1158,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('storage:move-to-cold', async () => {
+    fileCheckCache.clear()
     const result = await moveAllFilesToColdStorage((current, total, file) => {
       for (const win of BrowserWindow.getAllWindows()) {
         win.webContents.send('storage:move-to-cold-progress', { current, total, file })
@@ -1463,6 +1556,7 @@ app.whenReady().then(async () => {
   }
 
   downloadManager.onEpisodeComplete(async (animeName, episodeLabel) => {
+    fileCheckCache.delete(animeName)
     const autoMerge = store.get('autoMerge') as boolean
     if (autoMerge && ffmpegInfo.available && ffmpegPath) {
       const codec = store.get('videoCodec') as string || 'copy'
@@ -1480,6 +1574,7 @@ app.whenReady().then(async () => {
   })
 
   downloadManager.onMergeComplete(async (animeName, episodeLabel) => {
+    fileCheckCache.delete(animeName)
     // Auto-move to cold after merge
     if (isAdvancedStorage() && (store.get('autoMoveToCold') as boolean)) {
       await moveEpisodeToColdStorage(animeName, episodeLabel)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -59,6 +59,8 @@ interface Api {
   fileOpen: (filePath: string) => Promise<string>
   fileShowInFolder: (filePath: string) => Promise<void>
   fileDeleteEpisode: (animeName: string, episodeInt: string, animeId?: number, translationId?: number) => Promise<void>
+  onFileEpisodesChanged: (callback: (animeName: string, data: Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>) => void) => void
+  offFileEpisodesChanged: () => void
 
   onDownloadProgress: (callback: (data: EpisodeGroup[]) => void) => void
   offDownloadProgress: () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,12 @@ const api = {
   fileShowInFolder: (filePath: string) => ipcRenderer.invoke('file:show-in-folder', filePath),
   fileDeleteEpisode: (animeName: string, episodeInt: string, animeId?: number, translationId?: number) =>
     ipcRenderer.invoke('file:delete-episode', animeName, episodeInt, animeId, translationId),
+  onFileEpisodesChanged: (callback: (animeName: string, data: Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>) => void) => {
+    ipcRenderer.on('file:episodes-changed', (_event, animeName, data) => callback(animeName, data))
+  },
+  offFileEpisodesChanged: () => {
+    ipcRenderer.removeAllListeners('file:episodes-changed')
+  },
 
   // Storage
   storagePickHotDir: () => ipcRenderer.invoke('storage:pick-hot-dir'),

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -40,6 +40,7 @@ const shikiError = ref('')
 const friendsRates = ref<ShikiFriendRate[]>([])
 const friendsLoading = ref(false)
 const friendsCollapsed = ref(false)
+const shikiUserChecked = ref(false)
 
 const friendsSummary = computed(() => {
   const counts = new Map<string, number>()
@@ -213,7 +214,13 @@ function onMouseBack(e: MouseEvent): void {
 }
 
 async function loadShikimoriData(): Promise<void> {
-  shikiUser.value = await window.api.shikimoriGetUser()
+  try {
+    shikiUser.value = await window.api.shikimoriGetUser()
+  } catch (err) {
+    console.error('Failed to load Shikimori user:', err)
+  } finally {
+    shikiUserChecked.value = true
+  }
   if (!shikiUser.value || !anime.value?.myAnimeListId) return
 
   shikiLoading.value = true
@@ -253,14 +260,13 @@ onMounted(async () => {
     const res = await window.api.getAnime(props.animeId)
     anime.value = res.data
     dataSource.value = res.source
+    await loadPageEpisodes()
+    await checkFileStatus()
   } catch (err) {
-    console.error('Failed to load anime:', err)
+    console.error('Failed to load anime detail view:', err)
   } finally {
     loading.value = false
   }
-
-  await loadPageEpisodes()
-  await checkFileStatus()
 
   // If served from cache, try a background refresh
   if (dataSource.value === 'cache') {
@@ -272,6 +278,25 @@ onMounted(async () => {
   updateDownloadGroups(queue)
   window.api.onDownloadProgress(updateDownloadGroups)
 
+  // Subscribe to background file rescan updates
+  window.api.onFileEpisodesChanged((animeName, data) => {
+    if (anime.value && animeName === getAnimeName()) {
+      const episodeInts = filteredEpisodes.value.map(ep => ep.episodeInt)
+      const baseMap = new Map<string, string>()
+      for (const epInt of episodeInts) {
+        const padded = epInt.padStart(2, '0')
+        const base = sanitizeFilename(`${animeName} - ${padded}`)
+        baseMap.set(base, epInt)
+      }
+      const filtered: typeof fileStatus.value = {}
+      for (const [base, files] of Object.entries(data)) {
+        const epInt = baseMap.get(base)
+        if (epInt) filtered[epInt] = files
+      }
+      fileStatus.value = filtered
+    }
+  })
+
   // Load Shikimori data (non-blocking — don't hold up the episode list)
   loadShikimoriData()
 })
@@ -279,6 +304,7 @@ onMounted(async () => {
 onUnmounted(() => {
   window.removeEventListener('mouseup', onMouseBack)
   window.api.offDownloadProgress()
+  window.api.offFileEpisodesChanged()
 })
 
 const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
@@ -672,7 +698,11 @@ async function openFile(row: EpisodeRow): Promise<void> {
     const localSubs = await window.api.playerGetLocalSubtitles(info.filePath)
     emit('playFile', info.filePath, '', localSubs || '', name, row.episode.episodeInt, [], row.selectedTr.id, buildTranslationList(row), [...row.downloadedTrIds])
   } else {
-    await window.api.fileOpen(info.filePath)
+    const result = await window.api.fileOpen(info.filePath)
+    if (result) {
+      errorMessage.value = result
+      await checkFileStatus()
+    }
   }
 }
 
@@ -754,44 +784,47 @@ function typeChip(type: string): { short: string; color: string } {
         </div>
       </div>
 
-      <div v-if="shikiUser && anime.myAnimeListId" class="shiki-panel">
-        <div class="shiki-header">
-          <span class="shiki-label">Shikimori</span>
-          <a :href="`https://shikimori.one/animes/${anime.myAnimeListId}`" target="_blank" class="shiki-link">
-            Open on Shikimori
-          </a>
-        </div>
-        <div v-if="shikiLoading" class="shiki-loading">Loading...</div>
-        <div v-else class="shiki-controls">
-          <select v-model="shikiStatus" class="select shiki-select">
-            <option v-for="s in SHIKI_STATUSES" :key="s.value" :value="s.value">{{ s.label }}</option>
-          </select>
-          <div class="shiki-episodes">
-            <span>Episodes:</span>
-            <input
-              v-model.number="shikiEpisodes"
-              type="number"
-              min="0"
-              :max="anime.numberOfEpisodes || undefined"
-              class="shiki-ep-input"
-            />
-            <span v-if="anime.numberOfEpisodes" class="shiki-ep-total">/ {{ anime.numberOfEpisodes }}</span>
+      <div v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)" class="shiki-panel">
+        <template v-if="shikiUser">
+          <div class="shiki-header">
+            <span class="shiki-label">Shikimori</span>
+            <a :href="`https://shikimori.one/animes/${anime.myAnimeListId}`" target="_blank" class="shiki-link">
+              Open on Shikimori
+            </a>
           </div>
-          <div class="shiki-episodes">
-            <span>Score:</span>
-            <select v-model.number="shikiScore" class="select shiki-score-select">
-              <option :value="0">—</option>
-              <option v-for="n in 10" :key="n" :value="n">{{ n }}</option>
+          <div v-if="shikiLoading" class="shiki-loading">Loading...</div>
+          <div v-else class="shiki-controls">
+            <select v-model="shikiStatus" class="select shiki-select">
+              <option v-for="s in SHIKI_STATUSES" :key="s.value" :value="s.value">{{ s.label }}</option>
             </select>
+            <div class="shiki-episodes">
+              <span>Episodes:</span>
+              <input
+                v-model.number="shikiEpisodes"
+                type="number"
+                min="0"
+                :max="anime.numberOfEpisodes || undefined"
+                class="shiki-ep-input"
+              />
+              <span v-if="anime.numberOfEpisodes" class="shiki-ep-total">/ {{ anime.numberOfEpisodes }}</span>
+            </div>
+            <div class="shiki-episodes">
+              <span>Score:</span>
+              <select v-model.number="shikiScore" class="select shiki-score-select">
+                <option :value="0">—</option>
+                <option v-for="n in 10" :key="n" :value="n">{{ n }}</option>
+              </select>
+            </div>
+            <button class="shiki-save-btn" :disabled="shikiSaving" @click="shikiSave">
+              {{ shikiSaving ? 'Saving...' : 'Save' }}
+            </button>
           </div>
-          <button class="shiki-save-btn" :disabled="shikiSaving" @click="shikiSave">
-            {{ shikiSaving ? 'Saving...' : 'Save' }}
-          </button>
-        </div>
-        <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
+          <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
+        </template>
+        <div v-else class="shiki-loading">Loading...</div>
       </div>
 
-      <div v-if="shikiUser && anime.myAnimeListId" class="friends-panel">
+      <div v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)" class="friends-panel">
         <div class="friends-header" @click="friendsCollapsed = !friendsCollapsed">
           <div class="friends-header-left">
             <svg


### PR DESCRIPTION
## Summary

Eliminates layout jumps on the anime detail page by deferring the loading spinner until all core data (episodes + file status) is ready, and showing compact placeholder rows for async Shikimori/Friends panels. Also adds a session-level file scan cache to speed up repeated visits.

### What changed

- **Deferred loading state**: `loading` spinner now stays visible until `loadPageEpisodes()` + `checkFileStatus()` both complete, so the episode list, controls, pagination, and file badges all appear together instead of popping in one by one
- **Shikimori/Friends panel placeholders**: Panels now show a compact "Loading..." row immediately when the anime has a MAL ID (before `shikimoriGetUser()` resolves). Once auth check completes, either the full controls appear or the small placeholder disappears — far less jarring than a full panel popping in
- **Session-level file scan cache**: `file:check-episodes` results are cached in an in-memory `Map<animeName, scanResult>` in the main process. First call per anime does the full `readdirSync`; subsequent calls return instantly from cache and trigger a background async rescan via `fsPromises.readdir`
- **Background rescan with IPC push**: If the background rescan detects changes vs. cached state, it updates the cache and pushes a `file:episodes-changed` IPC event to the renderer, which updates badges without a page reload
- **File existence check on open**: `file:open` now verifies `fs.existsSync(filePath)` before calling `shell.openPath`. If the file was externally deleted, it invalidates the cache, returns an error, and the renderer refreshes file status + shows an error banner
- **Cache invalidation**: Cache is invalidated on `file:delete-episode`, `onEpisodeComplete`, `onMergeComplete`, and cleared entirely on `storage:move-to-cold`

### Files changed

| File | Changes |
|------|---------|
| `src/main/index.ts` | Extracted `scanEpisodeFiles()` / `filterScanResult()` / `backgroundRescan()` helpers; added `fileCheckCache`; updated `file:check-episodes`, `file:open`, `file:delete-episode` handlers; added invalidation in download/merge callbacks |
| `src/preload/index.ts` | Added `onFileEpisodesChanged` / `offFileEpisodesChanged` listener bridge |
| `src/preload/index.d.ts` | Added types for the new IPC listeners |
| `src/renderer/src/components/AnimeDetailView.vue` | Deferred `loading = false`; added `shikiUserChecked` ref for panel placeholders; handle `fileOpen` error; subscribe to `file:episodes-changed` |
| `DESIGN.md` | Documented file scan cache, updated IPC table |
| `TODO.md` | Struck through completed item #1 |
| `package.json` | Version bump 3.3.0 → 3.4.0 |

## Test plan

- [ ] Open an anime detail page → single spinner until everything loads at once (no layout jumps)
- [ ] Anime with MAL ID shows compact "Loading..." placeholder for Shikimori/Friends, then resolves or disappears
- [ ] Navigate away from anime detail and back → file status loads instantly from cache
- [ ] Externally delete a downloaded file, click Open → error banner shown, file badges refresh
- [ ] Download an episode → file scan cache invalidated, badges update on next visit
- [ ] Move files to cold storage → cache cleared, correct files shown on next visit

🤖 Generated with [Claude Code](https://claude.com/claude-code)