### PR TITLE
feat: stream MKV playback without full remux wait

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -295,8 +295,14 @@ LibraryView shows both with indicators:
 | `player:get-stream-url` | invoke | Fetch CDN stream URL + raw ASS subtitle content + all available stream qualities for a translation |
 | `player:get-local-subtitles` | invoke | Read local .ass file alongside video, return raw ASS content |
 | `player:find-local-file` | invoke | Find local file path for a translation by animeName/episodeInt/translationId |
-| `player:remux-mkv` | invoke | Remux MKV→MP4 via ffmpeg stream copy to temp dir for HTML5 playback |
-| `player:cleanup-remux` | invoke | Delete temp remuxed files when player closes |
+| `player:remux-mkv` | invoke | Legacy: remux MKV→MP4 via ffmpeg stream copy, await completion before returning (used as fallback when codecs aren't MSE-compatible) |
+| `player:remux-mkv-stream` | invoke | ffprobe MKV + start fragmented-MP4 pipe from ffmpeg; returns `{ sessionId, duration, mimeType, hasSubtitlesPending }` for MSE consumption |
+| `player:stream-chunk` | event (main→renderer) | Fragmented-MP4 bytes from an active session, appended into the renderer's `SourceBuffer` |
+| `player:stream-end` | event (main→renderer) | ffmpeg finished writing; renderer calls `mediaSource.endOfStream()` after draining its queue |
+| `player:stream-error` | event (main→renderer) | ffmpeg exited non-zero or spawn failed; renderer falls back to legacy remux |
+| `player:stream-ack` | invoke | Renderer reports bytes it has consumed from the session; main resumes ffmpeg stdout once pending bytes drop below the low watermark |
+| `player:stream-subtitles` | event (main→renderer) | Subtitle `.ass` content extracted from an MKV stream session, pushed when extraction finishes |
+| `player:cleanup-remux` | invoke | Kill any active stream sessions and delete all temp remuxed files |
 | `shell:open-external` | invoke | Open URL in default browser (returns success boolean) |
 
 ## Key Types
@@ -407,12 +413,12 @@ In-app HTML5 video player with optional Anime4K WebGPU upscaling shaders. Uses `
 
 ### Custom Protocol
 
-`anime-video://` protocol registered via `protocol.handle` serves local video files to the `<video>` element. The `stream: true` privilege enables HTTP range requests for seeking. The handler manually parses `Range` headers and returns 206 Partial Content responses using `fs.createReadStream({ start, end })` for proper seeking support. Files are encoded as `anime-video://{encodeURIComponent(filePath)}`.
+`anime-video://` protocol registered via `protocol.handle` serves local video files to the `<video>` element. The `stream: true` privilege enables HTTP range requests for seeking. The handler manually parses `Range` headers and returns 206 Partial Content responses using `fs.createReadStream({ start, end })` for proper seeking support. URL shape: `anime-video://{encodeURIComponent(filePath)}`. (MKV streaming does not use this protocol — it flows through MSE over IPC; see below.)
 
 ### Video Playback
 
 - **Local .mp4**: Served via `anime-video://` protocol
-- **Local .mkv**: Remuxed to temp MP4 via ffmpeg stream copy (`-c copy -movflags +faststart`), then served via `anime-video://`. Shows "Preparing MKV for playback..." spinner during remux. Temp files cleaned up on player close via `player:cleanup-remux`. Temp dir: `os.tmpdir()/anime-dl-remux/`.
+- **Local .mkv**: Progressive playback via **MSE (MediaSource Extensions)**. The main process ffprobes the MKV for duration and H.264 / AAC codec parameters, then spawns ffmpeg with `-c copy -movflags +frag_keyframe+empty_moov+default_base_moof -f mp4 pipe:1` and streams its stdout to the renderer via `player:stream-chunk` events. `player:remux-mkv-stream` returns `{ sessionId, duration, mimeType, hasSubtitlesPending }` immediately. The renderer creates a `MediaSource`, sets `duration` upfront, calls `addSourceBuffer(mimeType)`, appends each incoming chunk, and binds `<video>` to the `URL.createObjectURL(mediaSource)`. Backpressure: main tracks pending-bytes per session and pauses `ffmpeg.stdout` above 32 MB; renderer acks via `player:stream-ack` each 1 MB appended. Subtitle extraction runs in parallel and is pushed via `player:stream-subtitles` when ready. Fallback: if ffprobe reports an unsupported codec combo (anything non-H.264/AAC, e.g. HEVC, Opus, FLAC) or ffmpeg errors, renderer falls back to legacy `player:remux-mkv` (full remux with `+faststart`, blocking "Preparing MKV…" overlay). SourceBuffer quota is managed by evicting buffered data >60 s behind the playhead on every `updateend`, with a `QuotaExceededError` retry path. `player:cleanup-remux` SIGKILLs active ffmpeg processes and sweeps the temp dir (`os.tmpdir()/anime-dl-remux/`, used only for extracted `.ass` files).
 - **Non-downloaded episodes**: Streams directly from smotret-anime CDN via `player:get-stream-url` IPC
 
 ### Anime4K WebGPU Pipeline

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,13 +8,14 @@ import * as fs from 'fs'
 import * as fsPromises from 'fs/promises'
 import * as path from 'path'
 import ffbinaries from 'ffbinaries'
-import { execFile } from 'child_process'
+import { execFile, spawn, type ChildProcess } from 'child_process'
 import * as os from 'os'
 import Ffmpeg from 'fluent-ffmpeg'
 import { autoUpdater } from 'electron-updater'
 import * as shikimori from './shikimori'
 import { pathToFileURL } from 'url'
 import { Readable } from 'stream'
+import { randomUUID } from 'crypto'
 import { SmotretApi } from './smotret-api'
 import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, EpisodeDetail, Translation } from './smotret-api'
 
@@ -1400,14 +1401,12 @@ function registerIpcHandlers(): void {
     return null
   })
 
-  // Remux MKV to MP4 (stream copy) for HTML5 playback
-  const remuxTmpDir = path.join(os.tmpdir(), 'anime-dl-remux')
-
+  // Remux MKV to fragmented MP4 (stream copy) for progressive HTML5 playback.
+  // See protocol.handle('anime-video', …) below for the streaming reader.
   ipcMain.handle('player:remux-mkv', async (_event, mkvPath: string): Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }> => {
     if (!ffmpegPath) return { error: 'ffmpeg not available' }
     if (!fs.existsSync(mkvPath)) return { error: 'File not found' }
 
-    // Create temp dir
     fs.mkdirSync(remuxTmpDir, { recursive: true })
 
     const stamp = Date.now()
@@ -1416,7 +1415,6 @@ function registerIpcHandlers(): void {
 
     Ffmpeg.setFfmpegPath(ffmpegPath)
 
-    // Run remux and subtitle extraction in parallel
     const remuxPromise = new Promise<void>((resolve, reject) => {
       Ffmpeg(mkvPath)
         .outputOptions(['-c', 'copy', '-movflags', '+faststart'])
@@ -1432,37 +1430,7 @@ function registerIpcHandlers(): void {
         .run()
     })
 
-    // Extract first subtitle stream (if any) to a temp .ass file
-    const subtitlePromise = (async (): Promise<string | undefined> => {
-      try {
-        if (!ffprobePath) return undefined
-        Ffmpeg.setFfprobePath(ffprobePath)
-        const hasSubStream = await new Promise<boolean>((res) => {
-          Ffmpeg.ffprobe(mkvPath, (err, metadata) => {
-            res(err ? false : !!metadata.streams?.find(s => s.codec_type === 'subtitle'))
-          })
-        })
-        if (!hasSubStream) return undefined
-
-        const assPath = path.join(remuxTmpDir, `${baseName}-${stamp}.ass`)
-        await new Promise<void>((res, rej) => {
-          Ffmpeg(mkvPath)
-            .outputOptions(['-map', '0:s:0', '-c:s', 'ass'])
-            .output(assPath)
-            .on('error', (err) => {
-              console.error('[remux] Subtitle extraction error:', err.message)
-              rej(err)
-            })
-            .on('end', () => res())
-            .run()
-        })
-        const content = fs.readFileSync(assPath, 'utf-8')
-        console.log('[remux] Subtitle extracted:', assPath)
-        return content
-      } catch {
-        return undefined
-      }
-    })()
+    const subtitlePromise = extractFirstSubtitle(mkvPath, path.join(remuxTmpDir, `${baseName}-${stamp}.ass`))
 
     try {
       const [, subtitleContent] = await Promise.all([remuxPromise, subtitlePromise])
@@ -1473,7 +1441,133 @@ function registerIpcHandlers(): void {
     }
   })
 
+  // Start an MSE-friendly fragmented MP4 pipe. Returns duration + codecs MIME so the
+  // renderer can set MediaSource.duration and addSourceBuffer(mimeType) upfront.
+  // Video bytes are pushed to the renderer via 'player:stream-chunk' events.
+  ipcMain.handle('player:remux-mkv-stream', async (event, mkvPath: string, initialSeek?: number): Promise<MseOpenResult | { error: string }> => {
+    if (!ffmpegPath) return { error: 'ffmpeg not available' }
+    if (!fs.existsSync(mkvPath)) return { error: 'File not found' }
+
+    const probe = await probeMkvForMse(mkvPath)
+    if (!probe) return { error: 'Codecs not supported for MSE' }
+
+    fs.mkdirSync(remuxTmpDir, { recursive: true })
+
+    const sessionId = randomUUID()
+    const baseName = path.basename(mkvPath, path.extname(mkvPath))
+
+    const session: MseSession = {
+      proc: null as unknown as ChildProcess,
+      pendingBytes: 0,
+      stderrTail: [],
+      done: false,
+      error: null,
+      senderId: event.sender.id,
+      ready: false,
+      prelude: [],
+      mkvPath,
+      generation: 0
+    }
+    mseSessions.set(sessionId, session)
+    const startSeek = typeof initialSeek === 'number' && isFinite(initialSeek) && initialSeek > 0 ? initialSeek : 0
+    session.proc = spawnFfmpegForSession(session, event, sessionId, startSeek)
+
+    // Kick off subtitle extraction in parallel; push to renderer when ready.
+    const assPath = path.join(remuxTmpDir, `${baseName}-${sessionId}.ass`)
+    let hasSubtitlesPending = false
+    try {
+      if (ffprobePath) {
+        Ffmpeg.setFfprobePath(ffprobePath)
+        hasSubtitlesPending = await new Promise<boolean>((res) => {
+          Ffmpeg.ffprobe(mkvPath, (err, metadata) => {
+            res(err ? false : !!metadata.streams?.find((s) => s.codec_type === 'subtitle'))
+          })
+        })
+      }
+    } catch { /* ignore probe failures */ }
+
+    if (hasSubtitlesPending) {
+      extractFirstSubtitle(mkvPath, assPath).then((content) => {
+        if (!content) return
+        const sender = event.sender
+        if (sender && !sender.isDestroyed()) {
+          sender.send('player:stream-subtitles', { sessionId, content })
+        }
+      }).catch(() => { /* already logged */ })
+    }
+
+    return {
+      sessionId,
+      generation: session.generation,
+      duration: probe.duration,
+      mimeType: probe.mimeType,
+      hasSubtitlesPending,
+      initialSeek: startSeek
+    }
+  })
+
+  // Forward seek past the buffered region: respawn ffmpeg with `-ss` so output
+  // starts at (or just before) the requested timestamp. The renderer will have
+  // already set sourceBuffer.timestampOffset to place fragments on the correct
+  // MSE timeline position. Stale chunks from the old proc are filtered out by
+  // the generation counter captured in spawnFfmpegForSession.
+  ipcMain.handle('player:stream-seek', (event, sessionId: string, seekSeconds: number) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return { error: 'session not found' }
+    session.generation++
+    try { session.proc.kill('SIGKILL') } catch { /* ignore */ }
+    session.pendingBytes = 0
+    session.prelude = []
+    session.done = false
+    session.error = null
+    // Hold new chunks in the prelude until the renderer has set its
+    // SourceBuffer.timestampOffset and called player:stream-start again.
+    // Otherwise first frames of the new run race ahead of the offset change
+    // and get placed on the wrong MSE timeline.
+    session.ready = false
+    if (session.proc.stdout && session.proc.stdout.isPaused()) {
+      try { session.proc.stdout.resume() } catch { /* ignore */ }
+    }
+    session.proc = spawnFfmpegForSession(session, event, sessionId, Math.max(0, seekSeconds))
+    return { ok: true, generation: session.generation }
+  })
+
+  // Handshake: renderer's MediaSource + SourceBuffer are ready to receive chunks.
+  // Flush any buffered prelude (the MP4 moov header lives in here) and switch to
+  // forwarding subsequent chunks directly.
+  ipcMain.handle('player:stream-start', (event, sessionId: string) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return
+    if (session.ready) return
+    session.ready = true
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      const gen = session.generation
+      for (const chunk of session.prelude) {
+        sender.send('player:stream-chunk', { sessionId, gen, data: chunk })
+      }
+    }
+    session.prelude = []
+  })
+
+  // Backpressure ack: renderer reports bytes it has appended into its SourceBuffer.
+  // When enough data has been consumed we resume the ffmpeg stdout pipe.
+  ipcMain.handle('player:stream-ack', (_event, sessionId: string, bytesConsumed: number) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return
+    session.pendingBytes = Math.max(0, session.pendingBytes - bytesConsumed)
+    if (
+      session.pendingBytes < STREAM_BACKPRESSURE_LOW_WATERMARK &&
+      session.proc.stdout?.isPaused()
+    ) {
+      session.proc.stdout.resume()
+    }
+  })
+
   ipcMain.handle('player:cleanup-remux', async () => {
+    for (const sessionId of Array.from(mseSessions.keys())) {
+      cleanupMseSession(sessionId)
+    }
     try {
       if (fs.existsSync(remuxTmpDir)) {
         const files = fs.readdirSync(remuxTmpDir)
@@ -1484,6 +1578,213 @@ function registerIpcHandlers(): void {
       }
     } catch { /* ignore */ }
   })
+}
+
+interface MseOpenResult {
+  sessionId: string
+  generation: number
+  duration: number
+  mimeType: string
+  hasSubtitlesPending: boolean
+  initialSeek: number
+}
+
+interface MseSession {
+  proc: ChildProcess
+  pendingBytes: number
+  stderrTail: string[]
+  done: boolean
+  error: string | null
+  senderId: number
+  ready: boolean
+  prelude: Buffer[]
+  mkvPath: string
+  generation: number
+}
+
+function spawnFfmpegForSession(
+  session: MseSession,
+  event: Electron.IpcMainInvokeEvent,
+  sessionId: string,
+  seekSeconds: number
+): ChildProcess {
+  const args: string[] = ['-fflags', '+genpts']
+  if (seekSeconds > 0) args.push('-ss', String(seekSeconds))
+  args.push(
+    '-i', session.mkvPath,
+    '-map', '0:v:0',
+    '-map', '0:a:0?',
+    '-c', 'copy',
+    '-avoid_negative_ts', 'make_zero',
+    '-muxpreload', '0',
+    '-muxdelay', '0',
+    '-movflags', '+frag_keyframe+empty_moov+default_base_moof+separate_moof',
+    '-frag_duration', '1000000',
+    '-f', 'mp4',
+    'pipe:1'
+  )
+  const proc = spawn(ffmpegPath!, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  const procGen = session.generation
+  console.log(`[remux-stream] spawned ffmpeg session ${sessionId.slice(0, 8)} gen=${procGen} seek=${seekSeconds}`)
+
+  proc.stderr?.on('data', (data: Buffer) => {
+    if (procGen !== session.generation) return
+    const line = data.toString()
+    session.stderrTail.push(line)
+    if (session.stderrTail.length > 40) session.stderrTail.shift()
+  })
+
+  let totalBytes = 0
+  let chunkCount = 0
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    if (procGen !== session.generation) return
+    session.pendingBytes += chunk.length
+    totalBytes += chunk.length
+    chunkCount++
+    if (chunkCount === 1 || chunkCount % 400 === 0) {
+      console.log(`[remux-stream] ${sessionId.slice(0, 8)} gen=${procGen} chunk ${chunkCount} total=${(totalBytes / 1024 / 1024).toFixed(1)}MB pending=${(session.pendingBytes / 1024 / 1024).toFixed(1)}MB ready=${session.ready}`)
+    }
+    if (session.ready) {
+      const sender = event.sender
+      if (sender && !sender.isDestroyed()) {
+        sender.send('player:stream-chunk', { sessionId, gen: procGen, data: chunk })
+      }
+    } else {
+      session.prelude.push(chunk)
+    }
+    if (session.pendingBytes > STREAM_BACKPRESSURE_HIGH_WATERMARK) {
+      proc.stdout?.pause()
+    }
+  })
+
+  proc.stdout?.on('end', () => {
+    if (procGen !== session.generation) return
+    if (session.done) return
+    session.done = true
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      sender.send('player:stream-end', { sessionId })
+    }
+  })
+
+  proc.on('error', (err) => {
+    if (procGen !== session.generation) return
+    if (session.done) return
+    session.done = true
+    session.error = err.message
+    console.error('[remux-stream] spawn error:', err.message)
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      sender.send('player:stream-error', { sessionId, error: err.message })
+    }
+  })
+
+  proc.on('exit', (code, signal) => {
+    if (procGen !== session.generation) return
+    if (signal === 'SIGKILL') return
+    if (code !== 0 && !session.done) {
+      const msg = `ffmpeg exited with code ${code}: ${session.stderrTail.slice(-3).join('').trim()}`
+      session.error = msg
+      session.done = true
+      console.error('[remux-stream]', msg)
+      const sender = event.sender
+      if (sender && !sender.isDestroyed()) {
+        sender.send('player:stream-error', { sessionId, error: msg })
+      }
+    }
+  })
+
+  return proc
+}
+
+const remuxTmpDir = path.join(os.tmpdir(), 'anime-dl-remux')
+const mseSessions = new Map<string, MseSession>()
+const STREAM_BACKPRESSURE_HIGH_WATERMARK = 32 * 1024 * 1024
+const STREAM_BACKPRESSURE_LOW_WATERMARK = 8 * 1024 * 1024
+
+function cleanupMseSession(sessionId: string): void {
+  const session = mseSessions.get(sessionId)
+  if (!session) return
+  session.done = true
+  try { session.proc.kill('SIGKILL') } catch { /* ignore */ }
+  mseSessions.delete(sessionId)
+}
+
+async function probeMkvForMse(mkvPath: string): Promise<{ duration: number; mimeType: string } | null> {
+  if (!ffprobePath) return null
+  try {
+    Ffmpeg.setFfprobePath(ffprobePath)
+    const metadata = await new Promise<Ffmpeg.FfprobeData>((res, rej) => {
+      Ffmpeg.ffprobe(mkvPath, (err, m) => (err ? rej(err) : res(m)))
+    })
+    const durationStr = metadata.format?.duration
+    const duration = typeof durationStr === 'number' ? durationStr : parseFloat(String(durationStr))
+    if (!isFinite(duration) || duration <= 0) return null
+    const video = metadata.streams?.find((s) => s.codec_type === 'video')
+    const audio = metadata.streams?.find((s) => s.codec_type === 'audio')
+    if (!video || !audio) return null
+    const vStr = avcCodecString(video)
+    const aStr = aacCodecString(audio)
+    if (!vStr || !aStr) return null
+    return { duration, mimeType: `video/mp4; codecs="${vStr}, ${aStr}"` }
+  } catch {
+    return null
+  }
+}
+
+function avcCodecString(stream: Ffmpeg.FfprobeStream): string | null {
+  if (stream.codec_name !== 'h264') return null
+  const profile = (stream.profile || '').toString().toLowerCase()
+  let pp: string, cc: string
+  if (profile.includes('constrained baseline')) { pp = '42'; cc = 'E0' }
+  else if (profile.includes('baseline')) { pp = '42'; cc = '00' }
+  else if (profile.includes('main')) { pp = '4D'; cc = '40' }
+  else if (profile.includes('high 10')) { pp = '6E'; cc = '00' }
+  else if (profile.includes('high 4:2:2')) { pp = '7A'; cc = '00' }
+  else if (profile.includes('high 4:4:4')) { pp = 'F4'; cc = '00' }
+  else if (profile.includes('high')) { pp = '64'; cc = '00' }
+  else return null
+  const level = typeof stream.level === 'number' ? stream.level : 0
+  if (level <= 0) return null
+  const ll = level.toString(16).padStart(2, '0').toUpperCase()
+  return `avc1.${pp}${cc}${ll}`
+}
+
+function aacCodecString(stream: Ffmpeg.FfprobeStream): string | null {
+  if (stream.codec_name !== 'aac') return null
+  const profile = (stream.profile || '').toString().toUpperCase()
+  if (profile === 'HE-AAC') return 'mp4a.40.5'
+  if (profile === 'HE-AACV2' || profile === 'HE-AAC V2') return 'mp4a.40.29'
+  return 'mp4a.40.2'
+}
+
+async function extractFirstSubtitle(mkvPath: string, assPath: string): Promise<string | undefined> {
+  try {
+    if (!ffprobePath) return undefined
+    Ffmpeg.setFfprobePath(ffprobePath)
+    const hasSubStream = await new Promise<boolean>((res) => {
+      Ffmpeg.ffprobe(mkvPath, (err, metadata) => {
+        res(err ? false : !!metadata.streams?.find((s) => s.codec_type === 'subtitle'))
+      })
+    })
+    if (!hasSubStream) return undefined
+    await new Promise<void>((res, rej) => {
+      Ffmpeg(mkvPath)
+        .outputOptions(['-map', '0:s:0', '-c:s', 'ass'])
+        .output(assPath)
+        .on('error', (err) => {
+          console.error('[remux] Subtitle extraction error:', err.message)
+          rej(err)
+        })
+        .on('end', () => res())
+        .run()
+    })
+    const content = fs.readFileSync(assPath, 'utf-8')
+    console.log('[remux] Subtitle extracted:', assPath)
+    return content
+  } catch {
+    return undefined
+  }
 }
 
 function createWindow(): void {
@@ -1518,9 +1819,11 @@ function createWindow(): void {
 }
 
 app.whenReady().then(async () => {
-  // Handle anime-video:// protocol for local video playback with Range request support
+  // Handle anime-video:// protocol for local video playback with Range request support.
+  // Only one URL shape: anime-video://{absolute-path}. MKV streaming now uses MSE via IPC.
   protocol.handle('anime-video', async (request) => {
-    const filePath = decodeURIComponent(request.url.replace('anime-video://', ''))
+    const raw = request.url.replace('anime-video://', '')
+    const filePath = decodeURIComponent(raw)
 
     let stat: fs.Stats
     try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -116,8 +116,43 @@ const api = {
     ipcRenderer.invoke('player:find-local-file', animeName, episodeInt, translationId) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
   playerRemuxMkv: (mkvPath: string) =>
     ipcRenderer.invoke('player:remux-mkv', mkvPath) as Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>,
+  playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) =>
+    ipcRenderer.invoke('player:remux-mkv-stream', mkvPath, initialSeek) as Promise<
+      | { sessionId: string; generation: number; duration: number; mimeType: string; hasSubtitlesPending: boolean; initialSeek: number }
+      | { error: string }
+    >,
+  playerStreamStart: (sessionId: string) =>
+    ipcRenderer.invoke('player:stream-start', sessionId) as Promise<void>,
+  playerStreamAck: (sessionId: string, bytes: number) =>
+    ipcRenderer.invoke('player:stream-ack', sessionId, bytes) as Promise<void>,
+  playerStreamSeek: (sessionId: string, seekSeconds: number) =>
+    ipcRenderer.invoke('player:stream-seek', sessionId, seekSeconds) as Promise<{ ok: true; generation: number } | { error: string }>,
   playerCleanupRemux: () =>
     ipcRenderer.invoke('player:cleanup-remux') as Promise<void>,
+  onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => {
+    ipcRenderer.on('player:stream-subtitles', (_event, data) => callback(data))
+  },
+  offPlayerStreamSubtitles: () => {
+    ipcRenderer.removeAllListeners('player:stream-subtitles')
+  },
+  onPlayerStreamChunk: (callback: (data: { sessionId: string; gen: number; data: Uint8Array }) => void) => {
+    ipcRenderer.on('player:stream-chunk', (_event, data) => callback(data))
+  },
+  offPlayerStreamChunk: () => {
+    ipcRenderer.removeAllListeners('player:stream-chunk')
+  },
+  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => {
+    ipcRenderer.on('player:stream-end', (_event, data) => callback(data))
+  },
+  offPlayerStreamEnd: () => {
+    ipcRenderer.removeAllListeners('player:stream-end')
+  },
+  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => {
+    ipcRenderer.on('player:stream-error', (_event, data) => callback(data))
+  },
+  offPlayerStreamError: () => {
+    ipcRenderer.removeAllListeners('player:stream-error')
+  },
 
   // Shikimori
   shikimoriGetAuthUrl: () => ipcRenderer.invoke('shikimori:get-auth-url') as Promise<string>,

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -90,7 +90,22 @@ interface Api {
   playerGetLocalSubtitles: (filePath: string) => Promise<string | null>
   playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) => Promise<{ filePath: string; subtitleContent: string | null } | null>
   playerRemuxMkv: (mkvPath: string) => Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>
+  playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) => Promise<
+    | { sessionId: string; generation: number; duration: number; mimeType: string; hasSubtitlesPending: boolean; initialSeek: number }
+    | { error: string }
+  >
+  playerStreamStart: (sessionId: string) => Promise<void>
+  playerStreamAck: (sessionId: string, bytes: number) => Promise<void>
+  playerStreamSeek: (sessionId: string, seekSeconds: number) => Promise<{ ok: true; generation: number } | { error: string }>
   playerCleanupRemux: () => Promise<void>
+  onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => void
+  offPlayerStreamSubtitles: () => void
+  onPlayerStreamChunk: (callback: (data: { sessionId: string; gen: number; data: Uint8Array }) => void) => void
+  offPlayerStreamChunk: () => void
+  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => void
+  offPlayerStreamEnd: () => void
+  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => void
+  offPlayerStreamError: () => void
 
   // Shikimori
   shikimoriGetAuthUrl: () => Promise<string>

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -58,7 +58,25 @@ const activeFilePath = ref(props.filePath)
 const isMkv = computed(() => !!activeFilePath.value && activeFilePath.value.toLowerCase().endsWith('.mkv'))
 const remuxing = ref(false)
 const remuxError = ref('')
-const remuxedPath = ref('')
+const remuxedPath = ref('')           // used by legacy full-remux fallback
+const streamSessionId = ref('')       // active MSE session id
+const mseSrcUrl = ref('')             // URL.createObjectURL(MediaSource)
+const mkvBuffering = ref(false)       // shows "Buffering…" toast while MSE waits for data
+
+// MSE internals (not reactive)
+let mediaSource: MediaSource | null = null
+let sourceBuffer: SourceBuffer | null = null
+let streamEnded = false
+const appendQueue: Uint8Array[] = []
+let pendingAckBytes = 0
+let mseInitialSeek = 0
+// Generation of the ffmpeg run whose chunks are currently valid. Bumped by main
+// on each respawn (seek). Chunks still in-flight from the previous run — sent
+// before main's generation++ reached us — carry an older `gen` and must be
+// dropped, otherwise they are appended with the new timestampOffset and extend
+// MediaSource.duration / corrupt the parser after sb.abort().
+let currentStreamGen = 0
+const STREAM_ACK_THRESHOLD = 1 * 1024 * 1024
 
 // Quality selector state
 const activeStreamUrl = ref(props.streamUrl)
@@ -208,6 +226,18 @@ async function resumeFromSavedPosition(): Promise<void> {
     if (saved.watched) return
     const d = video.duration || saved.duration
     if (!d) return
+    // For MSE MKV streams the ffmpeg run was already started at the saved
+    // position; skip the native seek to avoid a spurious unbuffered-seek flow.
+    if (streamSessionId.value && mseInitialSeek > 0) {
+      if (video.currentTime < mseInitialSeek) {
+        try { video.currentTime = mseInitialSeek } catch { /* ignore */ }
+      }
+      currentTime.value = mseInitialSeek
+      resumeToast.value = `Resumed at ${formatTime(saved.position)}`
+      if (resumeToastTimer) clearTimeout(resumeToastTimer)
+      resumeToastTimer = setTimeout(() => { resumeToast.value = '' }, 3000)
+      return
+    }
     if (saved.position > 5 && saved.position / d < 0.95) {
       video.currentTime = saved.position
       currentTime.value = saved.position
@@ -262,17 +292,311 @@ fn main(@builtin(position) coord: vec4f) -> @location(0) vec4f {
 
 const videoSrc = computed(() => {
   if (activeFilePath.value) {
-    // For MKV files, use the remuxed MP4 path
+    // For MKV files, prefer the MSE stream URL; fall back to legacy full remux.
     if (isMkv.value) {
-      if (remuxedPath.value) {
-        return 'anime-video://' + encodeURIComponent(remuxedPath.value)
-      }
-      return '' // Not ready yet — remuxing in progress
+      if (mseSrcUrl.value) return mseSrcUrl.value
+      if (remuxedPath.value) return 'anime-video://' + encodeURIComponent(remuxedPath.value)
+      return ''
     }
     return 'anime-video://' + encodeURIComponent(activeFilePath.value)
   }
   return activeStreamUrl.value
 })
+
+async function prepareMkvForPlayback(filePath: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  resetMseState()
+  streamSessionId.value = ''
+  remuxedPath.value = ''
+  remuxError.value = ''
+
+  // Resolve saved position up front so ffmpeg's first spawn already starts
+  // near the resume point. Avoids the "append-during-parse" race that fires
+  // if we set timestampOffset after the first chunks are already parsing.
+  let initialSeek = 0
+  try {
+    const epInt = currentEpisodeInt.value
+    if (props.animeId && epInt) {
+      const saved = await window.api.watchProgressGet(props.animeId, epInt)
+      if (saved && !saved.watched && saved.position > 5 && saved.duration > 0 && saved.position / saved.duration < 0.95) {
+        initialSeek = Math.max(0, saved.position - 1)
+      }
+    }
+  } catch { /* ignore */ }
+
+  const streamResult = await window.api.playerRemuxMkvStream(filePath, initialSeek)
+  if (!('error' in streamResult)) {
+    if (typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(streamResult.mimeType)) {
+      startMseSession(streamResult.sessionId, streamResult.generation, streamResult.duration, streamResult.mimeType, streamResult.initialSeek)
+      mkvBuffering.value = true
+      return { ok: true }
+    }
+    console.warn('[player] MSE does not support codecs:', streamResult.mimeType, '— falling back to legacy remux')
+    await window.api.playerCleanupRemux()
+  } else {
+    console.warn('[player] MSE stream open failed, falling back to legacy remux:', streamResult.error)
+  }
+
+  remuxing.value = true
+  try {
+    const legacy = await window.api.playerRemuxMkv(filePath)
+    if ('error' in legacy) return { ok: false, error: legacy.error }
+    remuxedPath.value = legacy.mp4Path
+    if (!activeSubtitleContent.value && legacy.subtitleContent) {
+      activeSubtitleContent.value = legacy.subtitleContent
+    }
+    return { ok: true }
+  } finally {
+    remuxing.value = false
+  }
+}
+
+function startMseSession(sessionId: string, generation: number, duration: number, mimeType: string, initialSeek: number): void {
+  streamSessionId.value = sessionId
+  currentStreamGen = generation
+  mseInitialSeek = initialSeek
+  const ms = new MediaSource()
+  mediaSource = ms
+  mseSrcUrl.value = URL.createObjectURL(ms)
+  ms.addEventListener('sourceopen', () => {
+    try {
+      console.log('[player] sourceopen, adding SourceBuffer:', mimeType, 'initialSeek=', initialSeek)
+      const sb = ms.addSourceBuffer(mimeType)
+      sourceBuffer = sb
+      try { ms.duration = duration } catch (e) { console.warn('[player] set duration failed:', e) }
+      if (initialSeek > 0) {
+        try { sb.timestampOffset = initialSeek } catch (e) { console.warn('[player] initial timestampOffset failed:', e) }
+      }
+      sb.addEventListener('updateend', onSourceBufferUpdateEnd)
+      sb.addEventListener('error', (e) => console.error('[player] SourceBuffer error event:', e))
+      sb.addEventListener('abort', () => console.warn('[player] SourceBuffer abort'))
+      window.api.playerStreamStart(sessionId)
+      pumpAppendQueue()
+    } catch (e) {
+      console.error('[player] addSourceBuffer failed:', e)
+    }
+  }, { once: true })
+}
+
+let appendCount = 0
+function onSourceBufferUpdateEnd(): void {
+  const sb = sourceBuffer
+  if (sb && sb.buffered.length > 0) {
+    appendCount++
+    if (appendCount <= 5 || appendCount % 50 === 0) {
+      const ranges: string[] = []
+      for (let i = 0; i < sb.buffered.length; i++) {
+        ranges.push(`[${sb.buffered.start(i).toFixed(2)}-${sb.buffered.end(i).toFixed(2)}]`)
+      }
+      console.log(`[player] append #${appendCount} buffered=${ranges.join(',')} t=${(videoRef.value?.currentTime ?? 0).toFixed(2)}`)
+    }
+    const bufStart = sb.buffered.start(0)
+    const t = videoRef.value?.currentTime ?? 0
+    if (bufStart < t - 60 && !sb.updating) {
+      try { sb.remove(bufStart, Math.max(bufStart + 1, t - 30)) } catch { /* ignore */ }
+    }
+  }
+  pumpAppendQueue()
+}
+
+const MAX_BUFFER_AHEAD = 30
+function pumpAppendQueue(): void {
+  const sb = sourceBuffer
+  const ms = mediaSource
+  if (!sb || sb.updating || !ms) return
+  if (unbufferedSeekInFlight) return
+
+  if (appendQueue.length === 0) {
+    if (streamEnded && ms.readyState === 'open') {
+      try { ms.endOfStream() } catch { /* ignore */ }
+    }
+    return
+  }
+
+  // Throttle: stop pumping once we have enough lead ahead of the playhead.
+  // Without this, SourceBuffer fills to the Chromium quota and eviction would
+  // remove the [0, 1] keyframe the playhead is still stuck on, leaving a gap.
+  if (sb.buffered.length > 0) {
+    const t = videoRef.value?.currentTime ?? 0
+    const lead = sb.buffered.end(sb.buffered.length - 1) - t
+    if (lead > MAX_BUFFER_AHEAD) return
+  }
+
+  const v = videoRef.value
+  if (v && v.error) return
+  const chunk = appendQueue.shift()!
+  try {
+    sb.appendBuffer(chunk as unknown as BufferSource)
+    pendingAckBytes += chunk.byteLength
+    if (pendingAckBytes >= STREAM_ACK_THRESHOLD && streamSessionId.value) {
+      const bytes = pendingAckBytes
+      pendingAckBytes = 0
+      window.api.playerStreamAck(streamSessionId.value, bytes)
+    }
+  } catch (e) {
+    const err = e as DOMException
+    if (err.name === 'QuotaExceededError') {
+      appendQueue.unshift(chunk)
+      // Only evict data strictly behind the playhead. Never drop the range
+      // the video element is currently sitting inside, or playback stalls.
+      const t = videoRef.value?.currentTime ?? 0
+      if (sb.buffered.length > 0 && !sb.updating) {
+        const bufStart = sb.buffered.start(0)
+        const removeUntil = t - 5
+        if (removeUntil > bufStart + 1) {
+          try { sb.remove(bufStart, removeUntil) } catch { /* ignore */ }
+        }
+      }
+    } else {
+      console.error('[player] appendBuffer failed:', err)
+    }
+  }
+}
+
+let unbufferedSeekInFlight = false
+let respawnDebounceTimer: ReturnType<typeof setTimeout> | null = null
+const RESPAWN_DEBOUNCE_MS = 250
+
+function maybeRespawnForUnbufferedPosition(): void {
+  const v = videoRef.value
+  const sb = sourceBuffer
+  if (!v || !sb || !streamSessionId.value) return
+  // Debounce. Check `currentTime` vs buffered ranges only when the timer fires,
+  // so a burst of rapid seeks coalesces into one respawn at the final target.
+  if (respawnDebounceTimer) clearTimeout(respawnDebounceTimer)
+  respawnDebounceTimer = setTimeout(() => {
+    respawnDebounceTimer = null
+    if (unbufferedSeekInFlight) return
+    const cur = videoRef.value
+    const curSb = sourceBuffer
+    if (!cur || !curSb) return
+    const t = cur.currentTime
+    for (let i = 0; i < curSb.buffered.length; i++) {
+      if (t >= curSb.buffered.start(i) - 0.25 && t <= curSb.buffered.end(i) + 0.25) return
+    }
+    // Nothing buffered yet (fresh respawn) — wait for data.
+    if (curSb.buffered.length === 0) return
+    handleUnbufferedSeek()
+  }, RESPAWN_DEBOUNCE_MS)
+}
+
+async function handleUnbufferedSeek(): Promise<void> {
+  const v = videoRef.value
+  const sb = sourceBuffer
+  if (!v || !sb || !streamSessionId.value) return
+  const target = v.currentTime
+  // If the target falls inside any existing buffered range, the video element
+  // handles the seek natively — nothing to do.
+  for (let i = 0; i < sb.buffered.length; i++) {
+    if (target >= sb.buffered.start(i) - 0.25 && target <= sb.buffered.end(i) + 0.25) {
+      return
+    }
+  }
+  if (unbufferedSeekInFlight) return
+  unbufferedSeekInFlight = true
+  const seekAt = Math.max(0, target - 1)
+  console.log(`[player] unbuffered seek → respawn ffmpeg at ${seekAt.toFixed(2)} (target ${target.toFixed(2)})`)
+  try {
+    // Drop any queued chunks from the old ffmpeg — main will stop sending new
+    // ones as soon as the seek IPC below bumps the session generation.
+    appendQueue.length = 0
+    pendingAckBytes = 0
+    const result = await window.api.playerStreamSeek(streamSessionId.value, seekAt)
+    if ('error' in result) {
+      console.error('[player] stream-seek failed:', result.error)
+      return
+    }
+    // Switch the expected generation so any further in-flight chunks from the
+    // old ffmpeg run are dropped, and drain anything stale that arrived in
+    // `appendQueue` while we were awaiting the IPC round-trip.
+    currentStreamGen = result.generation
+    appendQueue.length = 0
+    pendingAckBytes = 0
+    streamEnded = false
+    // Reset the SourceBuffer segment parser. Without this, an interrupted
+    // append leaves the parser in PARSING_MEDIA_SEGMENT and any subsequent
+    // timestampOffset change or appendBuffer throws. abort() also cancels
+    // any in-flight update, so no updateend wait is needed.
+    try { sb.abort() } catch (e) { console.warn('[player] sb.abort failed:', e) }
+    // Drop old buffered data so the previous audio ahead of us doesn't keep
+    // playing while the new fragments arrive and decode.
+    try {
+      if (sb.buffered.length > 0) {
+        sb.remove(sb.buffered.start(0), sb.buffered.end(sb.buffered.length - 1))
+        await new Promise<void>((res) => sb.addEventListener('updateend', () => res(), { once: true }))
+      }
+    } catch (e) {
+      console.warn('[player] buffer clear failed:', e)
+    }
+    if (v.error) {
+      console.error('[player] video element errored during seek:', v.error.code, v.error.message)
+      return
+    }
+    try {
+      sb.timestampOffset = seekAt
+    } catch (e) {
+      console.warn('[player] timestampOffset set failed:', e)
+    }
+    // Release main's buffered prelude for the new ffmpeg run.
+    window.api.playerStreamStart(streamSessionId.value)
+  } finally {
+    unbufferedSeekInFlight = false
+    // If the user kept seeking while the respawn was in flight, the playhead
+    // may now be outside the fresh buffered range too — re-check.
+    maybeRespawnForUnbufferedPosition()
+  }
+}
+
+let chunkRecvCount = 0
+let chunkRecvBytes = 0
+function handleStreamChunk(sessionId: string, gen: number, data: Uint8Array): void {
+  if (sessionId !== streamSessionId.value) return
+  // Drop chunks from an obsolete ffmpeg run. Main bumped its generation on the
+  // last seek; anything still arriving with an older `gen` was already in the
+  // IPC queue at that point and is now stale media with PTS unrelated to the
+  // current timestampOffset.
+  if (gen !== currentStreamGen) return
+  const u8 = data instanceof Uint8Array ? data : new Uint8Array(data)
+  chunkRecvCount++
+  chunkRecvBytes += u8.byteLength
+  if (chunkRecvCount === 1 || chunkRecvCount % 200 === 0) {
+    console.log(`[player] recv chunk #${chunkRecvCount} total=${(chunkRecvBytes / 1024 / 1024).toFixed(1)}MB queue=${appendQueue.length}`)
+  }
+  appendQueue.push(u8)
+  pumpAppendQueue()
+}
+
+function handleStreamEnd(sessionId: string): void {
+  if (sessionId !== streamSessionId.value) return
+  streamEnded = true
+  pumpAppendQueue()
+}
+
+function handleStreamError(sessionId: string, error: string): void {
+  if (sessionId !== streamSessionId.value) return
+  console.error('[player] stream error:', error)
+  remuxError.value = error
+  resetMseState()
+}
+
+function resetMseState(): void {
+  streamEnded = false
+  pendingAckBytes = 0
+  appendQueue.length = 0
+  mseInitialSeek = 0
+  currentStreamGen = 0
+  if (sourceBuffer) {
+    try { sourceBuffer.removeEventListener('updateend', onSourceBufferUpdateEnd) } catch { /* ignore */ }
+    sourceBuffer = null
+  }
+  if (mediaSource && mediaSource.readyState === 'open') {
+    try { mediaSource.endOfStream() } catch { /* ignore */ }
+  }
+  mediaSource = null
+  if (mseSrcUrl.value) {
+    try { URL.revokeObjectURL(mseSrcUrl.value) } catch { /* ignore */ }
+    mseSrcUrl.value = ''
+  }
+}
 
 function formatTime(seconds: number): string {
   if (!isFinite(seconds) || seconds < 0) return '0:00'
@@ -390,6 +714,10 @@ function onProgress(): void {
   const video = videoRef.value
   if (!video || video.buffered.length === 0) return
   buffered.value = video.buffered.end(video.buffered.length - 1)
+}
+
+function onCanPlay(): void {
+  if (mkvBuffering.value) mkvBuffering.value = false
 }
 
 function onSeekStart(): void {
@@ -840,10 +1168,12 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
       if (localResult) {
         activeTranslationId.value = tr.id
 
-        // Clean up previous remux if any
-        if (remuxedPath.value) {
+        // Clean up previous remux / stream session if any
+        if (remuxedPath.value || streamSessionId.value) {
           await window.api.playerCleanupRemux()
           remuxedPath.value = ''
+          streamSessionId.value = ''
+          resetMseState()
         }
 
         // Switch to local file
@@ -851,19 +1181,12 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
         activeStreamUrl.value = ''
         activeSubtitleContent.value = localResult.subtitleContent || ''
 
-        // Remux MKV if needed
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
-          remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkv(localResult.filePath)
-          remuxing.value = false
-          if ('error' in remuxResult) {
-            remuxError.value = remuxResult.error
+          const prep = await prepareMkvForPlayback(localResult.filePath)
+          if (!prep.ok) {
+            remuxError.value = prep.error
             switchingTranslation.value = false
             return
-          }
-          remuxedPath.value = remuxResult.mp4Path
-          if (!activeSubtitleContent.value && remuxResult.subtitleContent) {
-            activeSubtitleContent.value = remuxResult.subtitleContent
           }
         }
 
@@ -893,10 +1216,12 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
 
     activeTranslationId.value = tr.id
 
-    // Clean up previous remux if switching from local to stream
-    if (remuxedPath.value) {
+    // Clean up previous remux / MSE stream if switching from local to stream
+    if (remuxedPath.value || streamSessionId.value) {
       await window.api.playerCleanupRemux()
       remuxedPath.value = ''
+      streamSessionId.value = ''
+      resetMseState()
     }
 
     activeFilePath.value = ''
@@ -990,10 +1315,12 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
   }
 
   try {
-    // Clean up previous remux
-    if (remuxedPath.value) {
+    // Clean up previous remux / MSE stream
+    if (remuxedPath.value || streamSessionId.value) {
       await window.api.playerCleanupRemux()
       remuxedPath.value = ''
+      streamSessionId.value = ''
+      resetMseState()
     }
 
     // Update episode state
@@ -1014,17 +1341,17 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
         activeSubtitleContent.value = localResult.subtitleContent || ''
 
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
-          remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkv(localResult.filePath)
-          remuxing.value = false
-          if ('error' in remuxResult) {
-            remuxError.value = remuxResult.error
+          if (remuxedPath.value || streamSessionId.value) {
+            await window.api.playerCleanupRemux()
+            remuxedPath.value = ''
+            streamSessionId.value = ''
+            resetMseState()
+          }
+          const prep = await prepareMkvForPlayback(localResult.filePath)
+          if (!prep.ok) {
+            remuxError.value = prep.error
             navigating.value = false
             return
-          }
-          remuxedPath.value = remuxResult.mp4Path
-          if (!activeSubtitleContent.value && remuxResult.subtitleContent) {
-            activeSubtitleContent.value = remuxResult.subtitleContent
           }
         }
 
@@ -1132,27 +1459,51 @@ onMounted(async () => {
   const savedShortcuts = await window.api.getSetting('keyboardShortcuts') as Record<string, string> | null
   playerShortcuts.value = { ...DEFAULT_PLAYER_SHORTCUTS, ...(savedShortcuts || {}) }
 
-  // Remux MKV to MP4 if needed
+  // Subtitles extracted from MKV streams arrive asynchronously via IPC.
+  window.api.onPlayerStreamSubtitles(({ sessionId, content }) => {
+    if (sessionId !== streamSessionId.value) return
+    if (activeSubtitleContent.value) return
+    activeSubtitleContent.value = content
+    const v = videoRef.value
+    if (v) {
+      destroySubtitles()
+      initSubtitles(v)
+    }
+  })
+
+  // MSE fragmented MP4 chunks / end / error events.
+  window.api.onPlayerStreamChunk(({ sessionId, gen, data }) => handleStreamChunk(sessionId, gen, data))
+  window.api.onPlayerStreamEnd(({ sessionId }) => handleStreamEnd(sessionId))
+  window.api.onPlayerStreamError(({ sessionId, error }) => handleStreamError(sessionId, error))
+
+  // Diagnostic listeners on the video element to see why MSE playback stalls.
+  watch(videoRef, (v) => {
+    if (!v) return
+    v.addEventListener('waiting', () => console.warn(`[player] video 'waiting' t=${v.currentTime.toFixed(2)} readyState=${v.readyState}`))
+    v.addEventListener('stalled', () => console.warn(`[player] video 'stalled' t=${v.currentTime.toFixed(2)} readyState=${v.readyState}`))
+    v.addEventListener('error', () => {
+      const e = v.error
+      console.error(`[player] video element error: code=${e?.code} message=${e?.message} networkState=${v.networkState} readyState=${v.readyState}`)
+    })
+    v.addEventListener('timeupdate', () => pumpAppendQueue())
+    // Fires on every seek attempt (slider drag, arrow-key auto-repeat). Debounce
+    // so a burst collapses into one respawn at the final target — native seeks
+    // inside the buffered range are filtered out in the debounced callback.
+    v.addEventListener('seeking', () => maybeRespawnForUnbufferedPosition())
+  }, { immediate: true })
+
+  // Start MKV remux stream (or fall back to legacy full remux)
   if (isMkv.value && props.filePath) {
-    remuxing.value = true
-    remuxError.value = ''
     try {
-      const result = await window.api.playerRemuxMkv(props.filePath)
-      if ('error' in result) {
-        remuxError.value = result.error
-        remuxing.value = false
+      const prep = await prepareMkvForPlayback(props.filePath)
+      if (!prep.ok) {
+        remuxError.value = prep.error
         return
-      }
-      remuxedPath.value = result.mp4Path
-      if (!activeSubtitleContent.value && result.subtitleContent) {
-        activeSubtitleContent.value = result.subtitleContent
       }
     } catch (e) {
       remuxError.value = String(e)
-      remuxing.value = false
       return
     }
-    remuxing.value = false
   }
 
   // Initialize quality from available streams
@@ -1218,8 +1569,14 @@ onBeforeUnmount(() => {
     gpuDevice.destroy()
     gpuDevice = null
   }
-  // Clean up remuxed temp files
-  if (remuxedPath.value) {
+  // Stop listening for stream events
+  window.api.offPlayerStreamSubtitles()
+  window.api.offPlayerStreamChunk()
+  window.api.offPlayerStreamEnd()
+  window.api.offPlayerStreamError()
+  resetMseState()
+  // Clean up remuxed temp files / active stream sessions
+  if (remuxedPath.value || streamSessionId.value) {
     window.api.playerCleanupRemux()
   }
 })
@@ -1242,7 +1599,7 @@ const bufferedProgress = computed(() => {
     @mousemove="onMouseMove"
     @click.self="togglePlay"
   >
-    <!-- Remuxing MKV overlay -->
+    <!-- Remuxing MKV overlay (legacy full-remux fallback only) -->
     <div v-if="remuxing" class="remux-overlay">
       <div class="remux-modal">
         <div class="remux-spinner"></div>
@@ -1250,6 +1607,13 @@ const bufferedProgress = computed(() => {
         <p class="remux-hint">Remuxing to MP4 (stream copy, no re-encoding)</p>
       </div>
     </div>
+
+    <!-- Streaming MKV: subtle toast while the first seconds buffer -->
+    <transition name="fade">
+      <div v-if="mkvBuffering" class="mkv-buffering-toast">
+        Buffering MKV…
+      </div>
+    </transition>
 
     <!-- Remux error overlay -->
     <div v-if="remuxError" class="remux-overlay">
@@ -1285,7 +1649,7 @@ const bufferedProgress = computed(() => {
     <div class="video-wrapper">
       <video
         ref="videoRef"
-        :src="videoSrc"
+        :src="videoSrc || undefined"
         :class="{ hidden: anime4kActive }"
         class="player-video"
         crossorigin="anonymous"
@@ -1294,6 +1658,7 @@ const bufferedProgress = computed(() => {
         @timeupdate="onTimeUpdate"
         @durationchange="onDurationChange"
         @progress="onProgress"
+        @canplay="onCanPlay"
         @ended="onVideoEnded"
         @click="togglePlay"
         @dblclick="toggleFullscreen"
@@ -1595,6 +1960,19 @@ const bufferedProgress = computed(() => {
   background: rgba(15, 52, 96, 0.9);
   color: #e0e0e0;
   padding: 6px 16px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.mkv-buffering-toast {
+  position: absolute;
+  top: 100px;
+  right: 24px;
+  background: rgba(15, 52, 96, 0.85);
+  color: #e0e0e0;
+  padding: 6px 14px;
   border-radius: 6px;
   font-size: 0.8rem;
   z-index: 10;


### PR DESCRIPTION
## Summary

Opening an MKV in the built-in player previously blocked for 10–20 seconds behind a "Preparing MKV for playback…" overlay while ffmpeg remuxed the entire file to a temp MP4 via `-c copy -movflags +faststart`.

This PR replaces that with a streaming MSE (Media Source Extensions) pipeline: ffmpeg produces a fragmented MP4 to stdout, the main process forwards chunks over IPC, and the renderer feeds them into a `MediaSource` `SourceBuffer`. Playback starts in ~1 s. Unbuffered seeks are serviced by killing and respawning ffmpeg with `-ss`.

## Approach

### Main process

- `player:remux-mkv-stream(mkvPath, initialSeek?)` — spawns ffmpeg with fragmented MP4 output (`+frag_keyframe+empty_moov+default_base_moof+separate_moof`, `-frag_duration 1000000`) and timestamp normalization (`-fflags +genpts`, `-avoid_negative_ts make_zero`, `-muxpreload 0`, `-muxdelay 0`). Resolves once the MP4 header prelude is on the wire; returns `{ sessionId, duration, mimeType, hasSubtitlesPending, initialSeek }`.
- Session state (`MseSession`) holds the prelude buffer, pending chunks, generation counter, and child process handle.
- `player:stream-start(sessionId)` — flushes the prelude plus any queued chunks after the renderer has attached `MediaSource`.
- `player:stream-ack(sessionId, bytes)` — backpressure signal. Main pauses `stdout` above a high-watermark and resumes below a low-watermark to prevent unbounded memory growth.
- `player:stream-seek(sessionId, seekSeconds)` — bumps `session.generation`, SIGKILLs the current ffmpeg, clears prelude and queued chunks, respawns with `-ss seekSeconds`. Generation check in every stdout/stderr/exit handler drops stale chunks from the killed process.
- Subtitle extraction (ffprobe + `-map 0:s:0 -c:s ass`) runs in parallel and is pushed to the renderer via `player:stream-subtitles` when ready.
- `player:cleanup-remux` kills any active session and clears temp state.

### Renderer (`PlayerView.vue`)

- MSE wiring: `startMseSession` creates a `MediaSource`, attaches it via `URL.createObjectURL`, adds a `SourceBuffer` for the negotiated `mimeType`, sets `sb.timestampOffset = initialSeek` before the first chunk, and calls `playerStreamStart` to flush the prelude.
- `onPlayerStreamChunk` appends to a queue; `pumpAppendQueue` drains it with a `MAX_BUFFER_AHEAD` of 30 s (prevents `QuotaExceededError` piling up too far past the playhead).
- On quota hit: evict only ranges behind the playhead (keeps the nearest keyframe for current playback).
- Unbuffered seek: 250 ms-debounced on the `seeking` event. Calls `sb.abort()` (resets parser state), removes all buffered ranges, sets `timestampOffset = newPosition`, then calls `playerStreamSeek` → `playerStreamStart`. The `unbufferedSeekInFlight` flag blocks further appends until the new prelude arrives, avoiding audio overlap from the old segment.
- Rapid arrow-key handling: the debounce collapses spam into one respawn; the seeking handler short-circuits when the target is already inside `sb.buffered` or when `sb.buffered.length === 0` (just respawned — don't respawn again).
- Resume-from-timestamp: reads `watchProgressGet` in `prepareMkvForPlayback` and passes `saved.position - 1` as `initialSeek` so ffmpeg starts at the saved position directly. `resumeFromSavedPosition` skips its seek for MSE streams since the video is already at the right position.
- Template: `:src="videoSrc || undefined"` avoids an empty string setting `HTMLMediaElement.error` to `MEDIA_ERR_SRC_NOT_SUPPORTED` during tear-down.
- Fallback: if `playerRemuxMkvStream` errors, the renderer falls back to the legacy `playerRemuxMkv` (full remux) path and keeps playing.

## IPC surface

New channels:
- `player:remux-mkv-stream(mkvPath, initialSeek?)` → session info
- `player:stream-start(sessionId)`
- `player:stream-ack(sessionId, bytes)`
- `player:stream-seek(sessionId, seekSeconds)` → `{ ok: true } | { error }`

New events (main → renderer):
- `player:stream-chunk` — `{ sessionId, data: Uint8Array }`
- `player:stream-end` — `{ sessionId }`
- `player:stream-error` — `{ sessionId, error }`
- `player:stream-subtitles` — `{ sessionId, content }`

Updated: `player:cleanup-remux` now also terminates active streaming sessions.

## Files changed

| File | What changed |
|------|--------------|
| `src/main/index.ts` | Streaming session state, 5 new IPC handlers, ffmpeg respawn with generation counter, subtitle extraction wired to event |
| `src/preload/index.ts`, `src/preload/types.d.ts` | Bridges + types for the new IPC surface |
| `src/renderer/src/components/PlayerView.vue` | MSE wiring, append queue, quota eviction, debounced unbuffered seek, MKV fallback |
| `DESIGN.md` | Architecture notes for the streaming path |
| `TODO.md` | Strike the done item |
| `package.json` | Version bump 3.5.0 → 3.6.0 |

## Rollback

Legacy `player:remux-mkv` handler is preserved. If the MSE path breaks, remove the `playerRemuxMkvStream` call in `prepareMkvForPlayback` and only call `playerRemuxMkv`.

## Test plan

- [x] MKV opens in <2 s, no blocking overlay
- [x] Forward/backward seek inside buffered region (instant)
- [x] Forward seek past buffered region (ffmpeg respawns)
- [x] Backward seek past buffered region
- [x] Rapid arrow-key hold (no freeze, no respawn storm)
- [x] Resume from saved watch-progress timestamp
- [x] Translation / next-episode switch mid-playback (old session torn down, new session starts)
- [x] Subtitles appear shortly after playback starts
- [x] MP4 playback unaffected
- [x] Fallback path still works if streaming init fails

Generated with Claude Code
