### PR TITLE
Player UX: volume persistence, streaming toast, subtitle auto-pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,8 @@ const store = new Store({
     autoMoveToCold: false,
     malIdMap: {} as Record<string, AnimeSearchResult>,
     playerMode: 'system' as 'system' | 'builtin',
+    playerVolume: 1 as number,
+    playerMuted: false,
     anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
     watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>
   }

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -262,6 +262,35 @@ onMounted(async () => {
     dataSource.value = res.source
     await loadPageEpisodes()
     await checkFileStatus()
+    // If the user hasn't explicitly picked a translation type on this anime
+    // before, and something is already downloaded, prefer the (type, author)
+    // of the downloaded file(s) over the global settings default.
+    if (!props.initialPrefs?.translationType) {
+      const counts = new Map<string, number>()
+      for (const metaArr of Object.values(episodeMeta.value)) {
+        for (const m of metaArr) {
+          const key = `${m.translationType}\u0000${m.author}`
+          counts.set(key, (counts.get(key) || 0) + 1)
+        }
+      }
+      if (counts.size > 0) {
+        let bestKey = ''
+        let bestCount = 0
+        for (const [key, count] of counts) {
+          if (count > bestCount) { bestKey = key; bestCount = count }
+        }
+        if (bestKey) {
+          const [bestType, bestAuthor] = bestKey.split('\u0000')
+          translationType.value = bestType
+          // Only override selectedAuthor if the downloaded author is still
+          // offered for this type — the translation may have been deactivated
+          // or removed upstream, which would leave the <select> blank.
+          if (bestAuthor && availableAuthors.value.some(([a]) => a === bestAuthor)) {
+            selectedAuthor.value = bestAuthor
+          }
+        }
+      }
+    }
   } catch (err) {
     console.error('Failed to load anime detail view:', err)
   } finally {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -50,7 +50,6 @@ const anime4kActive = computed(() => webgpuAvailable.value && anime4kPreset.valu
 const showControls = ref(true)
 const showPresetMenu = ref(false)
 const showQualityMenu = ref(false)
-const isStreaming = computed(() => !!activeStreamUrl.value && !activeFilePath.value)
 let controlsTimer: ReturnType<typeof setTimeout> | null = null
 
 // MKV remux state
@@ -83,6 +82,25 @@ const STREAM_ACK_THRESHOLD = 1 * 1024 * 1024
 const activeStreamUrl = ref(props.streamUrl)
 const selectedHeight = ref(0)
 const hasQualities = computed(() => props.availableStreams.length > 0)
+
+const isStreaming = computed(() => !!activeStreamUrl.value && !activeFilePath.value)
+const streamingBannerVisible = ref(false)
+let streamingBannerTimer: ReturnType<typeof setTimeout> | null = null
+watch(isStreaming, (streaming) => {
+  if (streamingBannerTimer) {
+    clearTimeout(streamingBannerTimer)
+    streamingBannerTimer = null
+  }
+  if (streaming) {
+    streamingBannerVisible.value = true
+    streamingBannerTimer = setTimeout(() => {
+      streamingBannerTimer = null
+      streamingBannerVisible.value = false
+    }, 3500)
+  } else {
+    streamingBannerVisible.value = false
+  }
+}, { immediate: true })
 
 // Translation selector state
 const showTranslationMenu = ref(false)
@@ -656,6 +674,18 @@ function toggleMute(): void {
   muted.value = !muted.value
   video.muted = muted.value
 }
+
+let persistVolumeTimer: ReturnType<typeof setTimeout> | null = null
+let suppressVolumePersist = true  // don't write the restored values back on mount
+watch([volume, muted], ([v, m]) => {
+  if (suppressVolumePersist) return
+  if (persistVolumeTimer) clearTimeout(persistVolumeTimer)
+  persistVolumeTimer = setTimeout(() => {
+    persistVolumeTimer = null
+    window.api.setSetting('playerVolume', v)
+    window.api.setSetting('playerMuted', m)
+  }, 400)
+})
 
 function toggleFullscreen(): void {
   if (!document.fullscreenElement) {
@@ -1526,12 +1556,26 @@ onMounted(async () => {
     anime4kPreset.value = savedPreset as typeof anime4kPreset.value
   }
 
+  // Restore saved volume + mute
+  const savedVolume = await window.api.getSetting('playerVolume') as number | null
+  if (typeof savedVolume === 'number' && savedVolume >= 0 && savedVolume <= 1) {
+    volume.value = savedVolume
+  }
+  const savedMuted = await window.api.getSetting('playerMuted') as boolean | null
+  if (typeof savedMuted === 'boolean') {
+    muted.value = savedMuted
+  }
+  await nextTick()
+  suppressVolumePersist = false
+
   await initWebGPU()
 
   // Wait for video to be ready, then start pipeline if needed
   await nextTick()
   const video = videoRef.value
   if (video) {
+    video.volume = volume.value
+    video.muted = muted.value
     const onVideoReady = async (): Promise<void> => {
       if (anime4kPreset.value !== 'off' && webgpuAvailable.value) {
         await startAnime4KPipeline()
@@ -1563,6 +1607,14 @@ onBeforeUnmount(() => {
   document.removeEventListener('fullscreenchange', onFullscreenChange)
   window.removeEventListener('mouseup', onMouseBack, true)
   if (controlsTimer) clearTimeout(controlsTimer)
+  if (streamingBannerTimer) {
+    clearTimeout(streamingBannerTimer)
+    streamingBannerTimer = null
+  }
+  if (persistVolumeTimer) {
+    clearTimeout(persistVolumeTimer)
+    persistVolumeTimer = null
+  }
   cancelAutoAdvance()
   stopAnime4KPipeline()
   destroySubtitles()
@@ -1645,7 +1697,7 @@ const bufferedProgress = computed(() => {
 
     <!-- Streaming warning banner -->
     <transition name="fade">
-      <div v-if="isStreaming" class="streaming-banner">
+      <div v-if="streamingBannerVisible" class="streaming-banner">
         Streaming from server
       </div>
     </transition>


### PR DESCRIPTION
## Summary
- **Volume persistence**: player volume + mute are now saved under new `playerVolume` / `playerMuted` settings (400 ms debounced writes) and restored on every mount, so adjusting the slider once sticks across episodes and restarts.
- **Streaming toast**: the *Streaming from server* banner auto-dismisses after 3.5 s instead of sitting on screen for the whole episode.
- **Subtitle/translation auto-pick**: when opening an anime with no per-anime translation preference stored, the detail page counts `(translationType, author)` pairs across `downloadedEpisodes` metadata and defaults the selection to the most common pair — so if you have *English Subtitles — Anime Time* downloaded, the page opens on that instead of the global `subRu` default.

## Test plan
- [x] `npm run typecheck`
- [x] Volume: set slider mid-range on episode 1, switch to episode 2 → slider keeps the value. Restart app → slider still at that value.
- [x] Streaming: open a CDN-streamed episode → banner appears, fades out after ~3.5 s, does not reappear on play/pause.
- [x] Auto-pick: on an anime with English Anime Time downloads but no stored prefs, page opens with `subEn` + Anime Time selected (previously was `subRu` + SovetRomantica).
- [x] No regression on anime with an explicit stored translation pref — those still honor the stored choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)