### PR TITLE
feat: offline Shikimori queue + "Working offline" indicator

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -289,6 +289,8 @@ LibraryView shows both with indicators:
 | `shikimori:get-anime-rates` | invoke | Returns cached anime rates instantly (if available), triggers background API refresh; first call fetches from API |
 | `shikimori:rate-updated` | send | Single rate entry changed (after update-rate); renderer views surgically update their local state |
 | `shikimori:rates-refreshed` | send | Full rate list refreshed from API in background; renderer views replace their entries |
+| `shikimori:get-offline-queue-length` | invoke | Returns the number of rate updates currently queued for later sync (for initial UI hydration) |
+| `shikimori:offline-queue-changed` | send | Queue length changed; renderers update the "Working offline" indicator |
 | `shikimori:get-friends-activity` | invoke | Fetch recent anime history for all Shikimori friends, merged + sorted, MAL IDs resolved |
 | `storage:pick-hot-dir` | invoke | Open folder picker for hot storage directory |
 | `storage:pick-cold-dir` | invoke | Open folder picker for cold storage directory |
@@ -380,6 +382,7 @@ interface EpisodeMeta {
 | `hevcTranscodeOnPlay` | string | `'ask'` | HEVC fallback when the built-in player has no decoder: `ask` (show modal), `always` (transcode to H.264), `never` (open in external player) |
 | `watchProgress` | object | `{}` | Per-episode playback position + watched flag (key: `animeId:episodeInt`) |
 | `shikimoriUserRates` | array | `[]` | Cached Shikimori anime rate entries (served cache-first, background-refreshed) |
+| `shikimoriUpdateQueue` | array | `[]` | Pending rate updates queued when the `update-rate` IPC failed due to a network error (for later sync) |
 
 ## Watch Progress & Resume
 
@@ -504,6 +507,10 @@ Standalone API client with hardcoded client credentials. All methods throw `Shik
 ### Centralized Rate Cache
 
 Anime rates are persisted in `shikimoriUserRates` (electron-store). `shikimori:get-anime-rates` returns cached data instantly when available and triggers a background API refresh; the refresh result is broadcast via `shikimori:rates-refreshed` so open views update without a manual reload. `shikimori:update-rate` patches the cached entry in-place and broadcasts `shikimori:rate-updated` for surgical single-entry updates. ShikimoriView and AnimeDetailView both listen for these broadcasts. Cache is cleared on logout.
+
+### Offline Update Queue
+
+`shikimori:update-rate` distinguishes transport-level failures (fetch threw `TypeError` / `AbortError`) from HTTP errors (wrapped as `ShikiApiError`). HTTP errors propagate to the renderer as before. Transport failures are intercepted: the previous cached state is recorded as `before`, the requested change as `after`, and a `QueuedShikimoriUpdate` (`{ malId, rateId, before, after, queuedAt }`) is appended to `shikimoriUpdateQueue` in electron-store. The cached rate entry is then updated in place with the requested values so the UI reflects the change, and `shikimori:rate-updated` + `shikimori:offline-queue-changed` are broadcast. The handler returns a synthetic `ShikiUserRate` so callers (including `PlayerView`'s auto-tracker) don't need an offline branch. `AnimeDetailView` shows a "Working offline — N changes queued" chip while the queue is non-empty; the chip hydrates from `shikimori:get-offline-queue-length` on mount. Queue is cleared on logout. Actual sync-back to Shikimori when connectivity returns is handled by the next follow-up (Conflict-Aware Automatic Sync).
 
 ### Friends Activity Feed
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,7 @@
 - [x] HEVC (H.265) Support in MSE Streaming Path — `hevcCodecString` produces `hvc1.…` for Main / Main 10 / Main Still Picture; ffmpeg spawn emits `-tag:v hvc1` so Chromium MSE accepts the track; legacy full-remux fallback still fires when the platform has no HEVC decoder
 - [x] HEVC → H.264 transcode fallback for platforms without an HEVC decoder — new `player:remux-mkv-stream-transcode` IPC re-encodes HEVC to H.264 through the existing MSE pipe; `pickH264Encoder` dry-runs `h264_vaapi` / `h264_nvenc` / `h264_qsv` / `libx264` at startup; `hevcTranscodeOnPlay` setting (ask / always / never) with consent modal and `shell:open-external-file` escape hatch
 - [x] Centralized Shikimori Cache & Surgical UI Updates — persist `shikimoriUserRates` in electron-store, cache-first `get-anime-rates`, background API refresh with `shikimori:rates-refreshed` broadcast, surgical `shikimori:rate-updated` on rate changes
+- [x] Offline Shikimori Support: Queuing & Status Indicators — intercept transport-level failures in `shikimori:update-rate`, persist `{before, after}` deltas to `shikimoriUpdateQueue`, optimistically update cache, broadcast `shikimori:offline-queue-changed`, show "Working offline" chip in AnimeDetailView
 
 ---
 
@@ -61,7 +62,7 @@
 - **Schema Design:** Must define a robust schema for `shikimoriUserRates` that includes `updatedAt` to avoid stale cache issues.
 - **IPC Overhead:** Broadcasting full rate objects for large lists (1000+ entries) may cause renderer lag; needs optimized payload or filtered broadcasts.
 
-## 2. Offline Shikimori Support: Queuing & Status Indicators
+## ~~2. Offline Shikimori Support: Queuing & Status Indicators~~ (done)
 
 **Priority:** High | **Effort:** Medium
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -84,7 +84,8 @@ const store = new Store({
     anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
     hevcTranscodeOnPlay: 'ask' as 'ask' | 'always' | 'never',
     watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>,
-    shikimoriUserRates: [] as unknown[]
+    shikimoriUserRates: [] as unknown[],
+    shikimoriUpdateQueue: [] as unknown[]
   }
 })
 
@@ -92,6 +93,46 @@ function broadcastToAll(channel: string, ...args: unknown[]): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(channel, ...args)
   }
+}
+
+const NETWORK_ERROR_CODES = new Set([
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'EPIPE',
+  'UND_ERR_SOCKET',
+  'UND_ERR_CONNECT_TIMEOUT'
+])
+
+function errorCode(err: unknown): string | undefined {
+  if (err && typeof err === 'object' && 'code' in err && typeof (err as { code: unknown }).code === 'string') {
+    return (err as { code: string }).code
+  }
+  if (err && typeof err === 'object' && 'cause' in err) {
+    return errorCode((err as { cause: unknown }).cause)
+  }
+  return undefined
+}
+
+function isNetworkError(err: unknown): boolean {
+  if (err instanceof shikimori.ShikiApiError) return false
+  if (err instanceof TypeError) return true
+  if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) return true
+  const code = errorCode(err)
+  if (code && NETWORK_ERROR_CODES.has(code)) return true
+  return false
+}
+
+interface QueuedShikimoriUpdate {
+  malId: number
+  rateId: number | null
+  before: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+  after: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+  queuedAt: number
 }
 
 // --- Anime cache helpers (for offline support of downloaded anime) ---
@@ -1236,6 +1277,8 @@ function registerIpcHandlers(): void {
     store.set('shikimoriCredentials', null)
     store.set('shikimoriUser', null)
     store.set('shikimoriUserRates', [])
+    store.set('shikimoriUpdateQueue', [])
+    broadcastToAll('shikimori:offline-queue-changed', { length: 0 })
   })
 
   ipcMain.handle('shikimori:get-user', () => {
@@ -1252,35 +1295,77 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     'shikimori:update-rate',
     async (_event, malId: number, episodes: number, status: shikimori.ShikiUserRateStatus, score: number) => {
-      const accessToken = await shikimori.ensureFreshToken(store)
       const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
       if (!user) throw new Error('Not logged in to Shikimori')
-      const existing = await shikimori.getUserRate(accessToken, user.id, malId)
-      const updatedRate = existing
-        ? await shikimori.updateUserRate(accessToken, existing.id, episodes, status, score)
-        : await shikimori.createUserRate(accessToken, user.id, malId, episodes, status, score)
 
-      const cached = store.get('shikimoriUserRates') as { rate: Record<string, unknown> & { target_id: number }; shikiAnime: unknown; smotretAnime: unknown }[]
+      const cached = store.get('shikimoriUserRates') as { rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number }; shikiAnime: unknown; smotretAnime: unknown }[]
       const idx = cached.findIndex((e) => e.rate.target_id === malId)
-      if (idx !== -1) {
+
+      try {
+        const accessToken = await shikimori.ensureFreshToken(store)
+        const existing = await shikimori.getUserRate(accessToken, user.id, malId)
+        const updatedRate = existing
+          ? await shikimori.updateUserRate(accessToken, existing.id, episodes, status, score)
+          : await shikimori.createUserRate(accessToken, user.id, malId, episodes, status, score)
+
+        if (idx !== -1) {
+          cached[idx] = {
+            ...cached[idx],
+            rate: {
+              id: updatedRate.id,
+              score: updatedRate.score,
+              status: updatedRate.status,
+              episodes: updatedRate.episodes,
+              updated_at: new Date().toISOString(),
+              target_id: updatedRate.target_id
+            }
+          }
+          store.set('shikimoriUserRates', cached)
+          broadcastToAll('shikimori:rate-updated', cached[idx])
+        } else {
+          refreshShikimoriRatesInBackground()
+        }
+
+        return updatedRate
+      } catch (err) {
+        if (!isNetworkError(err) || idx === -1) throw err
+
+        const cachedEntry = cached[idx]
+        const rateId = typeof cachedEntry.rate.id === 'number' ? cachedEntry.rate.id : null
+        const before = {
+          episodes: cachedEntry.rate.episodes,
+          status: cachedEntry.rate.status,
+          score: cachedEntry.rate.score
+        }
+        const after = { episodes, status, score }
+
+        const queue = store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]
+        queue.push({ malId, rateId, before, after, queuedAt: Date.now() })
+        store.set('shikimoriUpdateQueue', queue)
+
         cached[idx] = {
-          ...cached[idx],
+          ...cachedEntry,
           rate: {
-            id: updatedRate.id,
-            score: updatedRate.score,
-            status: updatedRate.status,
-            episodes: updatedRate.episodes,
-            updated_at: new Date().toISOString(),
-            target_id: updatedRate.target_id
+            ...cachedEntry.rate,
+            episodes,
+            status,
+            score,
+            updated_at: new Date().toISOString()
           }
         }
         store.set('shikimoriUserRates', cached)
         broadcastToAll('shikimori:rate-updated', cached[idx])
-      } else {
-        refreshShikimoriRatesInBackground()
-      }
+        broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
 
-      return updatedRate
+        return {
+          id: rateId ?? -1,
+          score,
+          status,
+          episodes,
+          target_id: malId,
+          target_type: 'Anime'
+        } satisfies shikimori.ShikiUserRate
+      }
     }
   )
 
@@ -1335,6 +1420,10 @@ function registerIpcHandlers(): void {
       }
     }
     return fetchAndCacheShikimoriRates(status)
+  })
+
+  ipcMain.handle('shikimori:get-offline-queue-length', () => {
+    return (store.get('shikimoriUpdateQueue') as unknown[]).length
   })
 
   ipcMain.handle('shikimori:get-friends-activity', async () => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -193,6 +193,14 @@ const api = {
   offShikimoriRatesRefreshed: () => {
     ipcRenderer.removeAllListeners('shikimori:rates-refreshed')
   },
+  shikimoriGetOfflineQueueLength: () =>
+    ipcRenderer.invoke('shikimori:get-offline-queue-length') as Promise<number>,
+  onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => {
+    ipcRenderer.on('shikimori:offline-queue-changed', (_event, data) => callback(data))
+  },
+  offShikimoriOfflineQueueChanged: () => {
+    ipcRenderer.removeAllListeners('shikimori:offline-queue-changed')
+  },
 
   // Updates
   appVersion: () => ipcRenderer.invoke('app:version'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -128,6 +128,9 @@ interface Api {
   offShikimoriRateUpdated: () => void
   onShikimoriRatesRefreshed: (callback: (entries: ShikiAnimeRateEntry[]) => void) => void
   offShikimoriRatesRefreshed: () => void
+  shikimoriGetOfflineQueueLength: () => Promise<number>
+  onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => void
+  offShikimoriOfflineQueueChanged: () => void
 
   // Updates
   appVersion: () => Promise<string>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -35,6 +35,7 @@ const shikiScore = ref(0)
 const shikiLoading = ref(false)
 const shikiSaving = ref(false)
 const shikiError = ref('')
+const offlineQueueLength = ref(0)
 
 // Friends state
 const friendsRates = ref<ShikiFriendRate[]>([])
@@ -366,6 +367,13 @@ onMounted(async () => {
       shikiScore.value = match.rate.score
     }
   })
+
+  window.api.shikimoriGetOfflineQueueLength().then((n) => {
+    offlineQueueLength.value = n
+  })
+  window.api.onShikimoriOfflineQueueChanged((data) => {
+    offlineQueueLength.value = data.length
+  })
 })
 
 onUnmounted(() => {
@@ -375,6 +383,7 @@ onUnmounted(() => {
   window.api.offFileEpisodesChanged()
   window.api.offShikimoriRateUpdated()
   window.api.offShikimoriRatesRefreshed()
+  window.api.offShikimoriOfflineQueueChanged()
 })
 
 const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
@@ -1016,6 +1025,12 @@ function typeChip(type: string): { short: string; color: string } {
             </button>
           </div>
           <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
+          <div v-if="offlineQueueLength > 0" class="shiki-offline">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18M12 5a7 7 0 016.95 6.155A4 4 0 0118 19H9m-3-2a4 4 0 01-1.9-7.516" />
+            </svg>
+            Working offline — {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }} queued
+          </div>
         </template>
         <div v-else class="shiki-loading">Loading...</div>
       </div>
@@ -1838,6 +1853,19 @@ function typeChip(type: string): { short: string; color: string } {
   margin-top: 8px;
   font-size: 0.8rem;
   color: #e94560;
+}
+
+.shiki-offline {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  color: #f0a75f;
+  background: rgba(240, 167, 95, 0.12);
+  border: 1px solid rgba(240, 167, 95, 0.3);
+  border-radius: 4px;
 }
 
 .friends-panel {


### PR DESCRIPTION
## Summary
- Intercept transport-level fetch failures in `shikimori:update-rate` (distinguishes `TypeError` from `ShikiApiError`)
- Persist `{ malId, rateId, before, after, queuedAt }` records to `shikimoriUpdateQueue` (electron-store)
- Optimistically update the cached rate so UI reflects the change
- New IPCs: `shikimori:get-offline-queue-length` (invoke) and `shikimori:offline-queue-changed` (broadcast)
- AnimeDetailView shows a compact "Working offline — N changes queued" chip when the queue is non-empty
- Queue is cleared on logout
- Bumps version to 3.8.2

Actual sync-back on reconnect (with conflict resolution against the authoritative Shikimori state) is the next TODO (#3).

## Test plan
- [x] Normal online save: rate updates, no chip appears
- [x] Offline save: save appears successful, chip shows "Working offline — 1 change queued"
- [x] Multiple queued updates increment the counter
- [x] Chip persists across app restart (hydrated via `shikimoriGetOfflineQueueLength`)
- [x] HTTP 4xx error (e.g., invalidated token) propagates to `shikiError`, does NOT queue
- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)