### PR TITLE
feat: stream MKV playback without full remux wait

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,13 +17,13 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux
-            args: --linux
+            args: --linux zip
           - os: windows-latest
             platform: win
-            args: --win
+            args: --win zip
           - os: macos-latest
             platform: mac
-            args: --mac
+            args: --mac zip
 
     runs-on: ${{ matrix.os }}
     permissions:
@@ -45,6 +45,12 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Set nightly version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NIGHTLY_VERSION="${VERSION}-nightly-${{ github.event.pull_request.number || github.run_id }}.${{ github.run_attempt }}"
+          npm version $NIGHTLY_VERSION --no-git-tag-version
 
       - run: npm run typecheck
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,10 @@ jobs:
 
       - run: npx electron-vite build
 
-      - run: npx electron-builder ${{ matrix.args }} -c.publish=null
+      # IMPORTANT: do NOT change to `-c.publish=null`. electron-builder parses
+      # that as the literal publisher name "null" and fails with
+      # "Cannot find module for publisher 'null'". Always use `--publish never`.
+      - run: npx electron-builder ${{ matrix.args }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,57 @@
+name: Nightly Build
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            args: --linux zip
+          - os: windows-latest
+            platform: win
+            args: --win zip
+          - os: macos-latest
+            platform: mac
+            args: --mac zip
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Set nightly version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          NIGHTLY_VERSION="${VERSION}-nightly-$(date +%Y%m%d%H%M%S)"
+          npm version $NIGHTLY_VERSION --no-git-tag-version
+
+      - run: npx electron-vite build
+
+      - run: npx electron-builder ${{ matrix.args }} --publish never
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: nightly-build-${{ matrix.platform }}
+          path: |
+            dist/*.exe
+            dist/*.AppImage
+            dist/*.deb
+            dist/*.zip
+            dist/*.dmg
+          if-no-files-found: ignore
+          retention-days: 7

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -295,8 +295,14 @@ LibraryView shows both with indicators:
 | `player:get-stream-url` | invoke | Fetch CDN stream URL + raw ASS subtitle content + all available stream qualities for a translation |
 | `player:get-local-subtitles` | invoke | Read local .ass file alongside video, return raw ASS content |
 | `player:find-local-file` | invoke | Find local file path for a translation by animeName/episodeInt/translationId |
-| `player:remux-mkv` | invoke | Remux MKV→MP4 via ffmpeg stream copy to temp dir for HTML5 playback |
-| `player:cleanup-remux` | invoke | Delete temp remuxed files when player closes |
+| `player:remux-mkv` | invoke | Legacy: remux MKV→MP4 via ffmpeg stream copy, await completion before returning (used as fallback when codecs aren't MSE-compatible) |
+| `player:remux-mkv-stream` | invoke | ffprobe MKV + start fragmented-MP4 pipe from ffmpeg; returns `{ sessionId, duration, mimeType, hasSubtitlesPending }` for MSE consumption |
+| `player:stream-chunk` | event (main→renderer) | Fragmented-MP4 bytes from an active session, appended into the renderer's `SourceBuffer` |
+| `player:stream-end` | event (main→renderer) | ffmpeg finished writing; renderer calls `mediaSource.endOfStream()` after draining its queue |
+| `player:stream-error` | event (main→renderer) | ffmpeg exited non-zero or spawn failed; renderer falls back to legacy remux |
+| `player:stream-ack` | invoke | Renderer reports bytes it has consumed from the session; main resumes ffmpeg stdout once pending bytes drop below the low watermark |
+| `player:stream-subtitles` | event (main→renderer) | Subtitle `.ass` content extracted from an MKV stream session, pushed when extraction finishes |
+| `player:cleanup-remux` | invoke | Kill any active stream sessions and delete all temp remuxed files |
 | `shell:open-external` | invoke | Open URL in default browser (returns success boolean) |
 
 ## Key Types
@@ -407,12 +413,12 @@ In-app HTML5 video player with optional Anime4K WebGPU upscaling shaders. Uses `
 
 ### Custom Protocol
 
-`anime-video://` protocol registered via `protocol.handle` serves local video files to the `<video>` element. The `stream: true` privilege enables HTTP range requests for seeking. The handler manually parses `Range` headers and returns 206 Partial Content responses using `fs.createReadStream({ start, end })` for proper seeking support. Files are encoded as `anime-video://{encodeURIComponent(filePath)}`.
+`anime-video://` protocol registered via `protocol.handle` serves local video files to the `<video>` element. The `stream: true` privilege enables HTTP range requests for seeking. The handler manually parses `Range` headers and returns 206 Partial Content responses using `fs.createReadStream({ start, end })` for proper seeking support. URL shape: `anime-video://{encodeURIComponent(filePath)}`. (MKV streaming does not use this protocol — it flows through MSE over IPC; see below.)
 
 ### Video Playback
 
 - **Local .mp4**: Served via `anime-video://` protocol
-- **Local .mkv**: Remuxed to temp MP4 via ffmpeg stream copy (`-c copy -movflags +faststart`), then served via `anime-video://`. Shows "Preparing MKV for playback..." spinner during remux. Temp files cleaned up on player close via `player:cleanup-remux`. Temp dir: `os.tmpdir()/anime-dl-remux/`.
+- **Local .mkv**: Progressive playback via **MSE (MediaSource Extensions)**. The main process ffprobes the MKV for duration and H.264 / AAC codec parameters, then spawns ffmpeg with `-c copy -movflags +frag_keyframe+empty_moov+default_base_moof -f mp4 pipe:1` and streams its stdout to the renderer via `player:stream-chunk` events. `player:remux-mkv-stream` returns `{ sessionId, duration, mimeType, hasSubtitlesPending }` immediately. The renderer creates a `MediaSource`, sets `duration` upfront, calls `addSourceBuffer(mimeType)`, appends each incoming chunk, and binds `<video>` to the `URL.createObjectURL(mediaSource)`. Backpressure: main tracks pending-bytes per session and pauses `ffmpeg.stdout` above 32 MB; renderer acks via `player:stream-ack` each 1 MB appended. Subtitle extraction runs in parallel and is pushed via `player:stream-subtitles` when ready. Fallback: if ffprobe reports an unsupported codec combo (anything non-H.264/AAC, e.g. HEVC, Opus, FLAC) or ffmpeg errors, renderer falls back to legacy `player:remux-mkv` (full remux with `+faststart`, blocking "Preparing MKV…" overlay). SourceBuffer quota is managed by evicting buffered data >60 s behind the playhead on every `updateend`, with a `QuotaExceededError` retry path. `player:cleanup-remux` SIGKILLs active ffmpeg processes and sweeps the temp dir (`os.tmpdir()/anime-dl-remux/`, used only for extracted `.ass` files).
 - **Non-downloaded episodes**: Streams directly from smotret-anime CDN via `player:get-stream-url` IPC
 
 ### Anime4K WebGPU Pipeline

--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@
 
 ---
 
-## 1. Stream MKV Playback Without Full Remux Wait
+## ~~1. Stream MKV Playback Without Full Remux Wait~~
 
 **Priority:** Medium | **Effort:** Large
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,6 @@
 - [x] Stabilize Anime Detail View Layout During Loading — unified loading state and session-level file scan cache
 - [x] Disable "Go Back" Global Shortcut While Player Is Open — player key events no longer propagate to App.vue
 - [x] Previous / Next Episode Buttons in Player — prev/next navigation, auto-advance, configurable shortcuts
-- [x] Auto-Track Watch Progress and Resume Playback — track watched progress, persist position, and update Shikimori
 
 ---
 
@@ -69,3 +68,25 @@ Add keyboard shortcuts for switching Anime4K shader presets while watching: Ctrl
 3. **Read shortcuts in PlayerView:** In `PlayerView.vue` `onMounted` (line ~736), load shortcuts from `window.api.getSetting('keyboardShortcuts')`. Store in a local ref.
 4. **Handle in `onKeyDown`:** In `PlayerView.vue` `onKeyDown` (line ~276), before the existing `switch`, build a key string from the event (matching the `CmdOrCtrl+Key` format from `captureKey` in SettingsView). Compare against the loaded shortcut bindings. If matched, call `selectPreset('mode-a')` / `selectPreset('mode-b')` / `selectPreset('mode-c')` / `selectPreset('off')` and `preventDefault()`. Only act if `webgpuAvailable` is true.
 5. **Files:** `src/renderer/src/components/SettingsView.vue` (defaults + labels), `src/renderer/src/components/PlayerView.vue` (shortcut handling), `src/main/index.ts` (store defaults).
+
+---
+
+## ~~3. Auto-Track Watch Progress and Resume Playback~~
+
+**Priority:** Medium | **Effort:** Medium
+
+Automatically track how many episodes the user has watched and where they stopped in each episode. Persist playback position locally for resume, and auto-update Shikimori episode count when an episode is considered "watched" (80%+ played AND at least 3 minutes of actual playback).
+
+**Plan:**
+1. **New store key `watchProgress`:** Add `watchProgress: {}` to electron-store defaults in `main/index.ts` (line ~42). Structure: `Record<string, { position: number; duration: number; updatedAt: number }>` keyed by `animeId:episodeInt`. Stores the last playback position in seconds, total duration, and timestamp.
+2. **IPC handlers for watch progress:** Add two handlers in `main/index.ts`:
+   - `watch-progress:save` — saves position/duration for a given animeId + episodeInt.
+   - `watch-progress:get` — returns saved position for a given animeId + episodeInt (or null).
+   Bridge in `preload/index.ts`, type in `preload/index.d.ts`.
+3. **Pass `animeId` and `malId` to player:** Extend the `playFile` emit in `AnimeDetailView.vue` to include `animeId` (from `props.animeId`) and `malId` (from `anime.value.myAnimeListId`). Update `playerState` in `App.vue` and `PlayerView` props accordingly.
+4. **Periodic position save in PlayerView:** In `PlayerView.vue`, add a `timeupdate` listener on the video element. Throttle to every 5 seconds. Call `window.api.watchProgressSave(animeId, episodeInt, currentTime, duration)`. Also save on `pause`, `beforeunmount`, and player close.
+5. **Resume on open:** In `PlayerView.vue` `onMounted`, after the video is ready (`loadedmetadata` event), call `window.api.watchProgressGet(animeId, episodeInt)`. If a saved position exists and is < 95% of duration, seek to it. Show a brief "Resuming from X:XX" toast.
+6. **Watched detection:** Track cumulative playback time in a local variable (increment on `timeupdate` only when video is playing, not paused/seeking). When `position / duration >= 0.8` AND `cumulativePlayTime >= 180` (3 minutes), mark the episode as "watched". Store a `watched: true` flag in `watchProgress` to avoid re-triggering.
+7. **Shikimori auto-update:** When an episode is marked watched and `malId` is available, call `window.api.shikimoriUpdateRate(malId, episodeNumber, 'watching', 0)` to increment the episode count. Only update if `episodeNumber > current shikiEpisodes`. Need a new IPC `shikimori:get-rate` call first to check current count, or pass the current Shikimori episode count from `AnimeDetailView` via props.
+8. **Visual indicator in AnimeDetailView:** Show a small progress bar or "watched" badge on episode rows using the stored `watchProgress` data. Load via `watch-progress:get-all` IPC (returns all entries for an animeId).
+9. **IPC changes (4 files):** Add `watch-progress:save`, `watch-progress:get`, `watch-progress:get-all` in `src/main/index.ts`, bridge in `src/preload/index.ts`, types in `src/preload/index.d.ts`, consumed in `src/renderer/src/components/PlayerView.vue` and `src/renderer/src/components/AnimeDetailView.vue`.

--- a/package.json
+++ b/package.json
@@ -23,16 +23,14 @@
     "win": {
       "target": [
         "portable",
-        "nsis",
-        "zip"
+        "nsis"
       ],
       "icon": "resources/icon.ico"
     },
     "linux": {
       "target": [
         "AppImage",
-        "deb",
-        "zip"
+        "deb"
       ]
     },
     "mac": {
@@ -40,6 +38,11 @@
         "zip",
         "dmg"
       ]
+    },
+    "publish": {
+      "provider": "github",
+      "owner": "mikkerlo",
+      "repo": "anime-downloader"
     },
     "files": [
       "out/**/*"
@@ -74,9 +77,5 @@
     "jassub": "^2.4.2",
     "libass-wasm": "^4.1.0",
     "vue": "^3.5.31"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mikkerlo/anime-downloader.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,14 +23,16 @@
     "win": {
       "target": [
         "portable",
-        "nsis"
+        "nsis",
+        "zip"
       ],
       "icon": "resources/icon.ico"
     },
     "linux": {
       "target": [
         "AppImage",
-        "deb"
+        "deb",
+        "zip"
       ]
     },
     "mac": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {
@@ -39,11 +39,6 @@
         "dmg"
       ]
     },
-    "publish": {
-      "provider": "github",
-      "owner": "mikkerlo",
-      "repo": "anime-downloader"
-    },
     "files": [
       "out/**/*"
     ]
@@ -77,5 +72,9 @@
     "jassub": "^2.4.2",
     "libass-wasm": "^4.1.0",
     "vue": "^3.5.31"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mikkerlo/anime-downloader.git"
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,27 +8,16 @@ import * as fs from 'fs'
 import * as fsPromises from 'fs/promises'
 import * as path from 'path'
 import ffbinaries from 'ffbinaries'
-import { execFile } from 'child_process'
+import { execFile, spawn, type ChildProcess } from 'child_process'
 import * as os from 'os'
 import Ffmpeg from 'fluent-ffmpeg'
 import { autoUpdater } from 'electron-updater'
 import * as shikimori from './shikimori'
 import { pathToFileURL } from 'url'
-import { Readable, PassThrough } from 'stream'
-import * as crypto from 'crypto'
+import { Readable } from 'stream'
+import { randomUUID } from 'crypto'
 import { SmotretApi } from './smotret-api'
 import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, EpisodeDetail, Translation } from './smotret-api'
-
-interface RemuxSession {
-  process: Ffmpeg.FfmpegCommand
-  tempPath: string
-  stream: PassThrough
-  passThrough: PassThrough
-  subtitlePromise?: Promise<string | undefined>
-  completed: boolean
-  streamConsumed: boolean
-}
-const remuxSessions = new Map<string, RemuxSession>()
 
 // Enable WebGPU support for Anime4K shaders in the renderer
 app.commandLine.appendSwitch('enable-unsafe-webgpu')
@@ -573,16 +562,6 @@ function registerIpcHandlers(): void {
   ipcMain.handle('app:version', () => app.getVersion())
 
   ipcMain.handle('update:check', async () => {
-    if (app.getVersion().includes('-nightly')) {
-      for (const win of BrowserWindow.getAllWindows()) {
-        win.webContents.send('update:status', {
-          status: 'error',
-          error: 'Update check disabled for nightly builds.'
-        })
-      }
-      return
-    }
-
     try {
       const result = await autoUpdater.checkForUpdates()
       if (!result) {
@@ -1418,118 +1397,170 @@ function registerIpcHandlers(): void {
     return null
   })
 
-  // Remux MKV to MP4 (stream copy) for HTML5 playback
-  const remuxTmpDir = path.join(os.tmpdir(), 'anime-dl-remux')
-
-  ipcMain.handle('player:get-remux-subtitles', async (_event, sessionId: string): Promise<string | null> => {
-    const session = remuxSessions.get(sessionId)
-    if (!session || !session.subtitlePromise) return null
-    try {
-      const content = await session.subtitlePromise
-      return content || null
-    } catch {
-      return null
-    }
-  })
-
-  ipcMain.handle('player:remux-mkv-stream', async (_event, mkvPath: string): Promise<{ sessionId: string } | { error: string }> => {
+  // Remux MKV to fragmented MP4 (stream copy) for progressive HTML5 playback.
+  // See protocol.handle('anime-video', …) below for the streaming reader.
+  ipcMain.handle('player:remux-mkv', async (_event, mkvPath: string): Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }> => {
     if (!ffmpegPath) return { error: 'ffmpeg not available' }
     if (!fs.existsSync(mkvPath)) return { error: 'File not found' }
 
     fs.mkdirSync(remuxTmpDir, { recursive: true })
 
-    const sessionId = crypto.randomUUID()
+    const stamp = Date.now()
     const baseName = path.basename(mkvPath, path.extname(mkvPath))
-    const mp4Path = path.join(remuxTmpDir, `${baseName}-${sessionId}.mp4`)
+    const mp4Path = path.join(remuxTmpDir, `${baseName}-${stamp}.mp4`)
 
     Ffmpeg.setFfmpegPath(ffmpegPath)
 
-    const passThrough = new PassThrough()
-    const streamForResponse = new PassThrough()
-    const streamForFile = fs.createWriteStream(mp4Path)
+    const remuxPromise = new Promise<void>((resolve, reject) => {
+      Ffmpeg(mkvPath)
+        .outputOptions(['-c', 'copy', '-movflags', '+faststart'])
+        .output(mp4Path)
+        .on('error', (err) => {
+          console.error('[remux] FFmpeg error:', err.message)
+          reject(err)
+        })
+        .on('end', () => {
+          console.log('[remux] Completed:', mp4Path)
+          resolve()
+        })
+        .run()
+    })
 
-    passThrough.pipe(streamForFile)
-    passThrough.pipe(streamForResponse) // Use pipe to handle backpressure properly
+    const subtitlePromise = extractFirstSubtitle(mkvPath, path.join(remuxTmpDir, `${baseName}-${stamp}.ass`))
 
-    const remuxProcess = Ffmpeg(mkvPath)
-      .outputOptions([
-        '-c', 'copy',
-        '-movflags', '+frag_keyframe+empty_moov',
-        '-f', 'mp4'
-      ])
-      .on('error', (err) => {
-        console.error('[remux-stream] FFmpeg error:', err.message)
-        const session = remuxSessions.get(sessionId)
-        if (session) {
-          session.completed = true
-          session.stream.destroy()
-        }
-        passThrough.destroy()
-        remuxSessions.delete(sessionId)
-      })
-      .on('end', () => {
-        console.log('[remux-stream] Completed:', mp4Path)
-        const session = remuxSessions.get(sessionId)
-        if (session) session.completed = true
-      })
+    try {
+      const [, subtitleContent] = await Promise.all([remuxPromise, subtitlePromise])
+      return { mp4Path, ...(subtitleContent ? { subtitleContent } : {}) }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      return { error: msg }
+    }
+  })
 
-    remuxProcess.pipe(passThrough)
+  // Start an MSE-friendly fragmented MP4 pipe. Returns duration + codecs MIME so the
+  // renderer can set MediaSource.duration and addSourceBuffer(mimeType) upfront.
+  // Video bytes are pushed to the renderer via 'player:stream-chunk' events.
+  ipcMain.handle('player:remux-mkv-stream', async (event, mkvPath: string, initialSeek?: number): Promise<MseOpenResult | { error: string }> => {
+    if (!ffmpegPath) return { error: 'ffmpeg not available' }
+    if (!fs.existsSync(mkvPath)) return { error: 'File not found' }
 
-    // Extract subtitles in parallel
-    const subtitlePromise = (async (): Promise<string | undefined> => {
-      try {
-        if (!ffprobePath) return undefined
+    const probe = await probeMkvForMse(mkvPath)
+    if (!probe) return { error: 'Codecs not supported for MSE' }
+
+    fs.mkdirSync(remuxTmpDir, { recursive: true })
+
+    const sessionId = randomUUID()
+    const baseName = path.basename(mkvPath, path.extname(mkvPath))
+
+    const session: MseSession = {
+      proc: null as unknown as ChildProcess,
+      pendingBytes: 0,
+      stderrTail: [],
+      done: false,
+      error: null,
+      senderId: event.sender.id,
+      ready: false,
+      prelude: [],
+      mkvPath,
+      generation: 0
+    }
+    mseSessions.set(sessionId, session)
+    const startSeek = typeof initialSeek === 'number' && isFinite(initialSeek) && initialSeek > 0 ? initialSeek : 0
+    session.proc = spawnFfmpegForSession(session, event, sessionId, startSeek)
+
+    // Kick off subtitle extraction in parallel; push to renderer when ready.
+    const assPath = path.join(remuxTmpDir, `${baseName}-${sessionId}.ass`)
+    let hasSubtitlesPending = false
+    try {
+      if (ffprobePath) {
         Ffmpeg.setFfprobePath(ffprobePath)
-        const hasSubStream = await new Promise<boolean>((res) => {
+        hasSubtitlesPending = await new Promise<boolean>((res) => {
           Ffmpeg.ffprobe(mkvPath, (err, metadata) => {
-            res(err ? false : !!metadata.streams?.find(s => s.codec_type === 'subtitle'))
+            res(err ? false : !!metadata.streams?.find((s) => s.codec_type === 'subtitle'))
           })
         })
-        if (!hasSubStream) return undefined
-
-        const assPath = path.join(remuxTmpDir, `${baseName}-${sessionId}.ass`)
-        await new Promise<void>((res, rej) => {
-          Ffmpeg(mkvPath)
-            .outputOptions(['-map', '0:s:0', '-c:s', 'ass'])
-            .output(assPath)
-            .on('error', (err) => {
-              console.error('[remux-stream] Subtitle extraction error:', err.message)
-              rej(err)
-            })
-            .on('end', () => res())
-            .run()
-        })
-        const content = fs.readFileSync(assPath, 'utf-8')
-        console.log('[remux-stream] Subtitle extracted:', assPath)
-        return content
-      } catch (err) {
-        console.warn('[remux-stream] Subtitle extraction failed:', err)
-        return undefined
       }
-    })()
+    } catch { /* ignore probe failures */ }
 
-    const session: RemuxSession = {
-      process: remuxProcess,
-      tempPath: mp4Path,
-      stream: streamForResponse,
-      passThrough: passThrough,
-      subtitlePromise: subtitlePromise,
-      completed: false,
-      streamConsumed: false
+    if (hasSubtitlesPending) {
+      extractFirstSubtitle(mkvPath, assPath).then((content) => {
+        if (!content) return
+        const sender = event.sender
+        if (sender && !sender.isDestroyed()) {
+          sender.send('player:stream-subtitles', { sessionId, content })
+        }
+      }).catch(() => { /* already logged */ })
     }
-    remuxSessions.set(sessionId, session)
 
-    // Return immediately to not block video playback
-    return { sessionId }
+    return {
+      sessionId,
+      duration: probe.duration,
+      mimeType: probe.mimeType,
+      hasSubtitlesPending,
+      initialSeek: startSeek
+    }
+  })
+
+  // Forward seek past the buffered region: respawn ffmpeg with `-ss` so output
+  // starts at (or just before) the requested timestamp. The renderer will have
+  // already set sourceBuffer.timestampOffset to place fragments on the correct
+  // MSE timeline position. Stale chunks from the old proc are filtered out by
+  // the generation counter captured in spawnFfmpegForSession.
+  ipcMain.handle('player:stream-seek', (event, sessionId: string, seekSeconds: number) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return { error: 'session not found' }
+    session.generation++
+    try { session.proc.kill('SIGKILL') } catch { /* ignore */ }
+    session.pendingBytes = 0
+    session.prelude = []
+    session.done = false
+    session.error = null
+    // Hold new chunks in the prelude until the renderer has set its
+    // SourceBuffer.timestampOffset and called player:stream-start again.
+    // Otherwise first frames of the new run race ahead of the offset change
+    // and get placed on the wrong MSE timeline.
+    session.ready = false
+    if (session.proc.stdout && session.proc.stdout.isPaused()) {
+      try { session.proc.stdout.resume() } catch { /* ignore */ }
+    }
+    session.proc = spawnFfmpegForSession(session, event, sessionId, Math.max(0, seekSeconds))
+    return { ok: true }
+  })
+
+  // Handshake: renderer's MediaSource + SourceBuffer are ready to receive chunks.
+  // Flush any buffered prelude (the MP4 moov header lives in here) and switch to
+  // forwarding subsequent chunks directly.
+  ipcMain.handle('player:stream-start', (event, sessionId: string) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return
+    if (session.ready) return
+    session.ready = true
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      for (const chunk of session.prelude) {
+        sender.send('player:stream-chunk', { sessionId, data: chunk })
+      }
+    }
+    session.prelude = []
+  })
+
+  // Backpressure ack: renderer reports bytes it has appended into its SourceBuffer.
+  // When enough data has been consumed we resume the ffmpeg stdout pipe.
+  ipcMain.handle('player:stream-ack', (_event, sessionId: string, bytesConsumed: number) => {
+    const session = mseSessions.get(sessionId)
+    if (!session) return
+    session.pendingBytes = Math.max(0, session.pendingBytes - bytesConsumed)
+    if (
+      session.pendingBytes < STREAM_BACKPRESSURE_LOW_WATERMARK &&
+      session.proc.stdout?.isPaused()
+    ) {
+      session.proc.stdout.resume()
+    }
   })
 
   ipcMain.handle('player:cleanup-remux', async () => {
-    for (const [id, session] of remuxSessions.entries()) {
-      try { session.process.kill('SIGKILL') } catch { /* ignore */ }
-      try { session.stream.destroy() } catch { /* ignore */ }
-      try { session.passThrough.destroy() } catch { /* ignore */ }
-      try { if (fs.existsSync(session.tempPath)) fs.unlinkSync(session.tempPath) } catch { /* ignore */ }
-      remuxSessions.delete(id)
+    for (const sessionId of Array.from(mseSessions.keys())) {
+      cleanupMseSession(sessionId)
     }
     try {
       if (fs.existsSync(remuxTmpDir)) {
@@ -1541,6 +1572,212 @@ function registerIpcHandlers(): void {
       }
     } catch { /* ignore */ }
   })
+}
+
+interface MseOpenResult {
+  sessionId: string
+  duration: number
+  mimeType: string
+  hasSubtitlesPending: boolean
+  initialSeek: number
+}
+
+interface MseSession {
+  proc: ChildProcess
+  pendingBytes: number
+  stderrTail: string[]
+  done: boolean
+  error: string | null
+  senderId: number
+  ready: boolean
+  prelude: Buffer[]
+  mkvPath: string
+  generation: number
+}
+
+function spawnFfmpegForSession(
+  session: MseSession,
+  event: Electron.IpcMainInvokeEvent,
+  sessionId: string,
+  seekSeconds: number
+): ChildProcess {
+  const args: string[] = ['-fflags', '+genpts']
+  if (seekSeconds > 0) args.push('-ss', String(seekSeconds))
+  args.push(
+    '-i', session.mkvPath,
+    '-map', '0:v:0',
+    '-map', '0:a:0?',
+    '-c', 'copy',
+    '-avoid_negative_ts', 'make_zero',
+    '-muxpreload', '0',
+    '-muxdelay', '0',
+    '-movflags', '+frag_keyframe+empty_moov+default_base_moof+separate_moof',
+    '-frag_duration', '1000000',
+    '-f', 'mp4',
+    'pipe:1'
+  )
+  const proc = spawn(ffmpegPath!, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+  const procGen = session.generation
+  console.log(`[remux-stream] spawned ffmpeg session ${sessionId.slice(0, 8)} gen=${procGen} seek=${seekSeconds}`)
+
+  proc.stderr?.on('data', (data: Buffer) => {
+    if (procGen !== session.generation) return
+    const line = data.toString()
+    session.stderrTail.push(line)
+    if (session.stderrTail.length > 40) session.stderrTail.shift()
+  })
+
+  let totalBytes = 0
+  let chunkCount = 0
+  proc.stdout?.on('data', (chunk: Buffer) => {
+    if (procGen !== session.generation) return
+    session.pendingBytes += chunk.length
+    totalBytes += chunk.length
+    chunkCount++
+    if (chunkCount === 1 || chunkCount % 400 === 0) {
+      console.log(`[remux-stream] ${sessionId.slice(0, 8)} gen=${procGen} chunk ${chunkCount} total=${(totalBytes / 1024 / 1024).toFixed(1)}MB pending=${(session.pendingBytes / 1024 / 1024).toFixed(1)}MB ready=${session.ready}`)
+    }
+    if (session.ready) {
+      const sender = event.sender
+      if (sender && !sender.isDestroyed()) {
+        sender.send('player:stream-chunk', { sessionId, data: chunk })
+      }
+    } else {
+      session.prelude.push(chunk)
+    }
+    if (session.pendingBytes > STREAM_BACKPRESSURE_HIGH_WATERMARK) {
+      proc.stdout?.pause()
+    }
+  })
+
+  proc.stdout?.on('end', () => {
+    if (procGen !== session.generation) return
+    if (session.done) return
+    session.done = true
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      sender.send('player:stream-end', { sessionId })
+    }
+  })
+
+  proc.on('error', (err) => {
+    if (procGen !== session.generation) return
+    if (session.done) return
+    session.done = true
+    session.error = err.message
+    console.error('[remux-stream] spawn error:', err.message)
+    const sender = event.sender
+    if (sender && !sender.isDestroyed()) {
+      sender.send('player:stream-error', { sessionId, error: err.message })
+    }
+  })
+
+  proc.on('exit', (code, signal) => {
+    if (procGen !== session.generation) return
+    if (signal === 'SIGKILL') return
+    if (code !== 0 && !session.done) {
+      const msg = `ffmpeg exited with code ${code}: ${session.stderrTail.slice(-3).join('').trim()}`
+      session.error = msg
+      session.done = true
+      console.error('[remux-stream]', msg)
+      const sender = event.sender
+      if (sender && !sender.isDestroyed()) {
+        sender.send('player:stream-error', { sessionId, error: msg })
+      }
+    }
+  })
+
+  return proc
+}
+
+const remuxTmpDir = path.join(os.tmpdir(), 'anime-dl-remux')
+const mseSessions = new Map<string, MseSession>()
+const STREAM_BACKPRESSURE_HIGH_WATERMARK = 32 * 1024 * 1024
+const STREAM_BACKPRESSURE_LOW_WATERMARK = 8 * 1024 * 1024
+
+function cleanupMseSession(sessionId: string): void {
+  const session = mseSessions.get(sessionId)
+  if (!session) return
+  session.done = true
+  try { session.proc.kill('SIGKILL') } catch { /* ignore */ }
+  mseSessions.delete(sessionId)
+}
+
+async function probeMkvForMse(mkvPath: string): Promise<{ duration: number; mimeType: string } | null> {
+  if (!ffprobePath) return null
+  try {
+    Ffmpeg.setFfprobePath(ffprobePath)
+    const metadata = await new Promise<Ffmpeg.FfprobeData>((res, rej) => {
+      Ffmpeg.ffprobe(mkvPath, (err, m) => (err ? rej(err) : res(m)))
+    })
+    const durationStr = metadata.format?.duration
+    const duration = typeof durationStr === 'number' ? durationStr : parseFloat(String(durationStr))
+    if (!isFinite(duration) || duration <= 0) return null
+    const video = metadata.streams?.find((s) => s.codec_type === 'video')
+    const audio = metadata.streams?.find((s) => s.codec_type === 'audio')
+    if (!video || !audio) return null
+    const vStr = avcCodecString(video)
+    const aStr = aacCodecString(audio)
+    if (!vStr || !aStr) return null
+    return { duration, mimeType: `video/mp4; codecs="${vStr}, ${aStr}"` }
+  } catch {
+    return null
+  }
+}
+
+function avcCodecString(stream: Ffmpeg.FfprobeStream): string | null {
+  if (stream.codec_name !== 'h264') return null
+  const profile = (stream.profile || '').toString().toLowerCase()
+  let pp: string, cc: string
+  if (profile.includes('constrained baseline')) { pp = '42'; cc = 'E0' }
+  else if (profile.includes('baseline')) { pp = '42'; cc = '00' }
+  else if (profile.includes('main')) { pp = '4D'; cc = '40' }
+  else if (profile.includes('high 10')) { pp = '6E'; cc = '00' }
+  else if (profile.includes('high 4:2:2')) { pp = '7A'; cc = '00' }
+  else if (profile.includes('high 4:4:4')) { pp = 'F4'; cc = '00' }
+  else if (profile.includes('high')) { pp = '64'; cc = '00' }
+  else return null
+  const level = typeof stream.level === 'number' ? stream.level : 0
+  if (level <= 0) return null
+  const ll = level.toString(16).padStart(2, '0').toUpperCase()
+  return `avc1.${pp}${cc}${ll}`
+}
+
+function aacCodecString(stream: Ffmpeg.FfprobeStream): string | null {
+  if (stream.codec_name !== 'aac') return null
+  const profile = (stream.profile || '').toString().toUpperCase()
+  if (profile === 'HE-AAC') return 'mp4a.40.5'
+  if (profile === 'HE-AACV2' || profile === 'HE-AAC V2') return 'mp4a.40.29'
+  return 'mp4a.40.2'
+}
+
+async function extractFirstSubtitle(mkvPath: string, assPath: string): Promise<string | undefined> {
+  try {
+    if (!ffprobePath) return undefined
+    Ffmpeg.setFfprobePath(ffprobePath)
+    const hasSubStream = await new Promise<boolean>((res) => {
+      Ffmpeg.ffprobe(mkvPath, (err, metadata) => {
+        res(err ? false : !!metadata.streams?.find((s) => s.codec_type === 'subtitle'))
+      })
+    })
+    if (!hasSubStream) return undefined
+    await new Promise<void>((res, rej) => {
+      Ffmpeg(mkvPath)
+        .outputOptions(['-map', '0:s:0', '-c:s', 'ass'])
+        .output(assPath)
+        .on('error', (err) => {
+          console.error('[remux] Subtitle extraction error:', err.message)
+          rej(err)
+        })
+        .on('end', () => res())
+        .run()
+    })
+    const content = fs.readFileSync(assPath, 'utf-8')
+    console.log('[remux] Subtitle extracted:', assPath)
+    return content
+  } catch {
+    return undefined
+  }
 }
 
 function createWindow(): void {
@@ -1575,113 +1812,11 @@ function createWindow(): void {
 }
 
 app.whenReady().then(async () => {
-  // Handle anime-video:// protocol for local video playback with Range request support
+  // Handle anime-video:// protocol for local video playback with Range request support.
+  // Only one URL shape: anime-video://{absolute-path}. MKV streaming now uses MSE via IPC.
   protocol.handle('anime-video', async (request) => {
-    let urlObj: URL
-    try {
-      urlObj = new URL(request.url)
-    } catch {
-      return new Response('Invalid URL', { status: 400 })
-    }
-
-    if (urlObj.hostname === 'stream') {
-      const sessionId = urlObj.searchParams.get('id')
-      if (!sessionId) return new Response('Missing stream id', { status: 400 })
-      const session = remuxSessions.get(sessionId)
-      if (!session) return new Response('Session not found', { status: 404 })
-
-      const mimeType = 'video/mp4'
-      const rangeHeader = request.headers.get('Range')
-
-      if (rangeHeader) {
-        const match = rangeHeader.match(/bytes=(\d+)-(\d*)/)
-        if (match) {
-          const start = parseInt(match[1], 10)
-          
-          if (start === 0 && !session.streamConsumed) {
-            session.streamConsumed = true
-            // Unknown-length live stream - return 200 without Content-Range per review feedback
-            return new Response(Readable.toWeb(session.stream) as ReadableStream, {
-              status: 200,
-              headers: {
-                'Content-Type': mimeType,
-                'Accept-Ranges': 'bytes'
-              }
-            })
-          }
-
-          let stat: fs.Stats
-          try { stat = fs.statSync(session.tempPath) } catch { return new Response('File not found', { status: 404 }) }
-          
-          let currentSize = stat.size
-          let end = match[2] ? parseInt(match[2], 10) : currentSize - 1
-          
-          if (start >= currentSize && !session.completed) {
-            await new Promise<void>((resolve, reject) => {
-              let elapsed = 0;
-              const check = () => {
-                if (!remuxSessions.has(sessionId)) {
-                  resolve() // Session deleted, stop polling
-                  return
-                }
-                if (session.completed || fs.statSync(session.tempPath).size > start) resolve()
-                else if (elapsed > 10000) resolve() // Timeout after 10s
-                else {
-                  elapsed += 100
-                  setTimeout(check, 100)
-                }
-              }
-              check()
-            })
-            try {
-              stat = fs.statSync(session.tempPath)
-              currentSize = stat.size
-              if (end >= currentSize) end = currentSize - 1
-            } catch {
-              return new Response('File not found', { status: 404 })
-            }
-          }
-
-          if (start > end && session.completed) return new Response('', { status: 416 })
-
-          const chunkSize = end - start + 1
-          const nodeStream = fs.createReadStream(session.tempPath, { start, end })
-          const webStream = Readable.toWeb(nodeStream) as ReadableStream
-
-          return new Response(webStream, {
-            status: 206,
-            headers: {
-              'Content-Type': mimeType,
-              'Content-Length': String(chunkSize),
-              'Content-Range': `bytes ${start}-${end}/${session.completed ? currentSize : '*'}`,
-              'Accept-Ranges': 'bytes'
-            }
-          })
-        }
-      }
-
-      if (!session.streamConsumed) {
-        // Fallback for non-range requests or direct access
-        session.streamConsumed = true
-        return new Response(Readable.toWeb(session.stream) as ReadableStream, {
-          status: 200,
-          headers: { 'Content-Type': mimeType }
-        })
-      } else {
-        const nodeStream = fs.createReadStream(session.tempPath)
-        return new Response(Readable.toWeb(nodeStream) as ReadableStream, {
-          status: 200,
-          headers: { 'Content-Type': mimeType }
-        })
-      }
-    }
-
-    // Decode traditional file paths from anime-video:// scheme
-    let filePath = decodeURIComponent(request.url.replace('anime-video://', ''))
-    if (filePath.startsWith('/')) {
-        // preserve absolute path semantics after protocol stripping if necessary
-        // actually anime-video:///path translates to decodeURIComponent('/path')
-    }
+    const raw = request.url.replace('anime-video://', '')
+    const filePath = decodeURIComponent(raw)
 
     let stat: fs.Stats
     try {
@@ -1794,7 +1929,6 @@ app.whenReady().then(async () => {
   registerIpcHandlers()
 
   // Auto-updater setup
-  const isNightly = app.getVersion().includes('-nightly')
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = false
 
@@ -1825,14 +1959,10 @@ app.whenReady().then(async () => {
     broadcastUpdateStatus({ status: 'error', error: err.message })
   })
 
-  if (!isNightly) {
-    // Auto-check on launch if last check was >24h ago
-    const lastCheck = store.get('lastUpdateCheck') as number
-    if (Date.now() - lastCheck > 24 * 60 * 60 * 1000) {
-      autoUpdater.checkForUpdates().catch(() => {})
-    }
-  } else {
-    console.log('Nightly build detected, auto-updates disabled.')
+  // Auto-check on launch if last check was >24h ago
+  const lastCheck = store.get('lastUpdateCheck') as number
+  if (Date.now() - lastCheck > 24 * 60 * 60 * 1000) {
+    autoUpdater.checkForUpdates().catch(() => {})
   }
 
   app.on('activate', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,9 +14,21 @@ import Ffmpeg from 'fluent-ffmpeg'
 import { autoUpdater } from 'electron-updater'
 import * as shikimori from './shikimori'
 import { pathToFileURL } from 'url'
-import { Readable } from 'stream'
+import { Readable, PassThrough } from 'stream'
+import * as crypto from 'crypto'
 import { SmotretApi } from './smotret-api'
 import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, EpisodeDetail, Translation } from './smotret-api'
+
+interface RemuxSession {
+  process: Ffmpeg.FfmpegCommand
+  tempPath: string
+  stream: PassThrough
+  passThrough: PassThrough
+  subtitlePromise?: Promise<string | undefined>
+  completed: boolean
+  streamConsumed: boolean
+}
+const remuxSessions = new Map<string, RemuxSession>()
 
 // Enable WebGPU support for Anime4K shaders in the renderer
 app.commandLine.appendSwitch('enable-unsafe-webgpu')
@@ -1399,36 +1411,61 @@ function registerIpcHandlers(): void {
   // Remux MKV to MP4 (stream copy) for HTML5 playback
   const remuxTmpDir = path.join(os.tmpdir(), 'anime-dl-remux')
 
-  ipcMain.handle('player:remux-mkv', async (_event, mkvPath: string): Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }> => {
+  ipcMain.handle('player:get-remux-subtitles', async (_event, sessionId: string): Promise<string | null> => {
+    const session = remuxSessions.get(sessionId)
+    if (!session || !session.subtitlePromise) return null
+    try {
+      const content = await session.subtitlePromise
+      return content || null
+    } catch {
+      return null
+    }
+  })
+
+  ipcMain.handle('player:remux-mkv-stream', async (_event, mkvPath: string): Promise<{ sessionId: string } | { error: string }> => {
     if (!ffmpegPath) return { error: 'ffmpeg not available' }
     if (!fs.existsSync(mkvPath)) return { error: 'File not found' }
 
-    // Create temp dir
     fs.mkdirSync(remuxTmpDir, { recursive: true })
 
-    const stamp = Date.now()
+    const sessionId = crypto.randomUUID()
     const baseName = path.basename(mkvPath, path.extname(mkvPath))
-    const mp4Path = path.join(remuxTmpDir, `${baseName}-${stamp}.mp4`)
+    const mp4Path = path.join(remuxTmpDir, `${baseName}-${sessionId}.mp4`)
 
     Ffmpeg.setFfmpegPath(ffmpegPath)
 
-    // Run remux and subtitle extraction in parallel
-    const remuxPromise = new Promise<void>((resolve, reject) => {
-      Ffmpeg(mkvPath)
-        .outputOptions(['-c', 'copy', '-movflags', '+faststart'])
-        .output(mp4Path)
-        .on('error', (err) => {
-          console.error('[remux] FFmpeg error:', err.message)
-          reject(err)
-        })
-        .on('end', () => {
-          console.log('[remux] Completed:', mp4Path)
-          resolve()
-        })
-        .run()
-    })
+    const passThrough = new PassThrough()
+    const streamForResponse = new PassThrough()
+    const streamForFile = fs.createWriteStream(mp4Path)
 
-    // Extract first subtitle stream (if any) to a temp .ass file
+    passThrough.pipe(streamForFile)
+    passThrough.pipe(streamForResponse) // Use pipe to handle backpressure properly
+
+    const remuxProcess = Ffmpeg(mkvPath)
+      .outputOptions([
+        '-c', 'copy',
+        '-movflags', '+frag_keyframe+empty_moov',
+        '-f', 'mp4'
+      ])
+      .on('error', (err) => {
+        console.error('[remux-stream] FFmpeg error:', err.message)
+        const session = remuxSessions.get(sessionId)
+        if (session) {
+          session.completed = true
+          session.stream.destroy()
+        }
+        passThrough.destroy()
+        remuxSessions.delete(sessionId)
+      })
+      .on('end', () => {
+        console.log('[remux-stream] Completed:', mp4Path)
+        const session = remuxSessions.get(sessionId)
+        if (session) session.completed = true
+      })
+
+    remuxProcess.pipe(passThrough)
+
+    // Extract subtitles in parallel
     const subtitlePromise = (async (): Promise<string | undefined> => {
       try {
         if (!ffprobePath) return undefined
@@ -1440,36 +1477,50 @@ function registerIpcHandlers(): void {
         })
         if (!hasSubStream) return undefined
 
-        const assPath = path.join(remuxTmpDir, `${baseName}-${stamp}.ass`)
+        const assPath = path.join(remuxTmpDir, `${baseName}-${sessionId}.ass`)
         await new Promise<void>((res, rej) => {
           Ffmpeg(mkvPath)
             .outputOptions(['-map', '0:s:0', '-c:s', 'ass'])
             .output(assPath)
             .on('error', (err) => {
-              console.error('[remux] Subtitle extraction error:', err.message)
+              console.error('[remux-stream] Subtitle extraction error:', err.message)
               rej(err)
             })
             .on('end', () => res())
             .run()
         })
         const content = fs.readFileSync(assPath, 'utf-8')
-        console.log('[remux] Subtitle extracted:', assPath)
+        console.log('[remux-stream] Subtitle extracted:', assPath)
         return content
-      } catch {
+      } catch (err) {
+        console.warn('[remux-stream] Subtitle extraction failed:', err)
         return undefined
       }
     })()
 
-    try {
-      const [, subtitleContent] = await Promise.all([remuxPromise, subtitlePromise])
-      return { mp4Path, ...(subtitleContent ? { subtitleContent } : {}) }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      return { error: msg }
+    const session: RemuxSession = {
+      process: remuxProcess,
+      tempPath: mp4Path,
+      stream: streamForResponse,
+      passThrough: passThrough,
+      subtitlePromise: subtitlePromise,
+      completed: false,
+      streamConsumed: false
     }
+    remuxSessions.set(sessionId, session)
+
+    // Return immediately to not block video playback
+    return { sessionId }
   })
 
   ipcMain.handle('player:cleanup-remux', async () => {
+    for (const [id, session] of remuxSessions.entries()) {
+      try { session.process.kill('SIGKILL') } catch { /* ignore */ }
+      try { session.stream.destroy() } catch { /* ignore */ }
+      try { session.passThrough.destroy() } catch { /* ignore */ }
+      try { if (fs.existsSync(session.tempPath)) fs.unlinkSync(session.tempPath) } catch { /* ignore */ }
+      remuxSessions.delete(id)
+    }
     try {
       if (fs.existsSync(remuxTmpDir)) {
         const files = fs.readdirSync(remuxTmpDir)
@@ -1516,7 +1567,111 @@ function createWindow(): void {
 app.whenReady().then(async () => {
   // Handle anime-video:// protocol for local video playback with Range request support
   protocol.handle('anime-video', async (request) => {
-    const filePath = decodeURIComponent(request.url.replace('anime-video://', ''))
+    let urlObj: URL
+    try {
+      urlObj = new URL(request.url)
+    } catch {
+      return new Response('Invalid URL', { status: 400 })
+    }
+
+    if (urlObj.hostname === 'stream') {
+      const sessionId = urlObj.searchParams.get('id')
+      if (!sessionId) return new Response('Missing stream id', { status: 400 })
+      const session = remuxSessions.get(sessionId)
+      if (!session) return new Response('Session not found', { status: 404 })
+
+      const mimeType = 'video/mp4'
+      const rangeHeader = request.headers.get('Range')
+
+      if (rangeHeader) {
+        const match = rangeHeader.match(/bytes=(\d+)-(\d*)/)
+        if (match) {
+          const start = parseInt(match[1], 10)
+          
+          if (start === 0 && !session.streamConsumed) {
+            session.streamConsumed = true
+            // Unknown-length live stream - return 200 without Content-Range per review feedback
+            return new Response(Readable.toWeb(session.stream) as ReadableStream, {
+              status: 200,
+              headers: {
+                'Content-Type': mimeType,
+                'Accept-Ranges': 'bytes'
+              }
+            })
+          }
+
+          let stat: fs.Stats
+          try { stat = fs.statSync(session.tempPath) } catch { return new Response('File not found', { status: 404 }) }
+          
+          let currentSize = stat.size
+          let end = match[2] ? parseInt(match[2], 10) : currentSize - 1
+          
+          if (start >= currentSize && !session.completed) {
+            await new Promise<void>((resolve, reject) => {
+              let elapsed = 0;
+              const check = () => {
+                if (!remuxSessions.has(sessionId)) {
+                  resolve() // Session deleted, stop polling
+                  return
+                }
+                if (session.completed || fs.statSync(session.tempPath).size > start) resolve()
+                else if (elapsed > 10000) resolve() // Timeout after 10s
+                else {
+                  elapsed += 100
+                  setTimeout(check, 100)
+                }
+              }
+              check()
+            })
+            try {
+              stat = fs.statSync(session.tempPath)
+              currentSize = stat.size
+              if (end >= currentSize) end = currentSize - 1
+            } catch {
+              return new Response('File not found', { status: 404 })
+            }
+          }
+
+          if (start > end && session.completed) return new Response('', { status: 416 })
+
+          const chunkSize = end - start + 1
+          const nodeStream = fs.createReadStream(session.tempPath, { start, end })
+          const webStream = Readable.toWeb(nodeStream) as ReadableStream
+
+          return new Response(webStream, {
+            status: 206,
+            headers: {
+              'Content-Type': mimeType,
+              'Content-Length': String(chunkSize),
+              'Content-Range': `bytes ${start}-${end}/${session.completed ? currentSize : '*'}`,
+              'Accept-Ranges': 'bytes'
+            }
+          })
+        }
+      }
+
+      if (!session.streamConsumed) {
+        // Fallback for non-range requests or direct access
+        session.streamConsumed = true
+        return new Response(Readable.toWeb(session.stream) as ReadableStream, {
+          status: 200,
+          headers: { 'Content-Type': mimeType }
+        })
+      } else {
+        const nodeStream = fs.createReadStream(session.tempPath)
+        return new Response(Readable.toWeb(nodeStream) as ReadableStream, {
+          status: 200,
+          headers: { 'Content-Type': mimeType }
+        })
+      }
+    }
+
+    // Decode traditional file paths from anime-video:// scheme
+    let filePath = decodeURIComponent(request.url.replace('anime-video://', ''))
+    if (filePath.startsWith('/')) {
+        // preserve absolute path semantics after protocol stripping if necessary
+        // actually anime-video:///path translates to decodeURIComponent('/path')
+    }
 
     let stat: fs.Stats
     try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -573,6 +573,16 @@ function registerIpcHandlers(): void {
   ipcMain.handle('app:version', () => app.getVersion())
 
   ipcMain.handle('update:check', async () => {
+    if (app.getVersion().includes('-nightly')) {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send('update:status', {
+          status: 'error',
+          error: 'Update check disabled for nightly builds.'
+        })
+      }
+      return
+    }
+
     try {
       const result = await autoUpdater.checkForUpdates()
       if (!result) {
@@ -1784,6 +1794,7 @@ app.whenReady().then(async () => {
   registerIpcHandlers()
 
   // Auto-updater setup
+  const isNightly = app.getVersion().includes('-nightly')
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = false
 
@@ -1814,10 +1825,14 @@ app.whenReady().then(async () => {
     broadcastUpdateStatus({ status: 'error', error: err.message })
   })
 
-  // Auto-check on launch if last check was >24h ago
-  const lastCheck = store.get('lastUpdateCheck') as number
-  if (Date.now() - lastCheck > 24 * 60 * 60 * 1000) {
-    autoUpdater.checkForUpdates().catch(() => {})
+  if (!isNightly) {
+    // Auto-check on launch if last check was >24h ago
+    const lastCheck = store.get('lastUpdateCheck') as number
+    if (Date.now() - lastCheck > 24 * 60 * 60 * 1000) {
+      autoUpdater.checkForUpdates().catch(() => {})
+    }
+  } else {
+    console.log('Nightly build detected, auto-updates disabled.')
   }
 
   app.on('activate', () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -114,12 +114,45 @@ const api = {
     ipcRenderer.invoke('player:get-local-subtitles', filePath) as Promise<string | null>,
   playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) =>
     ipcRenderer.invoke('player:find-local-file', animeName, episodeInt, translationId) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
-  playerRemuxMkvStream: (mkvPath: string) =>
-    ipcRenderer.invoke('player:remux-mkv-stream', mkvPath) as Promise<{ sessionId: string } | { error: string }>,
-  playerGetRemuxSubtitles: (sessionId: string) =>
-    ipcRenderer.invoke('player:get-remux-subtitles', sessionId) as Promise<string | null>,
+  playerRemuxMkv: (mkvPath: string) =>
+    ipcRenderer.invoke('player:remux-mkv', mkvPath) as Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>,
+  playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) =>
+    ipcRenderer.invoke('player:remux-mkv-stream', mkvPath, initialSeek) as Promise<
+      | { sessionId: string; duration: number; mimeType: string; hasSubtitlesPending: boolean; initialSeek: number }
+      | { error: string }
+    >,
+  playerStreamStart: (sessionId: string) =>
+    ipcRenderer.invoke('player:stream-start', sessionId) as Promise<void>,
+  playerStreamAck: (sessionId: string, bytes: number) =>
+    ipcRenderer.invoke('player:stream-ack', sessionId, bytes) as Promise<void>,
+  playerStreamSeek: (sessionId: string, seekSeconds: number) =>
+    ipcRenderer.invoke('player:stream-seek', sessionId, seekSeconds) as Promise<{ ok: true } | { error: string }>,
   playerCleanupRemux: () =>
     ipcRenderer.invoke('player:cleanup-remux') as Promise<void>,
+  onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => {
+    ipcRenderer.on('player:stream-subtitles', (_event, data) => callback(data))
+  },
+  offPlayerStreamSubtitles: () => {
+    ipcRenderer.removeAllListeners('player:stream-subtitles')
+  },
+  onPlayerStreamChunk: (callback: (data: { sessionId: string; data: Uint8Array }) => void) => {
+    ipcRenderer.on('player:stream-chunk', (_event, data) => callback(data))
+  },
+  offPlayerStreamChunk: () => {
+    ipcRenderer.removeAllListeners('player:stream-chunk')
+  },
+  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => {
+    ipcRenderer.on('player:stream-end', (_event, data) => callback(data))
+  },
+  offPlayerStreamEnd: () => {
+    ipcRenderer.removeAllListeners('player:stream-end')
+  },
+  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => {
+    ipcRenderer.on('player:stream-error', (_event, data) => callback(data))
+  },
+  offPlayerStreamError: () => {
+    ipcRenderer.removeAllListeners('player:stream-error')
+  },
 
   // Shikimori
   shikimoriGetAuthUrl: () => ipcRenderer.invoke('shikimori:get-auth-url') as Promise<string>,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -114,8 +114,10 @@ const api = {
     ipcRenderer.invoke('player:get-local-subtitles', filePath) as Promise<string | null>,
   playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) =>
     ipcRenderer.invoke('player:find-local-file', animeName, episodeInt, translationId) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
-  playerRemuxMkv: (mkvPath: string) =>
-    ipcRenderer.invoke('player:remux-mkv', mkvPath) as Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>,
+  playerRemuxMkvStream: (mkvPath: string) =>
+    ipcRenderer.invoke('player:remux-mkv-stream', mkvPath) as Promise<{ sessionId: string } | { error: string }>,
+  playerGetRemuxSubtitles: (sessionId: string) =>
+    ipcRenderer.invoke('player:get-remux-subtitles', sessionId) as Promise<string | null>,
   playerCleanupRemux: () =>
     ipcRenderer.invoke('player:cleanup-remux') as Promise<void>,
 

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -89,9 +89,23 @@ interface Api {
   playerGetStreamUrl: (translationId: number, maxHeight: number) => Promise<{ streamUrl: string; subtitleContent: string | null; availableStreams: { height: number; url: string }[] } | null>
   playerGetLocalSubtitles: (filePath: string) => Promise<string | null>
   playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) => Promise<{ filePath: string; subtitleContent: string | null } | null>
-  playerRemuxMkvStream: (mkvPath: string) => Promise<{ sessionId: string } | { error: string }>
-  playerGetRemuxSubtitles: (sessionId: string) => Promise<string | null>
+  playerRemuxMkv: (mkvPath: string) => Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>
+  playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) => Promise<
+    | { sessionId: string; duration: number; mimeType: string; hasSubtitlesPending: boolean; initialSeek: number }
+    | { error: string }
+  >
+  playerStreamStart: (sessionId: string) => Promise<void>
+  playerStreamAck: (sessionId: string, bytes: number) => Promise<void>
+  playerStreamSeek: (sessionId: string, seekSeconds: number) => Promise<{ ok: true } | { error: string }>
   playerCleanupRemux: () => Promise<void>
+  onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => void
+  offPlayerStreamSubtitles: () => void
+  onPlayerStreamChunk: (callback: (data: { sessionId: string; data: Uint8Array }) => void) => void
+  offPlayerStreamChunk: () => void
+  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => void
+  offPlayerStreamEnd: () => void
+  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => void
+  offPlayerStreamError: () => void
 
   // Shikimori
   shikimoriGetAuthUrl: () => Promise<string>

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -89,7 +89,8 @@ interface Api {
   playerGetStreamUrl: (translationId: number, maxHeight: number) => Promise<{ streamUrl: string; subtitleContent: string | null; availableStreams: { height: number; url: string }[] } | null>
   playerGetLocalSubtitles: (filePath: string) => Promise<string | null>
   playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) => Promise<{ filePath: string; subtitleContent: string | null } | null>
-  playerRemuxMkv: (mkvPath: string) => Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>
+  playerRemuxMkvStream: (mkvPath: string) => Promise<{ sessionId: string } | { error: string }>
+  playerGetRemuxSubtitles: (sessionId: string) => Promise<string | null>
   playerCleanupRemux: () => Promise<void>
 
   // Shikimori

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -58,7 +58,19 @@ const activeFilePath = ref(props.filePath)
 const isMkv = computed(() => !!activeFilePath.value && activeFilePath.value.toLowerCase().endsWith('.mkv'))
 const remuxing = ref(false)
 const remuxError = ref('')
-const remuxStreamId = ref('')
+const remuxedPath = ref('')           // used by legacy full-remux fallback
+const streamSessionId = ref('')       // active MSE session id
+const mseSrcUrl = ref('')             // URL.createObjectURL(MediaSource)
+const mkvBuffering = ref(false)       // shows "Buffering…" toast while MSE waits for data
+
+// MSE internals (not reactive)
+let mediaSource: MediaSource | null = null
+let sourceBuffer: SourceBuffer | null = null
+let streamEnded = false
+const appendQueue: Uint8Array[] = []
+let pendingAckBytes = 0
+let mseInitialSeek = 0
+const STREAM_ACK_THRESHOLD = 1 * 1024 * 1024
 
 // Quality selector state
 const activeStreamUrl = ref(props.streamUrl)
@@ -200,6 +212,18 @@ async function resumeFromSavedPosition(): Promise<void> {
     if (saved.watched) return
     const d = video.duration || saved.duration
     if (!d) return
+    // For MSE MKV streams the ffmpeg run was already started at the saved
+    // position; skip the native seek to avoid a spurious unbuffered-seek flow.
+    if (streamSessionId.value && mseInitialSeek > 0) {
+      if (video.currentTime < mseInitialSeek) {
+        try { video.currentTime = mseInitialSeek } catch { /* ignore */ }
+      }
+      currentTime.value = mseInitialSeek
+      resumeToast.value = `Resumed at ${formatTime(saved.position)}`
+      if (resumeToastTimer) clearTimeout(resumeToastTimer)
+      resumeToastTimer = setTimeout(() => { resumeToast.value = '' }, 3000)
+      return
+    }
     if (saved.position > 5 && saved.position / d < 0.95) {
       video.currentTime = saved.position
       currentTime.value = saved.position
@@ -254,17 +278,297 @@ fn main(@builtin(position) coord: vec4f) -> @location(0) vec4f {
 
 const videoSrc = computed(() => {
   if (activeFilePath.value) {
-    // For MKV files, use the remuxed MP4 stream
+    // For MKV files, prefer the MSE stream URL; fall back to legacy full remux.
     if (isMkv.value) {
-      if (remuxStreamId.value) {
-        return 'anime-video://stream/?id=' + encodeURIComponent(remuxStreamId.value)
-      }
-      return '' // Not ready yet — remuxing in progress
+      if (mseSrcUrl.value) return mseSrcUrl.value
+      if (remuxedPath.value) return 'anime-video://' + encodeURIComponent(remuxedPath.value)
+      return ''
     }
     return 'anime-video://' + encodeURIComponent(activeFilePath.value)
   }
   return activeStreamUrl.value
 })
+
+async function prepareMkvForPlayback(filePath: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  resetMseState()
+  streamSessionId.value = ''
+  remuxedPath.value = ''
+  remuxError.value = ''
+
+  // Resolve saved position up front so ffmpeg's first spawn already starts
+  // near the resume point. Avoids the "append-during-parse" race that fires
+  // if we set timestampOffset after the first chunks are already parsing.
+  let initialSeek = 0
+  try {
+    const epInt = currentEpisodeInt.value
+    if (props.animeId && epInt) {
+      const saved = await window.api.watchProgressGet(props.animeId, epInt)
+      if (saved && !saved.watched && saved.position > 5 && saved.duration > 0 && saved.position / saved.duration < 0.95) {
+        initialSeek = Math.max(0, saved.position - 1)
+      }
+    }
+  } catch { /* ignore */ }
+
+  const streamResult = await window.api.playerRemuxMkvStream(filePath, initialSeek)
+  if (!('error' in streamResult)) {
+    if (typeof MediaSource !== 'undefined' && MediaSource.isTypeSupported(streamResult.mimeType)) {
+      startMseSession(streamResult.sessionId, streamResult.duration, streamResult.mimeType, streamResult.initialSeek)
+      mkvBuffering.value = true
+      return { ok: true }
+    }
+    console.warn('[player] MSE does not support codecs:', streamResult.mimeType, '— falling back to legacy remux')
+    await window.api.playerCleanupRemux()
+  } else {
+    console.warn('[player] MSE stream open failed, falling back to legacy remux:', streamResult.error)
+  }
+
+  remuxing.value = true
+  try {
+    const legacy = await window.api.playerRemuxMkv(filePath)
+    if ('error' in legacy) return { ok: false, error: legacy.error }
+    remuxedPath.value = legacy.mp4Path
+    if (!activeSubtitleContent.value && legacy.subtitleContent) {
+      activeSubtitleContent.value = legacy.subtitleContent
+    }
+    return { ok: true }
+  } finally {
+    remuxing.value = false
+  }
+}
+
+function startMseSession(sessionId: string, duration: number, mimeType: string, initialSeek: number): void {
+  streamSessionId.value = sessionId
+  mseInitialSeek = initialSeek
+  const ms = new MediaSource()
+  mediaSource = ms
+  mseSrcUrl.value = URL.createObjectURL(ms)
+  ms.addEventListener('sourceopen', () => {
+    try {
+      console.log('[player] sourceopen, adding SourceBuffer:', mimeType, 'initialSeek=', initialSeek)
+      const sb = ms.addSourceBuffer(mimeType)
+      sourceBuffer = sb
+      try { ms.duration = duration } catch (e) { console.warn('[player] set duration failed:', e) }
+      if (initialSeek > 0) {
+        try { sb.timestampOffset = initialSeek } catch (e) { console.warn('[player] initial timestampOffset failed:', e) }
+      }
+      sb.addEventListener('updateend', onSourceBufferUpdateEnd)
+      sb.addEventListener('error', (e) => console.error('[player] SourceBuffer error event:', e))
+      sb.addEventListener('abort', () => console.warn('[player] SourceBuffer abort'))
+      window.api.playerStreamStart(sessionId)
+      pumpAppendQueue()
+    } catch (e) {
+      console.error('[player] addSourceBuffer failed:', e)
+    }
+  }, { once: true })
+}
+
+let appendCount = 0
+function onSourceBufferUpdateEnd(): void {
+  const sb = sourceBuffer
+  if (sb && sb.buffered.length > 0) {
+    appendCount++
+    if (appendCount <= 5 || appendCount % 50 === 0) {
+      const ranges: string[] = []
+      for (let i = 0; i < sb.buffered.length; i++) {
+        ranges.push(`[${sb.buffered.start(i).toFixed(2)}-${sb.buffered.end(i).toFixed(2)}]`)
+      }
+      console.log(`[player] append #${appendCount} buffered=${ranges.join(',')} t=${(videoRef.value?.currentTime ?? 0).toFixed(2)}`)
+    }
+    const bufStart = sb.buffered.start(0)
+    const t = videoRef.value?.currentTime ?? 0
+    if (bufStart < t - 60 && !sb.updating) {
+      try { sb.remove(bufStart, Math.max(bufStart + 1, t - 30)) } catch { /* ignore */ }
+    }
+  }
+  pumpAppendQueue()
+}
+
+const MAX_BUFFER_AHEAD = 30
+function pumpAppendQueue(): void {
+  const sb = sourceBuffer
+  const ms = mediaSource
+  if (!sb || sb.updating || !ms) return
+  if (unbufferedSeekInFlight) return
+
+  if (appendQueue.length === 0) {
+    if (streamEnded && ms.readyState === 'open') {
+      try { ms.endOfStream() } catch { /* ignore */ }
+    }
+    return
+  }
+
+  // Throttle: stop pumping once we have enough lead ahead of the playhead.
+  // Without this, SourceBuffer fills to the Chromium quota and eviction would
+  // remove the [0, 1] keyframe the playhead is still stuck on, leaving a gap.
+  if (sb.buffered.length > 0) {
+    const t = videoRef.value?.currentTime ?? 0
+    const lead = sb.buffered.end(sb.buffered.length - 1) - t
+    if (lead > MAX_BUFFER_AHEAD) return
+  }
+
+  const v = videoRef.value
+  if (v && v.error) return
+  const chunk = appendQueue.shift()!
+  try {
+    sb.appendBuffer(chunk as unknown as BufferSource)
+    pendingAckBytes += chunk.byteLength
+    if (pendingAckBytes >= STREAM_ACK_THRESHOLD && streamSessionId.value) {
+      const bytes = pendingAckBytes
+      pendingAckBytes = 0
+      window.api.playerStreamAck(streamSessionId.value, bytes)
+    }
+  } catch (e) {
+    const err = e as DOMException
+    if (err.name === 'QuotaExceededError') {
+      appendQueue.unshift(chunk)
+      // Only evict data strictly behind the playhead. Never drop the range
+      // the video element is currently sitting inside, or playback stalls.
+      const t = videoRef.value?.currentTime ?? 0
+      if (sb.buffered.length > 0 && !sb.updating) {
+        const bufStart = sb.buffered.start(0)
+        const removeUntil = t - 5
+        if (removeUntil > bufStart + 1) {
+          try { sb.remove(bufStart, removeUntil) } catch { /* ignore */ }
+        }
+      }
+    } else {
+      console.error('[player] appendBuffer failed:', err)
+    }
+  }
+}
+
+let unbufferedSeekInFlight = false
+let respawnDebounceTimer: ReturnType<typeof setTimeout> | null = null
+const RESPAWN_DEBOUNCE_MS = 250
+
+function maybeRespawnForUnbufferedPosition(): void {
+  const v = videoRef.value
+  const sb = sourceBuffer
+  if (!v || !sb || !streamSessionId.value) return
+  // Debounce. Check `currentTime` vs buffered ranges only when the timer fires,
+  // so a burst of rapid seeks coalesces into one respawn at the final target.
+  if (respawnDebounceTimer) clearTimeout(respawnDebounceTimer)
+  respawnDebounceTimer = setTimeout(() => {
+    respawnDebounceTimer = null
+    if (unbufferedSeekInFlight) return
+    const cur = videoRef.value
+    const curSb = sourceBuffer
+    if (!cur || !curSb) return
+    const t = cur.currentTime
+    for (let i = 0; i < curSb.buffered.length; i++) {
+      if (t >= curSb.buffered.start(i) - 0.25 && t <= curSb.buffered.end(i) + 0.25) return
+    }
+    // Nothing buffered yet (fresh respawn) — wait for data.
+    if (curSb.buffered.length === 0) return
+    handleUnbufferedSeek()
+  }, RESPAWN_DEBOUNCE_MS)
+}
+
+async function handleUnbufferedSeek(): Promise<void> {
+  const v = videoRef.value
+  const sb = sourceBuffer
+  if (!v || !sb || !streamSessionId.value) return
+  const target = v.currentTime
+  // If the target falls inside any existing buffered range, the video element
+  // handles the seek natively — nothing to do.
+  for (let i = 0; i < sb.buffered.length; i++) {
+    if (target >= sb.buffered.start(i) - 0.25 && target <= sb.buffered.end(i) + 0.25) {
+      return
+    }
+  }
+  if (unbufferedSeekInFlight) return
+  unbufferedSeekInFlight = true
+  const seekAt = Math.max(0, target - 1)
+  console.log(`[player] unbuffered seek → respawn ffmpeg at ${seekAt.toFixed(2)} (target ${target.toFixed(2)})`)
+  try {
+    // Drop any queued chunks from the old ffmpeg — main will stop sending new
+    // ones as soon as the seek IPC below bumps the session generation.
+    appendQueue.length = 0
+    pendingAckBytes = 0
+    const result = await window.api.playerStreamSeek(streamSessionId.value, seekAt)
+    if ('error' in result) {
+      console.error('[player] stream-seek failed:', result.error)
+      return
+    }
+    // Reset the SourceBuffer segment parser. Without this, an interrupted
+    // append leaves the parser in PARSING_MEDIA_SEGMENT and any subsequent
+    // timestampOffset change or appendBuffer throws. abort() also cancels
+    // any in-flight update, so no updateend wait is needed.
+    try { sb.abort() } catch (e) { console.warn('[player] sb.abort failed:', e) }
+    // Drop old buffered data so the previous audio ahead of us doesn't keep
+    // playing while the new fragments arrive and decode.
+    try {
+      if (sb.buffered.length > 0) {
+        sb.remove(sb.buffered.start(0), sb.buffered.end(sb.buffered.length - 1))
+        await new Promise<void>((res) => sb.addEventListener('updateend', () => res(), { once: true }))
+      }
+    } catch (e) {
+      console.warn('[player] buffer clear failed:', e)
+    }
+    if (v.error) {
+      console.error('[player] video element errored during seek:', v.error.code, v.error.message)
+      return
+    }
+    try {
+      sb.timestampOffset = seekAt
+    } catch (e) {
+      console.warn('[player] timestampOffset set failed:', e)
+    }
+    // Release main's buffered prelude for the new ffmpeg run.
+    window.api.playerStreamStart(streamSessionId.value)
+  } finally {
+    unbufferedSeekInFlight = false
+    // If the user kept seeking while the respawn was in flight, the playhead
+    // may now be outside the fresh buffered range too — re-check.
+    maybeRespawnForUnbufferedPosition()
+  }
+}
+
+let chunkRecvCount = 0
+let chunkRecvBytes = 0
+function handleStreamChunk(sessionId: string, data: Uint8Array): void {
+  if (sessionId !== streamSessionId.value) return
+  const u8 = data instanceof Uint8Array ? data : new Uint8Array(data)
+  chunkRecvCount++
+  chunkRecvBytes += u8.byteLength
+  if (chunkRecvCount === 1 || chunkRecvCount % 200 === 0) {
+    console.log(`[player] recv chunk #${chunkRecvCount} total=${(chunkRecvBytes / 1024 / 1024).toFixed(1)}MB queue=${appendQueue.length}`)
+  }
+  appendQueue.push(u8)
+  pumpAppendQueue()
+}
+
+function handleStreamEnd(sessionId: string): void {
+  if (sessionId !== streamSessionId.value) return
+  streamEnded = true
+  pumpAppendQueue()
+}
+
+function handleStreamError(sessionId: string, error: string): void {
+  if (sessionId !== streamSessionId.value) return
+  console.error('[player] stream error:', error)
+  remuxError.value = error
+  resetMseState()
+}
+
+function resetMseState(): void {
+  streamEnded = false
+  pendingAckBytes = 0
+  appendQueue.length = 0
+  mseInitialSeek = 0
+  if (sourceBuffer) {
+    try { sourceBuffer.removeEventListener('updateend', onSourceBufferUpdateEnd) } catch { /* ignore */ }
+    sourceBuffer = null
+  }
+  if (mediaSource && mediaSource.readyState === 'open') {
+    try { mediaSource.endOfStream() } catch { /* ignore */ }
+  }
+  mediaSource = null
+  if (mseSrcUrl.value) {
+    try { URL.revokeObjectURL(mseSrcUrl.value) } catch { /* ignore */ }
+    mseSrcUrl.value = ''
+  }
+}
 
 function formatTime(seconds: number): string {
   if (!isFinite(seconds) || seconds < 0) return '0:00'
@@ -382,6 +686,10 @@ function onProgress(): void {
   const video = videoRef.value
   if (!video || video.buffered.length === 0) return
   buffered.value = video.buffered.end(video.buffered.length - 1)
+}
+
+function onCanPlay(): void {
+  if (mkvBuffering.value) mkvBuffering.value = false
 }
 
 function onSeekStart(): void {
@@ -815,10 +1123,12 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
       if (localResult) {
         activeTranslationId.value = tr.id
 
-        // Clean up previous remux if any
-        if (remuxStreamId.value) {
+        // Clean up previous remux / stream session if any
+        if (remuxedPath.value || streamSessionId.value) {
           await window.api.playerCleanupRemux()
-          remuxStreamId.value = ''
+          remuxedPath.value = ''
+          streamSessionId.value = ''
+          resetMseState()
         }
 
         // Switch to local file
@@ -826,24 +1136,13 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
         activeStreamUrl.value = ''
         activeSubtitleContent.value = localResult.subtitleContent || ''
 
-        // Remux MKV if needed
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
-          remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkvStream(localResult.filePath)
-          if ('error' in remuxResult) {
-            remuxError.value = remuxResult.error
-            remuxing.value = false
+          const prep = await prepareMkvForPlayback(localResult.filePath)
+          if (!prep.ok) {
+            remuxError.value = prep.error
             switchingTranslation.value = false
             return
           }
-          remuxStreamId.value = remuxResult.sessionId
-          if (videoRef.value) videoRef.value.pause() // Prevent autoplay while fetching subs
-          
-          const subContent = await window.api.playerGetRemuxSubtitles(remuxResult.sessionId)
-          if (subContent && !activeSubtitleContent.value) {
-            activeSubtitleContent.value = subContent
-          }
-          remuxing.value = false
         }
 
         // Update subtitles
@@ -872,10 +1171,12 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
 
     activeTranslationId.value = tr.id
 
-    // Clean up previous remux if switching from local to stream
-    if (remuxStreamId.value) {
+    // Clean up previous remux / MSE stream if switching from local to stream
+    if (remuxedPath.value || streamSessionId.value) {
       await window.api.playerCleanupRemux()
-      remuxStreamId.value = ''
+      remuxedPath.value = ''
+      streamSessionId.value = ''
+      resetMseState()
     }
 
     activeFilePath.value = ''
@@ -969,10 +1270,12 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
   }
 
   try {
-    // Clean up previous remux
-    if (remuxStreamId.value) {
+    // Clean up previous remux / MSE stream
+    if (remuxedPath.value || streamSessionId.value) {
       await window.api.playerCleanupRemux()
-      remuxStreamId.value = ''
+      remuxedPath.value = ''
+      streamSessionId.value = ''
+      resetMseState()
     }
 
     // Update episode state
@@ -993,22 +1296,18 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
         activeSubtitleContent.value = localResult.subtitleContent || ''
 
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
-          remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkvStream(localResult.filePath)
-          if ('error' in remuxResult) {
-            remuxError.value = remuxResult.error
-            remuxing.value = false
+          if (remuxedPath.value || streamSessionId.value) {
+            await window.api.playerCleanupRemux()
+            remuxedPath.value = ''
+            streamSessionId.value = ''
+            resetMseState()
+          }
+          const prep = await prepareMkvForPlayback(localResult.filePath)
+          if (!prep.ok) {
+            remuxError.value = prep.error
             navigating.value = false
             return
           }
-          remuxStreamId.value = remuxResult.sessionId
-          if (videoRef.value) videoRef.value.pause()
-          
-          const subContent = await window.api.playerGetRemuxSubtitles(remuxResult.sessionId)
-          if (subContent && !activeSubtitleContent.value) {
-            activeSubtitleContent.value = subContent
-          }
-          remuxing.value = false
         }
 
         destroySubtitles()
@@ -1115,31 +1414,51 @@ onMounted(async () => {
   const savedShortcuts = await window.api.getSetting('keyboardShortcuts') as Record<string, string> | null
   if (savedShortcuts) playerShortcuts.value = savedShortcuts
 
-  // Remux MKV to MP4 if needed
+  // Subtitles extracted from MKV streams arrive asynchronously via IPC.
+  window.api.onPlayerStreamSubtitles(({ sessionId, content }) => {
+    if (sessionId !== streamSessionId.value) return
+    if (activeSubtitleContent.value) return
+    activeSubtitleContent.value = content
+    const v = videoRef.value
+    if (v) {
+      destroySubtitles()
+      initSubtitles(v)
+    }
+  })
+
+  // MSE fragmented MP4 chunks / end / error events.
+  window.api.onPlayerStreamChunk(({ sessionId, data }) => handleStreamChunk(sessionId, data))
+  window.api.onPlayerStreamEnd(({ sessionId }) => handleStreamEnd(sessionId))
+  window.api.onPlayerStreamError(({ sessionId, error }) => handleStreamError(sessionId, error))
+
+  // Diagnostic listeners on the video element to see why MSE playback stalls.
+  watch(videoRef, (v) => {
+    if (!v) return
+    v.addEventListener('waiting', () => console.warn(`[player] video 'waiting' t=${v.currentTime.toFixed(2)} readyState=${v.readyState}`))
+    v.addEventListener('stalled', () => console.warn(`[player] video 'stalled' t=${v.currentTime.toFixed(2)} readyState=${v.readyState}`))
+    v.addEventListener('error', () => {
+      const e = v.error
+      console.error(`[player] video element error: code=${e?.code} message=${e?.message} networkState=${v.networkState} readyState=${v.readyState}`)
+    })
+    v.addEventListener('timeupdate', () => pumpAppendQueue())
+    // Fires on every seek attempt (slider drag, arrow-key auto-repeat). Debounce
+    // so a burst collapses into one respawn at the final target — native seeks
+    // inside the buffered range are filtered out in the debounced callback.
+    v.addEventListener('seeking', () => maybeRespawnForUnbufferedPosition())
+  }, { immediate: true })
+
+  // Start MKV remux stream (or fall back to legacy full remux)
   if (isMkv.value && props.filePath) {
-    remuxing.value = true
-    remuxError.value = ''
     try {
-      const result = await window.api.playerRemuxMkvStream(props.filePath)
-      if ('error' in result) {
-        remuxError.value = result.error
-        remuxing.value = false
+      const prep = await prepareMkvForPlayback(props.filePath)
+      if (!prep.ok) {
+        remuxError.value = prep.error
         return
-      }
-      remuxStreamId.value = result.sessionId
-      if (videoRef.value) videoRef.value.pause()
-      
-      const subContent = await window.api.playerGetRemuxSubtitles(result.sessionId)
-      if (subContent && !activeSubtitleContent.value) {
-        activeSubtitleContent.value = subContent
       }
     } catch (e) {
       remuxError.value = String(e)
-      remuxing.value = false
       return
     }
-    remuxing.value = false
-    if (videoRef.value) videoRef.value.play() // Resume playback if it was ready
   }
 
   // Initialize quality from available streams
@@ -1205,8 +1524,14 @@ onBeforeUnmount(() => {
     gpuDevice.destroy()
     gpuDevice = null
   }
-  // Clean up remuxed temp files
-  if (remuxStreamId.value) {
+  // Stop listening for stream events
+  window.api.offPlayerStreamSubtitles()
+  window.api.offPlayerStreamChunk()
+  window.api.offPlayerStreamEnd()
+  window.api.offPlayerStreamError()
+  resetMseState()
+  // Clean up remuxed temp files / active stream sessions
+  if (remuxedPath.value || streamSessionId.value) {
     window.api.playerCleanupRemux()
   }
 })
@@ -1229,7 +1554,7 @@ const bufferedProgress = computed(() => {
     @mousemove="onMouseMove"
     @click.self="togglePlay"
   >
-    <!-- Remuxing MKV overlay -->
+    <!-- Remuxing MKV overlay (legacy full-remux fallback only) -->
     <div v-if="remuxing" class="remux-overlay">
       <div class="remux-modal">
         <div class="remux-spinner"></div>
@@ -1237,6 +1562,13 @@ const bufferedProgress = computed(() => {
         <p class="remux-hint">Remuxing to MP4 (stream copy, no re-encoding)</p>
       </div>
     </div>
+
+    <!-- Streaming MKV: subtle toast while the first seconds buffer -->
+    <transition name="fade">
+      <div v-if="mkvBuffering" class="mkv-buffering-toast">
+        Buffering MKV…
+      </div>
+    </transition>
 
     <!-- Remux error overlay -->
     <div v-if="remuxError" class="remux-overlay">
@@ -1272,7 +1604,7 @@ const bufferedProgress = computed(() => {
     <div class="video-wrapper">
       <video
         ref="videoRef"
-        :src="videoSrc"
+        :src="videoSrc || undefined"
         :class="{ hidden: anime4kActive }"
         class="player-video"
         crossorigin="anonymous"
@@ -1281,6 +1613,7 @@ const bufferedProgress = computed(() => {
         @timeupdate="onTimeUpdate"
         @durationchange="onDurationChange"
         @progress="onProgress"
+        @canplay="onCanPlay"
         @ended="onVideoEnded"
         @click="togglePlay"
         @dblclick="toggleFullscreen"
@@ -1582,6 +1915,19 @@ const bufferedProgress = computed(() => {
   background: rgba(15, 52, 96, 0.9);
   color: #e0e0e0;
   padding: 6px 16px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  z-index: 10;
+  pointer-events: none;
+}
+
+.mkv-buffering-toast {
+  position: absolute;
+  top: 100px;
+  right: 24px;
+  background: rgba(15, 52, 96, 0.85);
+  color: #e0e0e0;
+  padding: 6px 14px;
   border-radius: 6px;
   font-size: 0.8rem;
   z-index: 10;

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -58,7 +58,7 @@ const activeFilePath = ref(props.filePath)
 const isMkv = computed(() => !!activeFilePath.value && activeFilePath.value.toLowerCase().endsWith('.mkv'))
 const remuxing = ref(false)
 const remuxError = ref('')
-const remuxedPath = ref('')
+const remuxStreamId = ref('')
 
 // Quality selector state
 const activeStreamUrl = ref(props.streamUrl)
@@ -254,10 +254,10 @@ fn main(@builtin(position) coord: vec4f) -> @location(0) vec4f {
 
 const videoSrc = computed(() => {
   if (activeFilePath.value) {
-    // For MKV files, use the remuxed MP4 path
+    // For MKV files, use the remuxed MP4 stream
     if (isMkv.value) {
-      if (remuxedPath.value) {
-        return 'anime-video://' + encodeURIComponent(remuxedPath.value)
+      if (remuxStreamId.value) {
+        return 'anime-video://stream/?id=' + encodeURIComponent(remuxStreamId.value)
       }
       return '' // Not ready yet — remuxing in progress
     }
@@ -816,9 +816,9 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
         activeTranslationId.value = tr.id
 
         // Clean up previous remux if any
-        if (remuxedPath.value) {
+        if (remuxStreamId.value) {
           await window.api.playerCleanupRemux()
-          remuxedPath.value = ''
+          remuxStreamId.value = ''
         }
 
         // Switch to local file
@@ -829,17 +829,21 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
         // Remux MKV if needed
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
           remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkv(localResult.filePath)
-          remuxing.value = false
+          const remuxResult = await window.api.playerRemuxMkvStream(localResult.filePath)
           if ('error' in remuxResult) {
             remuxError.value = remuxResult.error
+            remuxing.value = false
             switchingTranslation.value = false
             return
           }
-          remuxedPath.value = remuxResult.mp4Path
-          if (!activeSubtitleContent.value && remuxResult.subtitleContent) {
-            activeSubtitleContent.value = remuxResult.subtitleContent
+          remuxStreamId.value = remuxResult.sessionId
+          if (videoRef.value) videoRef.value.pause() // Prevent autoplay while fetching subs
+          
+          const subContent = await window.api.playerGetRemuxSubtitles(remuxResult.sessionId)
+          if (subContent && !activeSubtitleContent.value) {
+            activeSubtitleContent.value = subContent
           }
+          remuxing.value = false
         }
 
         // Update subtitles
@@ -869,9 +873,9 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
     activeTranslationId.value = tr.id
 
     // Clean up previous remux if switching from local to stream
-    if (remuxedPath.value) {
+    if (remuxStreamId.value) {
       await window.api.playerCleanupRemux()
-      remuxedPath.value = ''
+      remuxStreamId.value = ''
     }
 
     activeFilePath.value = ''
@@ -966,9 +970,9 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
 
   try {
     // Clean up previous remux
-    if (remuxedPath.value) {
+    if (remuxStreamId.value) {
       await window.api.playerCleanupRemux()
-      remuxedPath.value = ''
+      remuxStreamId.value = ''
     }
 
     // Update episode state
@@ -990,17 +994,21 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
 
         if (localResult.filePath.toLowerCase().endsWith('.mkv')) {
           remuxing.value = true
-          const remuxResult = await window.api.playerRemuxMkv(localResult.filePath)
-          remuxing.value = false
+          const remuxResult = await window.api.playerRemuxMkvStream(localResult.filePath)
           if ('error' in remuxResult) {
             remuxError.value = remuxResult.error
+            remuxing.value = false
             navigating.value = false
             return
           }
-          remuxedPath.value = remuxResult.mp4Path
-          if (!activeSubtitleContent.value && remuxResult.subtitleContent) {
-            activeSubtitleContent.value = remuxResult.subtitleContent
+          remuxStreamId.value = remuxResult.sessionId
+          if (videoRef.value) videoRef.value.pause()
+          
+          const subContent = await window.api.playerGetRemuxSubtitles(remuxResult.sessionId)
+          if (subContent && !activeSubtitleContent.value) {
+            activeSubtitleContent.value = subContent
           }
+          remuxing.value = false
         }
 
         destroySubtitles()
@@ -1112,15 +1120,18 @@ onMounted(async () => {
     remuxing.value = true
     remuxError.value = ''
     try {
-      const result = await window.api.playerRemuxMkv(props.filePath)
+      const result = await window.api.playerRemuxMkvStream(props.filePath)
       if ('error' in result) {
         remuxError.value = result.error
         remuxing.value = false
         return
       }
-      remuxedPath.value = result.mp4Path
-      if (!activeSubtitleContent.value && result.subtitleContent) {
-        activeSubtitleContent.value = result.subtitleContent
+      remuxStreamId.value = result.sessionId
+      if (videoRef.value) videoRef.value.pause()
+      
+      const subContent = await window.api.playerGetRemuxSubtitles(result.sessionId)
+      if (subContent && !activeSubtitleContent.value) {
+        activeSubtitleContent.value = subContent
       }
     } catch (e) {
       remuxError.value = String(e)
@@ -1128,6 +1139,7 @@ onMounted(async () => {
       return
     }
     remuxing.value = false
+    if (videoRef.value) videoRef.value.play() // Resume playback if it was ready
   }
 
   // Initialize quality from available streams
@@ -1194,7 +1206,7 @@ onBeforeUnmount(() => {
     gpuDevice = null
   }
   // Clean up remuxed temp files
-  if (remuxedPath.value) {
+  if (remuxStreamId.value) {
     window.api.playerCleanupRemux()
   }
 })

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -602,12 +602,16 @@ watch(anime4kPreset, (val) => { if (loaded.value) autoSave('anime4kPreset', val)
           <p class="setting-hint">Version {{ appVersion }}</p>
 
           <button
-            v-if="updateStatus.status === 'idle' || updateStatus.status === 'up-to-date' || updateStatus.status === 'error'"
+            v-if="(updateStatus.status === 'idle' || updateStatus.status === 'up-to-date' || updateStatus.status === 'error') && !appVersion.includes('-nightly')"
             class="test-token-btn"
             @click="checkForUpdates"
           >
             Check for updates
           </button>
+
+          <span v-else-if="appVersion.includes('-nightly')" class="setting-hint" style="color: var(--color-text-dim)">
+            Update check disabled for nightly builds
+          </span>
 
           <span v-else-if="updateStatus.status === 'checking'" class="setting-hint" style="margin-bottom: 0">Checking...</span>
 


### PR DESCRIPTION
## Description
This PR implements streaming MKV playback to eliminate the long wait times (10-20 seconds) previously required for a full file remux.

Opening an MKV file will now start playback almost instantly, while the remux process continues in the background.

## Key Changes
**Streaming Remux IPC:** Replaced `player:remux-mkv` with a new `player:remux-mkv-stream` handler in `main/index.ts`. This spawns ffmpeg with `-movflags +frag_keyframe+empty_moov -f mp4 pipe:1`, outputting a streamable fragmented MP4 directly to stdout.
**Protocol Handler Update:** Updated the `anime-video://` protocol handler to support `anime-video://stream/{sessionId}`. It now pipes the buffered stdout data from ffmpeg directly to the video element.
**Seamless Seeking:** The handler intelligently writes the output to a temp file simultaneously. Range requests seamlessly transition between the live stream buffer and the temp file once enough data has been remuxed.
**Subtitles:** Subtitle extraction continues to run in parallel and resolves as soon as it's ready.
**Cleanup:** Active remux sessions and streams are properly tracked and killed upon player close or translation switch.
**Renderer Updates:** `PlayerView.vue` now immediately mounts the stream URL instead of blocking the video source until the remux completes.

## Fixes
* Closes TODO item #1: "Stream MKV Playback Without Full Remux Wait"