### PR TITLE
Potential fix for code scanning alert no. 5: Cache Poisoning via execution of untrusted code

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -50,7 +50,10 @@ jobs:
 
       - run: npx electron-vite build
 
-      - run: npx electron-builder ${{ matrix.args }} -c.publish=null
+      # IMPORTANT: do NOT change to `-c.publish=null`. electron-builder parses
+      # that as the literal publisher name "null" and fails with
+      # "Cannot find module for publisher 'null'". Always use `--publish never`.
+      - run: npx electron-builder ${{ matrix.args }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: ${{ github.event_name == 'pull_request' && 'npm' || '' }}
 
       - run: npm ci
 


### PR DESCRIPTION
Potential fix for [https://github.com/mikkerlo/anime-downloader/security/code-scanning/5](https://github.com/mikkerlo/anime-downloader/security/code-scanning/5)

General fix: prevent cache restore/save when running untrusted PR code from comment-triggered events. In GitHub Actions, the most robust low-impact change here is to make `actions/setup-node` caching conditional and disable it for `issue_comment`.

Best single fix without changing functional behavior: keep Node setup the same but change `cache: npm` to only apply on `pull_request`, and set empty cache value for `issue_comment`. This preserves faster builds for normal PR events while removing cache poisoning vector in the risky path.

Edit only `.github/workflows/check.yml`, in the `build` job, `actions/setup-node@v4` step (lines around 42–46).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
