### PR TITLE
feat: previous/next episode buttons in built-in player

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -354,7 +354,7 @@ interface EpisodeMeta {
 | `notificationMode` | string | `'off'` | Desktop notification mode: `off`, `each` (per episode), `queue` (when queue empties) |
 | `downloadSpeedLimit` | number | `0` | Download speed limit in bytes/sec (0 = unlimited), shared across active downloads |
 | `concurrentDownloads` | number | `2` | Max simultaneous downloads (1–3) |
-| `keyboardShortcuts` | object | `{back:'Escape', focusSearch:'CmdOrCtrl+F', goDownloads:'CmdOrCtrl+D'}` | Configurable keyboard shortcut bindings |
+| `keyboardShortcuts` | object | `{back:'Escape', focusSearch:'CmdOrCtrl+F', goDownloads:'CmdOrCtrl+D', playerPrevEpisode:'Shift+ArrowLeft', playerNextEpisode:'Shift+ArrowRight'}` | Configurable keyboard shortcut bindings |
 | `shikimoriCredentials` | object\|null | `null` | Shikimori OAuth tokens (access_token, refresh_token, created_at, expires_in) |
 | `shikimoriUser` | object\|null | `null` | Cached Shikimori user profile (id, nickname, avatar) |
 | `storageMode` | string | `'simple'` | Storage mode: `simple` (single dir) or `advanced` (hot/cold split) |
@@ -428,6 +428,16 @@ Dropdown in player controls showing all available stream heights (e.g., 1080p, 7
 ### Translation Selector
 
 Dropdown in player controls showing all available translations for the current episode. Translations are passed from `AnimeDetailView.episodeRows` data through `App.vue` to `PlayerView` as `{ id, label, type, height }[]`. Each option shows the author name and a sub-label with type (RU SUB, EN DUB, etc.) and quality. On switch: calls `player:get-stream-url` with the new translation ID to get a fresh stream URL + subtitles, updates `<video>` src and subtitle track, preserves playback position. Only visible when streaming with more than one translation available.
+
+### Episode Navigation
+
+Prev/next episode buttons in the title bar for seamless binge-watching. `AnimeDetailView` passes the full `filteredEpisodes` list (all episodes, not just the current page) as `allEpisodes` prop through `App.vue` to `PlayerView`. Each entry contains `{ episodeInt, episodeFull, translations, downloadedTrIds }`.
+
+Translation resolution for the target episode: same translationId → best quality of same type → first available. Tries local file first (via `playerFindLocalFile`), falls back to streaming (via `playerGetStreamUrl`). Cleans up previous MKV remux when switching.
+
+Auto-advance: when video ends and next episode is available, shows a 5-second countdown overlay. User can cancel or let it auto-navigate to the next episode.
+
+Configurable keyboard shortcuts: `playerPrevEpisode` (default Shift+ArrowLeft) and `playerNextEpisode` (default Shift+ArrowRight) in Settings > Shortcuts.
 
 ### WebGPU Requirements
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,28 +31,13 @@
 - [x] Friends Activity Feed — chronological feed of recent anime activity from Shikimori friends, globally sorted, top 50
 - [x] Support Multiple Downloaded Translations — multiple local versions per episode with author-tagged filenames, marked in menus
 - [x] Refactor Smotret-Anime API into a Dedicated Class — consolidated API logic into `SmotretApi` class in `smotret-api.ts`
+- [x] Stabilize Anime Detail View Layout During Loading — unified loading state and session-level file scan cache
+- [x] Disable "Go Back" Global Shortcut While Player Is Open — player key events no longer propagate to App.vue
+- [x] Previous / Next Episode Buttons in Player — prev/next navigation, auto-advance, configurable shortcuts
 
 ---
 
-## ~~1. Stabilize Anime Detail View Layout During Loading~~
-
-~~**Priority:** Medium | **Effort:** Medium~~
-
-~~The anime detail page "jumps" as different sections load asynchronously — episodes appear, then file status shifts badges, then Shikimori/Friends panels pop in and push everything down. The page should show an overall spinner until the episode list + file status are ready, then show compact spinner rows for Shikimori/Friends that haven't resolved yet.~~
-
-~~Additionally, `file:check-episodes` does a full `readdirSync` on every page load even though we already know what files were downloaded. We should cache file scan results in the main process for the session and only do a background rescan, verifying files exist on open rather than on every mount.~~
-
-~~**Plan:**~~
-~~1. **Overall loading state:** In `AnimeDetailView.vue`, keep the existing `loading` spinner visible until both `loadPageEpisodes()` and `checkFileStatus()` complete. Currently `loading` is set to `false` after `getAnime()` returns (line ~259), before episodes or files are loaded — move it after `checkFileStatus()` so the episode list, controls, pagination, and file badges all appear together instead of popping in one by one.~~
-~~2. **Compact spinner rows for Shikimori/Friends:** The Shikimori panel (`shiki-panel`) and Friends panel (`friends-panel`) load async via `loadShikimoriData()`. They already show "Loading..." text, but the panels themselves (`v-if="shikiUser && anime.myAnimeListId"`) only appear after `shikiUser` resolves. Reserve the panels immediately (show them with a spinner row as soon as `anime.myAnimeListId` exists) rather than waiting for `shikiUser`. After `loadShikimoriData` resolves, replace spinner with controls or hide the panel if not logged in.~~
-~~3. **Session-level file scan cache in main process:** Add an in-memory `Map<string, ...>` in `main/index.ts` (keyed by `animeName`) that caches the result of `file:check-episodes`. On first call per anime per session, do the full directory scan and cache. On subsequent calls, return the cached result immediately. Invalidate the cache entry when files change: after `file:delete-episode`, after download completion (in `downloadedEpisodesSet`), and after `storage:move-to-cold`.~~
-~~4. **Verify file on open:** In the `file:open` handler, check `fs.existsSync(filePath)` before calling `shell.openPath`. If the file is gone (e.g., user deleted externally), invalidate the cache for that anime and return an error so the renderer can refresh file status and show a message.~~
-~~5. **Background rescan:** After returning the cached result, optionally queue a background async rescan (using `fsPromises.readdir`) that updates the cache. If results differ from the cached version, send an IPC event to the renderer so it can refresh badges without a full page jump.~~
-~~6. **Files:** `src/main/index.ts` (file scan cache, IPC handlers), `src/renderer/src/components/AnimeDetailView.vue` (loading state, panel placeholders).~~
-
----
-
-## 2. Stream MKV Playback Without Full Remux Wait
+## 1. Stream MKV Playback Without Full Remux Wait
 
 **Priority:** Medium | **Effort:** Large
 
@@ -71,7 +56,7 @@ Opening an MKV file in the built-in player currently remuxes the entire file to 
 
 ---
 
-## 3. Configurable Anime4K Shader Shortcuts in Player
+## 2. Configurable Anime4K Shader Shortcuts in Player
 
 **Priority:** Medium | **Effort:** Small
 
@@ -86,40 +71,7 @@ Add keyboard shortcuts for switching Anime4K shader presets while watching: Ctrl
 
 ---
 
-## ~~4. Disable "Go Back" Global Shortcut While Player Is Open~~
-
-~~**Priority:** Medium | **Effort:** Small~~
-
-~~When pressing Escape in the built-in player, the player closes (via `handleClose()` in `PlayerView.vue` line ~267 → `emit('close')` → `closePlayer()` in `App.vue` sets `playerState = null`). But in the same keydown event, `App.vue`'s `handleKeydown` (line ~108) fires next — and since `playerState` is now null (just cleared synchronously by `closePlayer`), the `if (playerState.value) return` guard on line ~110 no longer blocks, so the "back" action also executes, closing the anime detail view. The user ends up back at the search/library grid instead of the anime page.~~
-
-~~**Plan:**~~
-~~1. **Add `stopPropagation()`:** In `PlayerView.vue` `onKeyDown` (line ~276), call `event.stopPropagation()` at the top of the function (before the switch). This prevents the event from reaching `App.vue`'s `handleKeydown` listener entirely while the player is mounted. This is safe because the player already handles all relevant keys (Space, arrows, F, M, Escape) and should consume all keyboard input while active.~~
-~~2. **Files:** `src/renderer/src/components/PlayerView.vue`.~~
-
----
-
-## 5. Previous / Next Episode Buttons in Player
-
-**Priority:** Medium | **Effort:** Medium
-
-Add prev/next episode navigation buttons to the built-in player controls for seamless binge-watching without returning to the anime detail view.
-
-**Translation resolution order for the target episode:** try downloaded file for same author → same translationId → best quality of current translation type → disable button if nothing available.
-
-**Plan:**
-1. **Pass episode list to player:** Extend the `playFile` emit in `AnimeDetailView.vue` (line ~673, ~684) to include the full `episodeRows` data: an ordered array of `{ episodeInt, episodeFull, translations, downloadedTrIds }` for all filtered episodes (not just the current page). Add a corresponding prop to `PlayerView.vue` and update `playerState` in `App.vue` `openPlayer` (line ~38).
-2. **Resolve target episode:** Add a helper function `resolveEpisodePlayback(targetEpisode, currentTranslationId, currentType)` in `PlayerView.vue` that implements the priority chain: (a) find a downloaded file matching the current author via `playerFindLocalFile`, (b) find the same `translationId`, (c) find the best quality translation of the current type, (d) return null (button disabled). This function returns `{ translationId, isLocal, filePath?, streamUrl?, subtitleContent? }` or null.
-3. **Computed prev/next availability:** Add computed properties `canPrev` / `canNext` that check whether the adjacent episode exists in the episode list and has a resolvable translation (call `resolveEpisodePlayback` reactively). Disable the buttons when null.
-4. **Navigation handler:** Add `goToEpisode(direction: 'prev' | 'next')` that calls `resolveEpisodePlayback`, then either loads the local file (via `playerFindLocalFile` + optional MKV remux) or fetches a stream URL (via `playerGetStreamUrl`). Update all reactive state: `activeFilePath`, `activeStreamUrl`, `activeSubtitleContent`, `activeTranslationId`, episode label in the title bar. Clean up previous remux if switching from MKV.
-5. **UI buttons:** Add prev/next buttons in the player controls bar (in the title bar area, next to the episode label). Use `‹` / `›` or skip-back/skip-forward SVG icons. Disable with reduced opacity when `!canPrev` / `!canNext`.
-6. **Keyboard shortcuts:** Add `Shift+ArrowLeft` for prev and `Shift+ArrowRight` for next in `onKeyDown` (line ~276). Make them configurable via `keyboardShortcuts` store (add `playerPrevEpisode: 'Shift+ArrowLeft'` and `playerNextEpisode: 'Shift+ArrowRight'` to `DEFAULT_SHORTCUTS` in `SettingsView.vue`).
-7. **Auto-advance on end (optional):** When the video fires the `ended` event and `canNext` is true, auto-navigate to the next episode after a brief delay (3s countdown with cancel).
-8. **IPC changes:** None — reuses existing `playerFindLocalFile`, `playerGetStreamUrl`, `playerRemuxMkv` handlers.
-9. **Files:** `src/renderer/src/components/AnimeDetailView.vue` (extend emit), `src/renderer/src/App.vue` (extend playerState + openPlayer + PlayerView props), `src/renderer/src/components/PlayerView.vue` (buttons, shortcuts, navigation logic), `src/renderer/src/components/SettingsView.vue` (shortcut defaults), `src/preload/index.d.ts` (update playFile emit type if needed).
-
----
-
-## 6. Auto-Track Watch Progress and Resume Playback
+## 3. Auto-Track Watch Progress and Resume Playback
 
 **Priority:** Medium | **Effort:** Medium
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.4.0",
+  "version": "3.4.2",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,7 +59,9 @@ const store = new Store({
     keyboardShortcuts: {
       back: 'Escape',
       focusSearch: 'CmdOrCtrl+F',
-      goDownloads: 'CmdOrCtrl+D'
+      goDownloads: 'CmdOrCtrl+D',
+      playerPrevEpisode: 'Shift+ArrowLeft',
+      playerNextEpisode: 'Shift+ArrowRight'
     } as Record<string, string>,
     shikimoriCredentials: null as shikimori.ShikiCredentials | null,
     shikimoriUser: null as shikimori.ShikiUser | null,

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -33,10 +33,12 @@ const playerState = ref<{
   translationId: number
   translations: { id: number; label: string; type: string; height: number }[]
   downloadedTrIds: number[]
+  allEpisodes: { episodeInt: string; episodeFull: string; translations: { id: number; label: string; type: string; height: number }[]; downloadedTrIds: number[] }[]
+  episodeIndex: number
 } | null>(null)
 
-function openPlayer(filePath: string, streamUrl: string, subtitleContent: string, animeName: string, episodeLabel: string, availableStreams: { height: number; url: string }[], translationId: number, translations: { id: number; label: string; type: string; height: number }[] = [], downloadedTrIds: number[] = []): void {
-  playerState.value = { filePath, streamUrl, subtitleContent, animeName, episodeLabel, availableStreams, translationId, translations, downloadedTrIds }
+function openPlayer(filePath: string, streamUrl: string, subtitleContent: string, animeName: string, episodeLabel: string, availableStreams: { height: number; url: string }[], translationId: number, translations: { id: number; label: string; type: string; height: number }[] = [], downloadedTrIds: number[] = [], allEpisodes: { episodeInt: string; episodeFull: string; translations: { id: number; label: string; type: string; height: number }[]; downloadedTrIds: number[] }[] = [], episodeIndex: number = 0): void {
+  playerState.value = { filePath, streamUrl, subtitleContent, animeName, episodeLabel, availableStreams, translationId, translations, downloadedTrIds, allEpisodes, episodeIndex }
 }
 
 function closePlayer(): void {
@@ -163,7 +165,7 @@ onBeforeUnmount(() => {
     <FriendsActivityView v-show="currentView === 'friends' && !activeAnimeId" @open-anime="openAnime" />
     <SettingsView v-if="currentView === 'settings'" />
     <DownloadsView v-if="currentView === 'downloads'" />
-    <PlayerView v-if="playerState" :file-path="playerState.filePath" :stream-url="playerState.streamUrl" :subtitle-content="playerState.subtitleContent" :anime-name="playerState.animeName" :episode-label="playerState.episodeLabel" :available-streams="playerState.availableStreams" :translation-id="playerState.translationId" :translations="playerState.translations" :downloaded-tr-ids="playerState.downloadedTrIds" @close="closePlayer" />
+    <PlayerView v-if="playerState" :file-path="playerState.filePath" :stream-url="playerState.streamUrl" :subtitle-content="playerState.subtitleContent" :anime-name="playerState.animeName" :episode-label="playerState.episodeLabel" :available-streams="playerState.availableStreams" :translation-id="playerState.translationId" :translations="playerState.translations" :downloaded-tr-ids="playerState.downloadedTrIds" :all-episodes="playerState.allEpisodes" :episode-index="playerState.episodeIndex" @close="closePlayer" />
     <div v-if="ffmpegDownloading" class="ffmpeg-overlay">
       <div class="ffmpeg-modal">
         <div class="ffmpeg-spinner"></div>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   back: []
   prefsChanged: [animeId: number, translationType: string, author: string]
-  playFile: [filePath: string, streamUrl: string, subtitleContent: string, animeName: string, episodeLabel: string, availableStreams: { height: number; url: string }[], translationId: number, translations: { id: number; label: string; type: string; height: number }[], downloadedTrIds: number[]]
+  playFile: [filePath: string, streamUrl: string, subtitleContent: string, animeName: string, episodeLabel: string, availableStreams: { height: number; url: string }[], translationId: number, translations: { id: number; label: string; type: string; height: number }[], downloadedTrIds: number[], allEpisodes: { episodeInt: string; episodeFull: string; translations: { id: number; label: string; type: string; height: number }[]; downloadedTrIds: number[] }[], episodeIndex: number]
 }>()
 
 const anime = ref<AnimeDetail | null>(null)
@@ -656,6 +656,18 @@ function buildTranslationList(row: EpisodeRow | undefined): { id: number; label:
   }))
 }
 
+function buildAllEpisodes(): { episodeInt: string; episodeFull: string; translations: { id: number; label: string; type: string; height: number }[]; downloadedTrIds: number[] }[] {
+  return filteredEpisodes.value.map(ep => {
+    const detail = episodes.value.get(ep.id)
+    const translations = detail
+      ? detail.translations.filter(t => t.isActive === 1).map(t => ({ id: t.id, label: t.authorsSummary, type: t.type, height: getRealHeight(t) }))
+      : []
+    const metas = episodeMeta.value[ep.episodeInt] || []
+    const downloadedTrIds = metas.map(m => m.translationId)
+    return { episodeInt: ep.episodeInt, episodeFull: ep.episodeFull, translations, downloadedTrIds }
+  })
+}
+
 function getFileForTranslation(episodeInt: string, translationId: number | undefined): { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string } | null {
   const files = fileStatus.value[episodeInt]
   if (!files || files.length === 0) return null
@@ -696,7 +708,9 @@ async function openFile(row: EpisodeRow): Promise<void> {
   if (playerMode.value === 'builtin') {
     const name = anime.value ? getAnimeName() : ''
     const localSubs = await window.api.playerGetLocalSubtitles(info.filePath)
-    emit('playFile', info.filePath, '', localSubs || '', name, row.episode.episodeInt, [], row.selectedTr.id, buildTranslationList(row), [...row.downloadedTrIds])
+    const allEps = buildAllEpisodes()
+    const epIdx = allEps.findIndex(e => e.episodeInt === row.episode.episodeInt)
+    emit('playFile', info.filePath, '', localSubs || '', name, row.episode.episodeInt, [], row.selectedTr.id, buildTranslationList(row), [...row.downloadedTrIds], allEps, epIdx)
   } else {
     const result = await window.api.fileOpen(info.filePath)
     if (result) {
@@ -711,7 +725,9 @@ async function playStream(row: EpisodeRow): Promise<void> {
   const name = anime.value ? getAnimeName() : ''
   const result = await window.api.playerGetStreamUrl(row.selectedTr.id, getRealHeight(row.selectedTr))
   if (result) {
-    emit('playFile', '', result.streamUrl, result.subtitleContent || '', name, row.episode.episodeInt, result.availableStreams, row.selectedTr.id, buildTranslationList(row), [...row.downloadedTrIds])
+    const allEps = buildAllEpisodes()
+    const epIdx = allEps.findIndex(e => e.episodeInt === row.episode.episodeInt)
+    emit('playFile', '', result.streamUrl, result.subtitleContent || '', name, row.episode.episodeInt, result.availableStreams, row.selectedTr.id, buildTranslationList(row), [...row.downloadedTrIds], allEps, epIdx)
   }
 }
 

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -12,6 +12,8 @@ const props = defineProps<{
   translationId: number
   translations: { id: number; label: string; type: string; height: number }[]
   downloadedTrIds: number[]
+  allEpisodes: { episodeInt: string; episodeFull: string; translations: { id: number; label: string; type: string; height: number }[]; downloadedTrIds: number[] }[]
+  episodeIndex: number
 }>()
 
 const emit = defineEmits<{
@@ -66,9 +68,21 @@ const showTranslationMenu = ref(false)
 const activeTranslationId = ref(props.translationId)
 const activeSubtitleContent = ref(props.subtitleContent)
 const switchingTranslation = ref(false)
-const hasTranslations = computed(() => props.translations.length > 1)
+const hasTranslations = computed(() => activeTranslations.value.length > 1)
 const translationMenuLevel = ref<'types' | 'items'>('types')
 const selectedTypeGroup = ref('')
+
+// Episode navigation state
+const activeEpisodeIndex = ref(props.episodeIndex)
+const activeEpisodeLabel = ref(props.episodeLabel)
+const activeTranslations = ref(props.translations)
+const activeDownloadedTrIds = ref(props.downloadedTrIds)
+const navigating = ref(false)
+const canPrev = computed(() => activeEpisodeIndex.value > 0)
+const canNext = computed(() => activeEpisodeIndex.value < props.allEpisodes.length - 1)
+const autoAdvanceCountdown = ref(0)
+let autoAdvanceTimer: ReturnType<typeof setInterval> | null = null
+const playerShortcuts = ref<Record<string, string>>({})
 
 // WebGPU pipeline state
 let gpuDevice: GPUDevice | null = null
@@ -127,6 +141,7 @@ function formatTime(seconds: number): string {
 
 // Playback controls
 function togglePlay(): void {
+  cancelAutoAdvance()
   const video = videoRef.value
   if (!video) return
   if (video.paused) {
@@ -281,10 +296,43 @@ function onMouseBack(e: MouseEvent): void {
 }
 
 // Keyboard shortcuts
+const isMac = navigator.platform.toUpperCase().includes('MAC')
+
+function matchesBinding(e: KeyboardEvent, binding: string): boolean {
+  const parts = binding.split('+')
+  const key = parts[parts.length - 1]
+  const mods = parts.slice(0, -1).map((m) => m.toLowerCase())
+  const needCtrl = mods.includes('ctrl')
+  const needMeta = mods.includes('meta')
+  const needCmdOrCtrl = mods.includes('cmdorctrl')
+  const needShift = mods.includes('shift')
+  const needAlt = mods.includes('alt')
+  const wantCtrl = needCtrl || (needCmdOrCtrl && !isMac)
+  const wantMeta = needMeta || (needCmdOrCtrl && isMac)
+  if (e.ctrlKey !== wantCtrl) return false
+  if (e.metaKey !== wantMeta) return false
+  if (e.shiftKey !== needShift) return false
+  if (e.altKey !== needAlt) return false
+  return e.key.toLowerCase() === key.toLowerCase()
+}
+
 function onKeyDown(event: KeyboardEvent): void {
   event.stopPropagation()
   // Don't handle if a preset menu input is focused
   if ((event.target as HTMLElement)?.tagName === 'SELECT') return
+
+  const prevBinding = playerShortcuts.value.playerPrevEpisode || 'Shift+ArrowLeft'
+  const nextBinding = playerShortcuts.value.playerNextEpisode || 'Shift+ArrowRight'
+  if (matchesBinding(event, prevBinding)) {
+    event.preventDefault()
+    if (canPrev.value) goToEpisode('prev')
+    return
+  }
+  if (matchesBinding(event, nextBinding)) {
+    event.preventDefault()
+    if (canNext.value) goToEpisode('next')
+    return
+  }
 
   switch (event.key) {
     case ' ':
@@ -552,7 +600,7 @@ function translationTypeLabel(type: string): string {
 }
 
 const currentTranslation = computed(() =>
-  props.translations.find(t => t.id === activeTranslationId.value)
+  activeTranslations.value.find(t => t.id === activeTranslationId.value)
 )
 
 const currentTranslationLabel = computed(() => {
@@ -563,7 +611,7 @@ const currentTranslationLabel = computed(() => {
 
 const translationTypeGroups = computed(() => {
   const groups: Record<string, { id: number; label: string; type: string; height: number }[]> = {}
-  for (const tr of props.translations) {
+  for (const tr of activeTranslations.value) {
     const key = tr.type
     if (!groups[key]) groups[key] = []
     groups[key].push(tr)
@@ -619,8 +667,8 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
 
   try {
     // Check if this translation has a local file
-    if (props.downloadedTrIds.includes(tr.id)) {
-      const localResult = await window.api.playerFindLocalFile(props.animeName, props.episodeLabel, tr.id)
+    if (activeDownloadedTrIds.value.includes(tr.id)) {
+      const localResult = await window.api.playerFindLocalFile(props.animeName, activeEpisodeLabel.value, tr.id)
       if (localResult) {
         activeTranslationId.value = tr.id
 
@@ -711,6 +759,139 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
   }
 }
 
+async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
+  const targetIndex = direction === 'prev' ? activeEpisodeIndex.value - 1 : activeEpisodeIndex.value + 1
+  if (targetIndex < 0 || targetIndex >= props.allEpisodes.length) return
+  if (navigating.value) return
+
+  cancelAutoAdvance()
+  navigating.value = true
+  const video = videoRef.value
+  const targetEp = props.allEpisodes[targetIndex]
+
+  // Find the current translation type for resolution
+  const currentTr = activeTranslations.value.find(t => t.id === activeTranslationId.value)
+  const currentType = currentTr?.type || ''
+
+  // Resolution priority chain
+  let resolvedTr: { id: number; label: string; type: string; height: number } | null = null
+
+  // (a) Same translationId if available in target episode
+  resolvedTr = targetEp.translations.find(t => t.id === activeTranslationId.value) || null
+
+  // (b) Best quality of same type
+  if (!resolvedTr) {
+    const sameType = targetEp.translations
+      .filter(t => t.type === currentType)
+      .sort((a, b) => b.height - a.height)
+    resolvedTr = sameType[0] || null
+  }
+
+  // (c) First available translation
+  if (!resolvedTr) {
+    resolvedTr = targetEp.translations[0] || null
+  }
+
+  if (!resolvedTr) {
+    navigating.value = false
+    return
+  }
+
+  try {
+    // Clean up previous remux
+    if (remuxedPath.value) {
+      await window.api.playerCleanupRemux()
+      remuxedPath.value = ''
+    }
+
+    // Update episode state
+    activeEpisodeIndex.value = targetIndex
+    activeEpisodeLabel.value = targetEp.episodeInt
+    activeTranslations.value = targetEp.translations
+    activeDownloadedTrIds.value = targetEp.downloadedTrIds
+    activeTranslationId.value = resolvedTr.id
+
+    // Try local file first if downloaded
+    if (targetEp.downloadedTrIds.includes(resolvedTr.id)) {
+      const localResult = await window.api.playerFindLocalFile(props.animeName, targetEp.episodeInt, resolvedTr.id)
+      if (localResult) {
+        activeFilePath.value = localResult.filePath
+        activeStreamUrl.value = ''
+        activeSubtitleContent.value = localResult.subtitleContent || ''
+
+        if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
+          remuxing.value = true
+          const remuxResult = await window.api.playerRemuxMkv(localResult.filePath)
+          remuxing.value = false
+          if ('error' in remuxResult) {
+            remuxError.value = remuxResult.error
+            navigating.value = false
+            return
+          }
+          remuxedPath.value = remuxResult.mp4Path
+          if (!activeSubtitleContent.value && remuxResult.subtitleContent) {
+            activeSubtitleContent.value = remuxResult.subtitleContent
+          }
+        }
+
+        destroySubtitles()
+        if (activeSubtitleContent.value && video) initSubtitles(video)
+
+        nextTick(() => {
+          const v = videoRef.value
+          if (v) { v.currentTime = 0; v.play() }
+          navigating.value = false
+        })
+        return
+      }
+    }
+
+    // Fall back to streaming
+    const result = await window.api.playerGetStreamUrl(resolvedTr.id, resolvedTr.height)
+    if (!result) { navigating.value = false; return }
+
+    activeFilePath.value = ''
+    activeStreamUrl.value = result.streamUrl
+    activeSubtitleContent.value = result.subtitleContent || ''
+
+    if (result.availableStreams.length > 0) {
+      const current = result.availableStreams.find(s => s.url === result.streamUrl)
+      selectedHeight.value = current ? current.height : result.availableStreams[0].height
+    }
+
+    destroySubtitles()
+    if (result.subtitleContent && video) initSubtitles(video)
+
+    nextTick(() => {
+      const v = videoRef.value
+      if (v) { v.currentTime = 0; v.play() }
+      navigating.value = false
+    })
+  } catch {
+    navigating.value = false
+  }
+}
+
+function cancelAutoAdvance(): void {
+  if (autoAdvanceTimer) {
+    clearInterval(autoAdvanceTimer)
+    autoAdvanceTimer = null
+  }
+  autoAdvanceCountdown.value = 0
+}
+
+function onVideoEnded(): void {
+  if (!canNext.value) return
+  autoAdvanceCountdown.value = 5
+  autoAdvanceTimer = setInterval(() => {
+    autoAdvanceCountdown.value--
+    if (autoAdvanceCountdown.value <= 0) {
+      cancelAutoAdvance()
+      goToEpisode('next')
+    }
+  }, 1000)
+}
+
 function initSubtitles(video: HTMLVideoElement): void {
   const content = activeSubtitleContent.value
   if (!content) return
@@ -746,6 +927,8 @@ onMounted(async () => {
   document.addEventListener('keydown', onKeyDown)
   document.addEventListener('fullscreenchange', onFullscreenChange)
   window.addEventListener('mouseup', onMouseBack, true)
+  const savedShortcuts = await window.api.getSetting('keyboardShortcuts') as Record<string, string> | null
+  if (savedShortcuts) playerShortcuts.value = savedShortcuts
 
   // Remux MKV to MP4 if needed
   if (isMkv.value && props.filePath) {
@@ -811,6 +994,7 @@ onBeforeUnmount(() => {
   document.removeEventListener('fullscreenchange', onFullscreenChange)
   window.removeEventListener('mouseup', onMouseBack, true)
   if (controlsTimer) clearTimeout(controlsTimer)
+  cancelAutoAdvance()
   stopAnime4KPipeline()
   destroySubtitles()
   // Pause and release video
@@ -866,6 +1050,14 @@ const bufferedProgress = computed(() => {
       </div>
     </div>
 
+    <!-- Auto-advance countdown -->
+    <div v-if="autoAdvanceCountdown > 0" class="auto-advance-overlay">
+      <div class="auto-advance-modal">
+        <p class="auto-advance-text">Next episode in {{ autoAdvanceCountdown }}...</p>
+        <button class="auto-advance-cancel" @click="cancelAutoAdvance">Cancel</button>
+      </div>
+    </div>
+
     <!-- Streaming warning banner -->
     <transition name="fade">
       <div v-if="isStreaming" class="streaming-banner">
@@ -887,6 +1079,7 @@ const bufferedProgress = computed(() => {
         @timeupdate="onTimeUpdate"
         @durationchange="onDurationChange"
         @progress="onProgress"
+        @ended="onVideoEnded"
         @click="togglePlay"
         @dblclick="toggleFullscreen"
         autoplay
@@ -911,7 +1104,17 @@ const bufferedProgress = computed(() => {
             <path d="M19 12H5M12 19l-7-7 7-7" />
           </svg>
         </button>
-        <span class="title-text">{{ animeName }} — {{ episodeLabel }}</span>
+        <button v-if="props.allEpisodes.length > 1" class="ep-nav-btn" :disabled="!canPrev || navigating" @click="goToEpisode('prev')" title="Previous episode (Shift+←)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span class="title-text">{{ animeName }} — {{ activeEpisodeLabel }}</span>
+        <button v-if="props.allEpisodes.length > 1" class="ep-nav-btn" :disabled="!canNext || navigating" @click="goToEpisode('next')" title="Next episode (Shift+→)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
       </div>
     </transition>
 
@@ -1019,10 +1222,10 @@ const bufferedProgress = computed(() => {
                   v-for="tr in selectedGroupItems"
                   :key="tr.id"
                   class="preset-option"
-                  :class="{ selected: activeTranslationId === tr.id, downloaded: downloadedTrIds.includes(tr.id) }"
+                  :class="{ selected: activeTranslationId === tr.id, downloaded: activeDownloadedTrIds.includes(tr.id) }"
                   @click="selectTranslation(tr)"
                 >
-                  <span v-if="downloadedTrIds.includes(tr.id)" class="tr-dl-icon">⬇</span>
+                  <span v-if="activeDownloadedTrIds.includes(tr.id)" class="tr-dl-icon">⬇</span>
                   <span class="tr-label">{{ tr.label }}</span>
                   <span class="tr-meta">{{ qualityLabel(tr.height) }}</span>
                 </button>
@@ -1268,6 +1471,66 @@ const bufferedProgress = computed(() => {
   font-size: 0.9rem;
   font-weight: 500;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.ep-nav-btn {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  opacity: 0.8;
+}
+
+.ep-nav-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.15);
+  opacity: 1;
+}
+
+.ep-nav-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.auto-advance-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 15;
+  pointer-events: none;
+}
+
+.auto-advance-modal {
+  background: rgba(0, 0, 0, 0.8);
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  text-align: center;
+  pointer-events: auto;
+}
+
+.auto-advance-text {
+  color: #fff;
+  font-size: 1.1rem;
+  margin: 0 0 0.8rem 0;
+}
+
+.auto-advance-cancel {
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  color: #fff;
+  padding: 6px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.auto-advance-cancel:hover {
+  background: rgba(255, 255, 255, 0.25);
 }
 
 /* Controls bar */

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -70,13 +70,17 @@ const benchmarkError = ref('')
 const DEFAULT_SHORTCUTS: Record<string, string> = {
   back: 'Escape',
   focusSearch: 'CmdOrCtrl+F',
-  goDownloads: 'CmdOrCtrl+D'
+  goDownloads: 'CmdOrCtrl+D',
+  playerPrevEpisode: 'Shift+ArrowLeft',
+  playerNextEpisode: 'Shift+ArrowRight'
 }
 
 const SHORTCUT_LABELS: Record<string, { label: string; hint: string }> = {
   back: { label: 'Go back', hint: 'Navigate back from anime detail view' },
   focusSearch: { label: 'Focus search', hint: 'Switch to Search tab and focus the input' },
-  goDownloads: { label: 'Go to downloads', hint: 'Switch to Downloads tab' }
+  goDownloads: { label: 'Go to downloads', hint: 'Switch to Downloads tab' },
+  playerPrevEpisode: { label: 'Previous episode', hint: 'Go to previous episode in the built-in player' },
+  playerNextEpisode: { label: 'Next episode', hint: 'Go to next episode in the built-in player' }
 }
 
 const shortcutBindings = ref<Record<string, string>>({})


### PR DESCRIPTION
## Summary

Adds prev/next episode navigation to the built-in player, enabling seamless binge-watching without returning to the anime detail view. Includes configurable keyboard shortcuts and auto-advance on video end.

### What changed

- **Episode navigation buttons**: Prev (‹) and next (›) buttons in the player title bar, flanking the episode label. Disabled with reduced opacity at first/last episode. Hidden for single-episode anime
- **Full episode list passed to player**: `AnimeDetailView` builds `allEpisodes` array from `filteredEpisodes` (all episodes, not just the current page) with translations and downloaded translation IDs per episode, passed through `App.vue` to `PlayerView`
- **Translation resolution for target episode**: Priority chain — same translationId → best quality of same type → first available. Tries local file first (via `playerFindLocalFile`), falls back to streaming (via `playerGetStreamUrl`). Cleans up previous MKV remux when switching
- **Auto-advance on video end**: When a video finishes and next episode is available, shows a 5-second countdown overlay ("Next episode in 5...") with Cancel button. Auto-navigates if not cancelled
- **Configurable keyboard shortcuts**: `playerPrevEpisode` (default Shift+←) and `playerNextEpisode` (default Shift+→) added to Settings > Shortcuts, stored in `keyboardShortcuts` setting
- **Reactive translation/episode state**: `activeTranslations`, `activeDownloadedTrIds`, `activeEpisodeLabel` refs update on episode navigation so translation menu and downloaded indicators stay correct

### Files changed

| File | Changes |
|------|---------|
| `src/renderer/src/components/AnimeDetailView.vue` | Extended `playFile` emit with `allEpisodes` + `episodeIndex`; added `buildAllEpisodes()` helper |
| `src/renderer/src/App.vue` | Extended `playerState` type and `openPlayer()` with new fields; updated `<PlayerView>` props |
| `src/renderer/src/components/PlayerView.vue` | New props, episode nav state, `goToEpisode()`, `onVideoEnded()` auto-advance, configurable shortcut matching, prev/next UI buttons, auto-advance overlay + CSS |
| `src/renderer/src/components/SettingsView.vue` | Added `playerPrevEpisode` / `playerNextEpisode` to `DEFAULT_SHORTCUTS` and `SHORTCUT_LABELS` |
| `src/main/index.ts` | Added default shortcut bindings to store defaults |
| `DESIGN.md` | Documented episode navigation, updated keyboard shortcuts setting |
| `TODO.md` | Struck through completed item #5 |
| `package.json` | Version bump 3.4.0 → 3.4.2 |

## Test plan

- [x] Open anime with multiple episodes → prev/next buttons visible in player title bar
- [x] First episode → prev disabled; last episode → next disabled
- [x] Click next → loads next episode, plays from start
- [x] Click prev → loads previous episode
- [x] Navigate to episode with local file → plays local; without → streams from CDN
- [x] Shift+ArrowRight → next episode; Shift+ArrowLeft → previous
- [x] Rebind shortcuts in Settings > Shortcuts → player respects new bindings
- [x] Let video end → 5s countdown overlay appears → advances to next episode
- [x] Cancel auto-advance → stays on current episode
- [ ] Single-episode anime → no nav buttons shown
- [x] Translation menu updates correctly after episode navigation (correct translations list, downloaded indicators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)