### PR TITLE
fix: prevent go-back shortcut from firing while player is open

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,15 +86,15 @@ Add keyboard shortcuts for switching Anime4K shader presets while watching: Ctrl
 
 ---
 
-## 4. Disable "Go Back" Global Shortcut While Player Is Open
+## ~~4. Disable "Go Back" Global Shortcut While Player Is Open~~
 
-**Priority:** Medium | **Effort:** Small
+~~**Priority:** Medium | **Effort:** Small~~
 
-When pressing Escape in the built-in player, the player closes (via `handleClose()` in `PlayerView.vue` line ~267 → `emit('close')` → `closePlayer()` in `App.vue` sets `playerState = null`). But in the same keydown event, `App.vue`'s `handleKeydown` (line ~108) fires next — and since `playerState` is now null (just cleared synchronously by `closePlayer`), the `if (playerState.value) return` guard on line ~110 no longer blocks, so the "back" action also executes, closing the anime detail view. The user ends up back at the search/library grid instead of the anime page.
+~~When pressing Escape in the built-in player, the player closes (via `handleClose()` in `PlayerView.vue` line ~267 → `emit('close')` → `closePlayer()` in `App.vue` sets `playerState = null`). But in the same keydown event, `App.vue`'s `handleKeydown` (line ~108) fires next — and since `playerState` is now null (just cleared synchronously by `closePlayer`), the `if (playerState.value) return` guard on line ~110 no longer blocks, so the "back" action also executes, closing the anime detail view. The user ends up back at the search/library grid instead of the anime page.~~
 
-**Plan:**
-1. **Add `stopPropagation()`:** In `PlayerView.vue` `onKeyDown` (line ~276), call `event.stopPropagation()` at the top of the function (before the switch). This prevents the event from reaching `App.vue`'s `handleKeydown` listener entirely while the player is mounted. This is safe because the player already handles all relevant keys (Space, arrows, F, M, Escape) and should consume all keyboard input while active.
-2. **Files:** `src/renderer/src/components/PlayerView.vue`.
+~~**Plan:**~~
+~~1. **Add `stopPropagation()`:** In `PlayerView.vue` `onKeyDown` (line ~276), call `event.stopPropagation()` at the top of the function (before the switch). This prevents the event from reaching `App.vue`'s `handleKeydown` listener entirely while the player is mounted. This is safe because the player already handles all relevant keys (Space, arrows, F, M, Escape) and should consume all keyboard input while active.~~
+~~2. **Files:** `src/renderer/src/components/PlayerView.vue`.~~
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -265,15 +265,24 @@ function onVolumeInput(event: Event): void {
 }
 
 function handleClose(): void {
-  if (isFullscreen.value) {
+  if (document.fullscreenElement) {
     document.exitFullscreen()
   } else {
     emit('close')
   }
 }
 
+function onMouseBack(e: MouseEvent): void {
+  if (e.button === 3) {
+    e.stopImmediatePropagation()
+    e.preventDefault()
+    handleClose()
+  }
+}
+
 // Keyboard shortcuts
 function onKeyDown(event: KeyboardEvent): void {
+  event.stopPropagation()
   // Don't handle if a preset menu input is focused
   if ((event.target as HTMLElement)?.tagName === 'SELECT') return
 
@@ -736,6 +745,7 @@ function destroySubtitles(): void {
 onMounted(async () => {
   document.addEventListener('keydown', onKeyDown)
   document.addEventListener('fullscreenchange', onFullscreenChange)
+  window.addEventListener('mouseup', onMouseBack, true)
 
   // Remux MKV to MP4 if needed
   if (isMkv.value && props.filePath) {
@@ -799,6 +809,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', onKeyDown)
   document.removeEventListener('fullscreenchange', onFullscreenChange)
+  window.removeEventListener('mouseup', onMouseBack, true)
   if (controlsTimer) clearTimeout(controlsTimer)
   stopAnime4KPipeline()
   destroySubtitles()


### PR DESCRIPTION
## Summary

Fixes a bug where pressing Escape or the mouse back button to close the built-in player would also trigger the "go back" navigation, sending the user all the way back to the search/library grid instead of staying on the anime detail page.

### Root cause

**Keyboard (Escape):** `PlayerView.handleClose()` emits `close` → `App.vue.closePlayer()` sets `playerState = null` synchronously. In the same keydown event, `App.vue.handleKeydown` fires next — but since `playerState` is now `null`, the `if (playerState.value) return` guard no longer blocks, so the Escape binding triggers the "back" action on `AnimeDetailView`.

**Mouse back button:** `AnimeDetailView` registers a `window`-level `mouseup` listener for button 3 (mouse back). When the player is open, this listener still fires because the player had no mouse back handler — so clicking mouse back would navigate away from the anime detail view entirely.

### Fix

- **`handleClose()`**: Uses `document.fullscreenElement` directly instead of the reactive `isFullscreen.value` to avoid a race condition where the value could be stale if the user triggers close quickly after entering/exiting fullscreen.

- **`onKeyDown`**: Added `event.stopPropagation()` at the top of the function, preventing keyboard events from reaching `App.vue`'s `handleKeydown` listener while the player is mounted. This is safe because the player already handles all relevant keys (Space, arrows, F, M, Escape).

- **`onMouseBack`**: Added a new mouse back button handler in `PlayerView` registered with `capture: true` on `window`. Uses `stopImmediatePropagation()` to prevent `AnimeDetailView`'s same-level `window` listener from also firing. Mouse back now closes the player (or exits fullscreen if active) — matching Escape behavior.

### Files changed

| File | Changes |
|------|---------|
| `src/renderer/src/components/PlayerView.vue` | Fixed `handleClose()` race, added `stopPropagation()` in `onKeyDown`, added `onMouseBack` handler with capture-phase listener |
| `TODO.md` | Struck through completed item #4 |
| `package.json` | Version bump 3.3.0 → 3.3.1 |

## Test plan

- [ ] Open built-in player, press **Escape** → player closes, stays on anime detail page (not grid)
- [ ] Open built-in player, press **mouse back button** → player closes, stays on anime detail page
- [ ] Open built-in player in **fullscreen**, press Escape → exits fullscreen (does not close player)
- [ ] Open built-in player in **fullscreen**, press mouse back → exits fullscreen (does not close player)
- [ ] Rapidly toggle fullscreen then press Escape → no race condition, correct behavior