### PR TITLE
feat: conflict-aware automatic sync for offline Shikimori changes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -291,6 +291,9 @@ LibraryView shows both with indicators:
 | `shikimori:rates-refreshed` | send | Full rate list refreshed from API in background; renderer views replace their entries |
 | `shikimori:get-offline-queue-length` | invoke | Returns the number of rate updates currently queued for later sync (for initial UI hydration) |
 | `shikimori:offline-queue-changed` | send | Queue length changed; renderers update the "Working offline" indicator |
+| `shikimori:get-sync-status` | invoke | Returns `{ state, queueLength, lastSyncAt, lastSyncError }` for initial UI hydration of the sync indicator |
+| `shikimori:trigger-sync` | invoke | Manually kicks off a drain attempt (fire-and-forget); powers the "Retry now" button |
+| `shikimori:sync-status` | send | Sync worker state changed (idle ↔ syncing) or a drain just finished; renderers swap offline/syncing chip variants |
 | `shikimori:get-friends-activity` | invoke | Fetch recent anime history for all Shikimori friends, merged + sorted, MAL IDs resolved |
 | `storage:pick-hot-dir` | invoke | Open folder picker for hot storage directory |
 | `storage:pick-cold-dir` | invoke | Open folder picker for cold storage directory |
@@ -510,7 +513,19 @@ Anime rates are persisted in `shikimoriUserRates` (electron-store). `shikimori:g
 
 ### Offline Update Queue
 
-`shikimori:update-rate` distinguishes transport-level failures (fetch threw `TypeError` / `AbortError`) from HTTP errors (wrapped as `ShikiApiError`). HTTP errors propagate to the renderer as before. Transport failures are intercepted: the previous cached state is recorded as `before`, the requested change as `after`, and a `QueuedShikimoriUpdate` (`{ malId, rateId, before, after, queuedAt }`) is appended to `shikimoriUpdateQueue` in electron-store. The cached rate entry is then updated in place with the requested values so the UI reflects the change, and `shikimori:rate-updated` + `shikimori:offline-queue-changed` are broadcast. The handler returns a synthetic `ShikiUserRate` so callers (including `PlayerView`'s auto-tracker) don't need an offline branch. `AnimeDetailView` shows a "Working offline — N changes queued" chip while the queue is non-empty; the chip hydrates from `shikimori:get-offline-queue-length` on mount. Queue is cleared on logout. Actual sync-back to Shikimori when connectivity returns is handled by the next follow-up (Conflict-Aware Automatic Sync).
+`shikimori:update-rate` distinguishes transport-level failures (fetch threw `TypeError` / `AbortError`) from HTTP errors (wrapped as `ShikiApiError`). HTTP errors propagate to the renderer as before. Transport failures are intercepted: the previous cached state is recorded as `before`, the requested change as `after`, and a `QueuedShikimoriUpdate` (`{ malId, rateId, before, after, queuedAt }`) is appended to `shikimoriUpdateQueue` in electron-store. The cached rate entry is then updated in place with the requested values so the UI reflects the change, and `shikimori:rate-updated` + `shikimori:offline-queue-changed` are broadcast. The handler returns a synthetic `ShikiUserRate` so callers (including `PlayerView`'s auto-tracker) don't need an offline branch. `AnimeDetailView` shows a "Working offline — N changes queued" chip while the queue is non-empty; it flips to a blue "Syncing…" variant with a spinner while the sync worker drains. The chip hydrates from `shikimori:get-offline-queue-length` + `shikimori:get-sync-status` on mount. Queue and timer are cleared on logout.
+
+#### Sync worker
+
+When the queue is non-empty, a background worker (`syncShikimoriQueue`, module-level in `src/main/index.ts`) drains it back to Shikimori. Trigger cadence is outcome-based — same philosophy as the offline intercept classifier: rather than trusting `navigator.onLine` / `net.isOnline()`, we try the drain and let the fetch result tell us whether we're really online. The worker fires on a 60s timer (started only while the queue is non-empty), on boot if the queue is non-empty, after any successful online `shikimori:update-rate` or `fetchAndCacheShikimoriRates`, and on demand via `shikimori:trigger-sync` ("Retry now" button).
+
+Before hitting the API, queued entries are consolidated per `malId` (first `before` + last `after`), so repeated offline bumps on the same anime produce a single PATCH. For each consolidated item the worker calls `getUserRate` to read current server state, then:
+
+- **Server state matches `before`** — no drift; apply `after` via `updateUserRate`.
+- **Server state drifted** — apply progress rule: only override if `after.episodes > current.episodes` AND the current status is not more advanced than `after.status` (ordering: `planned < watching/rewatching < on_hold/dropped < completed`). Otherwise reconcile local cache to the server's value and drop the queue item — the user's offline intent has been superseded by a more recent server-side decision.
+- **Server returned no rate (deleted)** — recreate with `after` via `createUserRate`.
+
+An in-memory mutex (`syncInProgress`) prevents overlapping drains. Items are processed sequentially with a 250 ms delay to stay under Shikimori's 5 req/s cap (the `shikiFetch` wrapper also handles 429 with `retry-after`). Network errors during drain abort the run and leave the queue intact for the next timer tick; 401/403 also abort without dropping items (user needs to re-auth); other HTTP errors drop the offending item and continue. `shikimori:rate-updated` is broadcast on both "applied" and "reconciled to server" paths so the UI stays consistent regardless of which branch fired.
 
 ### Friends Activity Feed
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,7 @@
 - [x] HEVC → H.264 transcode fallback for platforms without an HEVC decoder — new `player:remux-mkv-stream-transcode` IPC re-encodes HEVC to H.264 through the existing MSE pipe; `pickH264Encoder` dry-runs `h264_vaapi` / `h264_nvenc` / `h264_qsv` / `libx264` at startup; `hevcTranscodeOnPlay` setting (ask / always / never) with consent modal and `shell:open-external-file` escape hatch
 - [x] Centralized Shikimori Cache & Surgical UI Updates — persist `shikimoriUserRates` in electron-store, cache-first `get-anime-rates`, background API refresh with `shikimori:rates-refreshed` broadcast, surgical `shikimori:rate-updated` on rate changes
 - [x] Offline Shikimori Support: Queuing & Status Indicators — intercept transport-level failures in `shikimori:update-rate`, persist `{before, after}` deltas to `shikimoriUpdateQueue`, optimistically update cache, broadcast `shikimori:offline-queue-changed`, show "Working offline" chip in AnimeDetailView
+- [x] Conflict-Aware Automatic Sync for Offline Changes — background sync worker drains `shikimoriUpdateQueue` on 60s timer + post-success hooks + boot, consolidates per malId, progress-only override on server drift, recreate on server deletion, `shikimori:sync-status` broadcast + "Retry now" button in AnimeDetailView
 
 ---
 
@@ -78,7 +79,7 @@
 - **Dependency:** Hard-blocked by **Item #1** (requires the centralized cache to record the `before` state).
 - **False Positives:** `navigator.onLine` is notoriously unreliable; implementation must handle "lie-fi" (connected to Wi-Fi but no internet) to avoid lost requests.
 
-## 3. Conflict-Aware Automatic Sync for Offline Changes
+## ~~3. Conflict-Aware Automatic Sync for Offline Changes~~ (done)
 
 **Priority:** High | **Effort:** Medium
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,6 +135,225 @@ interface QueuedShikimoriUpdate {
   queuedAt: number
 }
 
+type ShikiSyncState = 'idle' | 'syncing'
+interface ShikiSyncStatus {
+  state: ShikiSyncState
+  queueLength: number
+  lastSyncAt: number
+  lastSyncError: string | null
+}
+
+const SYNC_TIMER_MS = 60_000
+const SYNC_ITEM_DELAY_MS = 250
+
+const STATUS_ORDER: Record<shikimori.ShikiUserRateStatus, number> = {
+  planned: 0,
+  watching: 1,
+  rewatching: 1,
+  on_hold: 2,
+  dropped: 2,
+  completed: 3
+}
+
+let syncInProgress = false
+let syncTimer: NodeJS.Timeout | null = null
+let lastSyncAt = 0
+let lastSyncError: string | null = null
+
+function getQueueLength(): number {
+  return (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).length
+}
+
+function getSyncStatus(): ShikiSyncStatus {
+  return {
+    state: syncInProgress ? 'syncing' : 'idle',
+    queueLength: getQueueLength(),
+    lastSyncAt,
+    lastSyncError
+  }
+}
+
+function broadcastSyncStatus(): void {
+  broadcastToAll('shikimori:sync-status', getSyncStatus())
+}
+
+function startSyncTimer(): void {
+  if (syncTimer) return
+  syncTimer = setInterval(() => {
+    void syncShikimoriQueue()
+  }, SYNC_TIMER_MS)
+}
+
+function stopSyncTimer(): void {
+  if (!syncTimer) return
+  clearInterval(syncTimer)
+  syncTimer = null
+}
+
+function adjustSyncTimer(): void {
+  if (getQueueLength() > 0) startSyncTimer()
+  else stopSyncTimer()
+}
+
+function consolidateQueue(queue: QueuedShikimoriUpdate[]): QueuedShikimoriUpdate[] {
+  const map = new Map<number, QueuedShikimoriUpdate>()
+  for (const entry of queue) {
+    const existing = map.get(entry.malId)
+    if (existing) {
+      existing.after = entry.after
+      existing.rateId = entry.rateId ?? existing.rateId
+    } else {
+      map.set(entry.malId, { ...entry })
+    }
+  }
+  return Array.from(map.values())
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function reconcileCacheFromRate(malId: number, rate: shikimori.ShikiUserRate): void {
+  const cached = store.get('shikimoriUserRates') as {
+    rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+    shikiAnime: unknown
+    smotretAnime: unknown
+  }[]
+  const idx = cached.findIndex((e) => e.rate.target_id === malId)
+  if (idx === -1) return
+  cached[idx] = {
+    ...cached[idx],
+    rate: {
+      ...cached[idx].rate,
+      id: rate.id,
+      episodes: rate.episodes,
+      status: rate.status,
+      score: rate.score,
+      updated_at: new Date().toISOString()
+    }
+  }
+  store.set('shikimoriUserRates', cached)
+  broadcastToAll('shikimori:rate-updated', cached[idx])
+}
+
+function shouldApplyOnDrift(
+  current: shikimori.ShikiUserRate,
+  after: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+): boolean {
+  if (after.episodes <= current.episodes) return false
+  if (STATUS_ORDER[current.status] > STATUS_ORDER[after.status]) return false
+  return true
+}
+
+async function syncShikimoriQueue(): Promise<void> {
+  if (syncInProgress) return
+  let queue = store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]
+  if (queue.length === 0) {
+    stopSyncTimer()
+    return
+  }
+  const creds = store.get('shikimoriCredentials') as shikimori.ShikiCredentials | null
+  const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
+  if (!creds || !user) return
+
+  syncInProgress = true
+  broadcastSyncStatus()
+
+  let accessToken: string
+  try {
+    accessToken = await shikimori.ensureFreshToken(store)
+  } catch (err) {
+    syncInProgress = false
+    if (!isNetworkError(err)) {
+      lastSyncError = err instanceof Error ? err.message : String(err)
+      console.warn('[shikimori sync] auth refresh failed:', err)
+    }
+    broadcastSyncStatus()
+    return
+  }
+
+  const work = consolidateQueue(queue)
+  let aborted = false
+
+  for (const item of work) {
+    try {
+      const current = await shikimori.getUserRate(accessToken, user.id, item.malId)
+
+      if (!current) {
+        const created = await shikimori.createUserRate(
+          accessToken,
+          user.id,
+          item.malId,
+          item.after.episodes,
+          item.after.status,
+          item.after.score
+        )
+        reconcileCacheFromRate(item.malId, created)
+      } else {
+        const driftMatches =
+          current.episodes === item.before.episodes &&
+          current.status === item.before.status &&
+          current.score === item.before.score
+
+        if (driftMatches) {
+          const updated = await shikimori.updateUserRate(
+            accessToken,
+            current.id,
+            item.after.episodes,
+            item.after.status,
+            item.after.score
+          )
+          reconcileCacheFromRate(item.malId, updated)
+        } else if (shouldApplyOnDrift(current, item.after)) {
+          const updated = await shikimori.updateUserRate(
+            accessToken,
+            current.id,
+            item.after.episodes,
+            item.after.status,
+            item.after.score
+          )
+          reconcileCacheFromRate(item.malId, updated)
+        } else {
+          reconcileCacheFromRate(item.malId, current)
+        }
+      }
+
+      queue = (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).filter(
+        (q) => q.malId !== item.malId
+      )
+      store.set('shikimoriUpdateQueue', queue)
+      broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+    } catch (err) {
+      if (isNetworkError(err)) {
+        aborted = true
+        break
+      }
+      if (err instanceof shikimori.ShikiApiError && (err.status === 401 || err.status === 403)) {
+        aborted = true
+        lastSyncError = err.message
+        console.warn('[shikimori sync] auth error, stopping drain:', err)
+        break
+      }
+      console.warn('[shikimori sync] dropping item', item.malId, err)
+      queue = (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).filter(
+        (q) => q.malId !== item.malId
+      )
+      store.set('shikimoriUpdateQueue', queue)
+      broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+    }
+
+    if (work.indexOf(item) < work.length - 1) await sleep(SYNC_ITEM_DELAY_MS)
+  }
+
+  syncInProgress = false
+  if (!aborted) {
+    lastSyncAt = Date.now()
+    lastSyncError = null
+  }
+  adjustSyncTimer()
+  broadcastSyncStatus()
+}
+
 // --- Anime cache helpers (for offline support of downloaded anime) ---
 
 function isDownloadedAnime(animeId: number): boolean {
@@ -1278,7 +1497,9 @@ function registerIpcHandlers(): void {
     store.set('shikimoriUser', null)
     store.set('shikimoriUserRates', [])
     store.set('shikimoriUpdateQueue', [])
+    stopSyncTimer()
     broadcastToAll('shikimori:offline-queue-changed', { length: 0 })
+    broadcastSyncStatus()
   })
 
   ipcMain.handle('shikimori:get-user', () => {
@@ -1326,6 +1547,7 @@ function registerIpcHandlers(): void {
           refreshShikimoriRatesInBackground()
         }
 
+        void syncShikimoriQueue()
         return updatedRate
       } catch (err) {
         if (!isNetworkError(err) || idx === -1) throw err
@@ -1356,6 +1578,7 @@ function registerIpcHandlers(): void {
         store.set('shikimoriUserRates', cached)
         broadcastToAll('shikimori:rate-updated', cached[idx])
         broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+        startSyncTimer()
 
         return {
           id: rateId ?? -1,
@@ -1407,7 +1630,10 @@ function registerIpcHandlers(): void {
 
   function refreshShikimoriRatesInBackground(): void {
     fetchAndCacheShikimoriRates()
-      .then((entries) => broadcastToAll('shikimori:rates-refreshed', entries))
+      .then((entries) => {
+        broadcastToAll('shikimori:rates-refreshed', entries)
+        void syncShikimoriQueue()
+      })
       .catch((err) => console.warn('[shikimori] background refresh failed:', err))
   }
 
@@ -1424,6 +1650,12 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('shikimori:get-offline-queue-length', () => {
     return (store.get('shikimoriUpdateQueue') as unknown[]).length
+  })
+
+  ipcMain.handle('shikimori:get-sync-status', () => getSyncStatus())
+
+  ipcMain.handle('shikimori:trigger-sync', () => {
+    void syncShikimoriQueue()
   })
 
   ipcMain.handle('shikimori:get-friends-activity', async () => {
@@ -2395,6 +2627,11 @@ app.whenReady().then(async () => {
   })
 
   registerIpcHandlers()
+
+  if (getQueueLength() > 0) {
+    startSyncTimer()
+    void syncShikimoriQueue()
+  }
 
   // Auto-updater setup
   autoUpdater.autoDownload = false

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -195,18 +195,33 @@ function adjustSyncTimer(): void {
   else stopSyncTimer()
 }
 
-function consolidateQueue(queue: QueuedShikimoriUpdate[]): QueuedShikimoriUpdate[] {
-  const map = new Map<number, QueuedShikimoriUpdate>()
+interface ConsolidatedWorkItem extends QueuedShikimoriUpdate {
+  consumedQueuedAts: number[]
+}
+
+function consolidateQueue(queue: QueuedShikimoriUpdate[]): ConsolidatedWorkItem[] {
+  const map = new Map<number, ConsolidatedWorkItem>()
   for (const entry of queue) {
     const existing = map.get(entry.malId)
     if (existing) {
       existing.after = entry.after
       existing.rateId = entry.rateId ?? existing.rateId
+      existing.consumedQueuedAts.push(entry.queuedAt)
     } else {
-      map.set(entry.malId, { ...entry })
+      map.set(entry.malId, { ...entry, consumedQueuedAts: [entry.queuedAt] })
     }
   }
   return Array.from(map.values())
+}
+
+function dropConsumedEntries(malId: number, consumedQueuedAts: number[]): number {
+  const consumed = new Set(consumedQueuedAts)
+  const queue = (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).filter(
+    (q) => !(q.malId === malId && consumed.has(q.queuedAt))
+  )
+  store.set('shikimoriUpdateQueue', queue)
+  broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+  return queue.length
 }
 
 function sleep(ms: number): Promise<void> {
@@ -241,13 +256,18 @@ function shouldApplyOnDrift(
   after: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
 ): boolean {
   if (after.episodes <= current.episodes) return false
-  if (STATUS_ORDER[current.status] > STATUS_ORDER[after.status]) return false
+  const currentRank = STATUS_ORDER[current.status]
+  const afterRank = STATUS_ORDER[after.status]
+  if (currentRank > afterRank) return false
+  // Same rank but different value (watching ↔ rewatching) is a user-meaningful side-grade,
+  // not pure episode progress — treat as drift and let the server value win
+  if (currentRank === afterRank && current.status !== after.status) return false
   return true
 }
 
 async function syncShikimoriQueue(): Promise<void> {
   if (syncInProgress) return
-  let queue = store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]
+  const queue = store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]
   if (queue.length === 0) {
     stopSyncTimer()
     return
@@ -318,11 +338,7 @@ async function syncShikimoriQueue(): Promise<void> {
         }
       }
 
-      queue = (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).filter(
-        (q) => q.malId !== item.malId
-      )
-      store.set('shikimoriUpdateQueue', queue)
-      broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+      dropConsumedEntries(item.malId, item.consumedQueuedAts)
     } catch (err) {
       if (isNetworkError(err)) {
         aborted = true
@@ -335,11 +351,7 @@ async function syncShikimoriQueue(): Promise<void> {
         break
       }
       console.warn('[shikimori sync] dropping item', item.malId, err)
-      queue = (store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]).filter(
-        (q) => q.malId !== item.malId
-      )
-      store.set('shikimoriUpdateQueue', queue)
-      broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+      dropConsumedEntries(item.malId, item.consumedQueuedAts)
     }
 
     if (work.indexOf(item) < work.length - 1) await sleep(SYNC_ITEM_DELAY_MS)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -201,6 +201,28 @@ const api = {
   offShikimoriOfflineQueueChanged: () => {
     ipcRenderer.removeAllListeners('shikimori:offline-queue-changed')
   },
+  shikimoriGetSyncStatus: () =>
+    ipcRenderer.invoke('shikimori:get-sync-status') as Promise<{
+      state: 'idle' | 'syncing'
+      queueLength: number
+      lastSyncAt: number
+      lastSyncError: string | null
+    }>,
+  shikimoriTriggerSync: () =>
+    ipcRenderer.invoke('shikimori:trigger-sync') as Promise<void>,
+  onShikimoriSyncStatus: (
+    callback: (data: {
+      state: 'idle' | 'syncing'
+      queueLength: number
+      lastSyncAt: number
+      lastSyncError: string | null
+    }) => void
+  ) => {
+    ipcRenderer.on('shikimori:sync-status', (_event, data) => callback(data))
+  },
+  offShikimoriSyncStatus: () => {
+    ipcRenderer.removeAllListeners('shikimori:sync-status')
+  },
 
   // Updates
   appVersion: () => ipcRenderer.invoke('app:version'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -131,6 +131,22 @@ interface Api {
   shikimoriGetOfflineQueueLength: () => Promise<number>
   onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => void
   offShikimoriOfflineQueueChanged: () => void
+  shikimoriGetSyncStatus: () => Promise<{
+    state: 'idle' | 'syncing'
+    queueLength: number
+    lastSyncAt: number
+    lastSyncError: string | null
+  }>
+  shikimoriTriggerSync: () => Promise<void>
+  onShikimoriSyncStatus: (
+    callback: (data: {
+      state: 'idle' | 'syncing'
+      queueLength: number
+      lastSyncAt: number
+      lastSyncError: string | null
+    }) => void
+  ) => void
+  offShikimoriSyncStatus: () => void
 
   // Updates
   appVersion: () => Promise<string>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -194,7 +194,17 @@ const episodeRows = computed((): EpisodeRow[] => {
       selectedTr = sorted.find(tr => tr.id === episodeOverrides.value.get(ep.id)) || null
     }
 
-    // Priority 3: Global default (same type + author)
+    // Priority 3: Prefer any downloaded translation on this episode — avoids silent fallback to
+    // streaming when the global default (type+author) doesn't match what's on disk
+    if (!isLocked && !selectedTr && downloadedTrIds.size > 0) {
+      const downloaded = sorted.filter(tr => downloadedTrIds.has(tr.id))
+      const sameType = downloaded
+        .filter(tr => tr.type === translationType.value)
+        .sort((a, b) => getRealHeight(b) - getRealHeight(a))
+      selectedTr = sameType[0] || downloaded[0] || null
+    }
+
+    // Priority 4: Global default (same type + author)
     if (!isLocked && !selectedTr) {
       const typeFiltered = sorted.filter(tr => tr.type === translationType.value)
       selectedTr = typeFiltered.find(tr => tr.authorsSummary === selectedAuthor.value)

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -36,6 +36,8 @@ const shikiLoading = ref(false)
 const shikiSaving = ref(false)
 const shikiError = ref('')
 const offlineQueueLength = ref(0)
+const syncState = ref<'idle' | 'syncing'>('idle')
+const lastSyncError = ref<string | null>(null)
 
 // Friends state
 const friendsRates = ref<ShikiFriendRate[]>([])
@@ -374,6 +376,16 @@ onMounted(async () => {
   window.api.onShikimoriOfflineQueueChanged((data) => {
     offlineQueueLength.value = data.length
   })
+  window.api.shikimoriGetSyncStatus().then((s) => {
+    syncState.value = s.state
+    offlineQueueLength.value = s.queueLength
+    lastSyncError.value = s.lastSyncError
+  })
+  window.api.onShikimoriSyncStatus((data) => {
+    syncState.value = data.state
+    offlineQueueLength.value = data.queueLength
+    lastSyncError.value = data.lastSyncError
+  })
 })
 
 onUnmounted(() => {
@@ -384,7 +396,12 @@ onUnmounted(() => {
   window.api.offShikimoriRateUpdated()
   window.api.offShikimoriRatesRefreshed()
   window.api.offShikimoriOfflineQueueChanged()
+  window.api.offShikimoriSyncStatus()
 })
+
+async function triggerSyncNow(): Promise<void> {
+  await window.api.shikimoriTriggerSync()
+}
 
 const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
   { value: 'planned', label: 'Planned' },
@@ -1025,11 +1042,49 @@ function typeChip(type: string): { short: string; color: string } {
             </button>
           </div>
           <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
-          <div v-if="offlineQueueLength > 0" class="shiki-offline">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14">
+          <div
+            v-if="offlineQueueLength > 0"
+            class="shiki-offline"
+            :class="{ 'shiki-syncing': syncState === 'syncing' }"
+            :title="lastSyncError || ''"
+          >
+            <svg
+              v-if="syncState === 'syncing'"
+              class="shiki-offline-spin"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              width="14"
+              height="14"
+            >
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-6.219-8.56" />
+            </svg>
+            <svg
+              v-else
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              width="14"
+              height="14"
+            >
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 3l18 18M12 5a7 7 0 016.95 6.155A4 4 0 0118 19H9m-3-2a4 4 0 01-1.9-7.516" />
             </svg>
-            Working offline — {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }} queued
+            <span v-if="syncState === 'syncing'">
+              Syncing {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }}…
+            </span>
+            <span v-else>
+              Working offline — {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }} queued
+            </span>
+            <button
+              v-if="syncState === 'idle'"
+              type="button"
+              class="shiki-offline-retry"
+              @click="triggerSyncNow"
+            >
+              Retry now
+            </button>
           </div>
         </template>
         <div v-else class="shiki-loading">Loading...</div>
@@ -1866,6 +1921,37 @@ function typeChip(type: string): { short: string; color: string } {
   background: rgba(240, 167, 95, 0.12);
   border: 1px solid rgba(240, 167, 95, 0.3);
   border-radius: 4px;
+}
+
+.shiki-offline.shiki-syncing {
+  color: #5e9cd8;
+  background: rgba(94, 156, 216, 0.12);
+  border-color: rgba(94, 156, 216, 0.3);
+}
+
+.shiki-offline-spin {
+  animation: shiki-offline-rotate 0.9s linear infinite;
+}
+
+@keyframes shiki-offline-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.shiki-offline-retry {
+  margin-left: 4px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  color: #f0a75f;
+  background: transparent;
+  border: 1px solid rgba(240, 167, 95, 0.5);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.shiki-offline-retry:hover {
+  background: rgba(240, 167, 95, 0.15);
 }
 
 .friends-panel {

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -195,13 +195,14 @@ const episodeRows = computed((): EpisodeRow[] => {
     }
 
     // Priority 3: Prefer any downloaded translation on this episode — avoids silent fallback to
-    // streaming when the global default (type+author) doesn't match what's on disk
+    // streaming when the global default (type+author) doesn't match what's on disk.
+    // Within same-type downloads, honor the user's author preference before picking highest quality.
     if (!isLocked && !selectedTr && downloadedTrIds.size > 0) {
       const downloaded = sorted.filter(tr => downloadedTrIds.has(tr.id))
-      const sameType = downloaded
-        .filter(tr => tr.type === translationType.value)
-        .sort((a, b) => getRealHeight(b) - getRealHeight(a))
-      selectedTr = sameType[0] || downloaded[0] || null
+      const sameType = downloaded.filter(tr => tr.type === translationType.value)
+      const sameAuthor = sameType.find(tr => tr.authorsSummary === selectedAuthor.value)
+      const bestSameType = [...sameType].sort((a, b) => getRealHeight(b) - getRealHeight(a))[0]
+      selectedTr = sameAuthor || bestSameType || downloaded[0] || null
     }
 
     // Priority 4: Global default (same type + author)


### PR DESCRIPTION
## Summary

Closes TODO #3. Background worker drains `shikimoriUpdateQueue` back to Shikimori when connectivity returns, reconciling each entry against server state so edits made on shikimori.one during the offline window aren't silently clobbered.

- Module-level `syncShikimoriQueue()` with in-memory mutex, 60s timer (runs only while queue non-empty), post-success hooks (after any online `update-rate` or rates refresh), boot kick-off if queue non-empty
- Per-malId consolidation: first `before` + last `after` — one PATCH even if the user bumped episodes multiple times offline
- Conflict rule: if server drifted from `before`, only apply `after` when it's strictly progress (`after.episodes > current.episodes` AND current status not more advanced than `after.status` using `planned < watching/rewatching < on_hold/dropped < completed`). Otherwise reconcile local cache to server and drop the item. Server deletion triggers recreate with `after`
- Outcome-based trigger (same philosophy as TODO #2): no `navigator.onLine` / `net.isOnline`, we test the real fetch result. Items serialized with 250ms spacing to stay under Shikimori's 5 req/s
- 401/403 aborts drain without dropping items (user re-auth needed); other HTTP errors drop the offending item; network errors leave the queue intact for next tick
- New IPCs: `shikimori:get-sync-status`, `shikimori:trigger-sync`, `shikimori:sync-status` broadcast
- AnimeDetailView chip flips amber "Working offline" ↔ blue "Syncing…" with spinner; "Retry now" button while idle; tooltip shows last sync error

Also includes a drive-by fix (separate commit) for the AnimeDetailView initial translation-picker: previously when a user's global type+author default didn't match the downloaded file on disk, `selectedTr` fell through to the streaming option and the Play File button didn't appear. PR 0a346a6 had patched this for next/prev navigation in PlayerView but missed the initial-selection path. Now adds a new Priority 3 between user override and global default: prefer any downloaded translation (same type highest quality first, then any).

## Test plan
- [ ] **Happy path**: offline → bump episodes → online → chip flips Syncing…→ disappears; shikimori.one matches
- [ ] **Non-progress drift**: offline set 5 → set 10 on web → online → drain skips, local reconciles to 10, queue clears
- [ ] **Progress drift**: offline set 15, server has 10 → drain applies 15
- [ ] **Server deletion**: offline edit → delete on web → online → recreate fires
- [ ] **Consolidation**: offline bump 5→6→7 three times → one PATCH only
- [ ] **Retry now** button while offline → momentary Syncing then returns to offline
- [ ] **Boot with queue**: kill offline with queued items, restart online → sync fires
- [ ] **Logout**: timer stops, queue cleared
- [ ] **Downloaded translation fix**: open an anime where your global default differs from the downloaded file's type/author → Play File button visible, downloaded translation pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)