### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,9 @@ jobs:
             args: --mac
 
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Potential fix for [https://github.com/mikkerlo/anime-downloader/security/code-scanning/3](https://github.com/mikkerlo/anime-downloader/security/code-scanning/3)

Add an explicit `permissions` block to the `build` job with least privilege.  
Best minimal fix here is:

- `contents: read` for checkout/repository read access.
- `actions: read` to avoid any artifact/action metadata access issues in stricter environments.

Where to change:
- File: `.github/workflows/check.yml`
- In `jobs.build`, add `permissions:` between `runs-on` and `steps` (or anywhere under the `build` job at the same indentation level as `runs-on`).

No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
