### PR TITLE
Watch Together (Syncplay)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,6 +31,7 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/main/smotret-api.ts` | Smotret-Anime API client: search, anime/episode details, embed, subtitles, token validation |
 | `src/main/download-manager.ts` | Download queue, concurrent downloads, progress, ffmpeg merge, scan-merge |
 | `src/main/shikimori.ts` | Shikimori API client: OAuth, token refresh, user rates, anime list |
+| `src/main/syncplay.ts` | Syncplay (Watch Together) TCP/TLS client: handshake, STARTTLS upgrade, `ignoringOnTheFly` bookkeeping, 1 s heartbeat, RTT compensation, auto-reconnect |
 | `src/main/ffmpeg-static.d.ts` | Type declaration for ffbinaries module |
 | `src/main/fpcalc-binaries.ts` | Auto-download Chromaprint `fpcalc` binary on first launch |
 | `src/main/fingerprint.ts` | Spawns fpcalc on a media file; parses raw 32-bit fingerprint hash array |
@@ -360,6 +361,18 @@ LibraryView shows both with indicators:
 | `player:cleanup-remux` | invoke | Kill any active stream sessions and delete all temp remuxed files |
 | `shell:open-external` | invoke | Open URL in default browser (returns success boolean) |
 | `shell:open-external-file` | invoke | Open a local file with the OS default app via `shell.openPath` (returns `{ ok, error? }`) |
+| `syncplay:connect` | invoke | Open a TLS-only Syncplay connection with supplied `{host, port, room, username, password?, autoReconnect}` (TCP → STARTTLS probe → TLS handshake → `Hello`; aborts if the server refuses TLS or fails cert validation) and persist the session intent |
+| `syncplay:disconnect` | invoke | Close the active Syncplay connection (cancels any pending auto-reconnect) |
+| `syncplay:set-file` | invoke | Announce the currently-playing file to the room as `{canonicalName, duration, features.animeDlAppMeta:{animeId, malId, episodeInt, translationId}}` |
+| `syncplay:local-state` | invoke | Emit a `State` message on a discrete local event (`play` / `pause` / `seek`); increments the client-side `ignoringOnTheFly` counter |
+| `syncplay:local-snapshot` | invoke | Renderer pushes `{position, paused}` every ~1 s so main's heartbeat carries fresh position without wiring `timeupdate` across IPC |
+| `syncplay:set-ready` | invoke | Send `Set: {ready: {isReady, manuallyInitiated:false}}` — flips buffering state so peers pause until everyone's ready |
+| `syncplay:get-status` | invoke | Return the current `{state, host, port, room, username, tls, error?}` for initial hydration |
+| `syncplay:connection-status` | send | State machine transitions (`idle` → `connecting` → `hello-sent` → `ready` → `reconnecting`/`disconnected`) |
+| `syncplay:remote-state` | send | Remote `play`/`pause`/`seek` resolved to `{paused, position, setBy, doSeek}` with RTT-compensated position, after the `ignoringOnTheFly` counter round-trips |
+| `syncplay:room-users` | send | Current room member list with each member's advertised file info and `animeDlAppMeta` (if available) |
+| `syncplay:room-event` | send | Info/warn/error/chat messages rendered as a toast in the player (join/leave/chat/disconnect) |
+| `syncplay:remote-episode-change` | send | Another room member (same anime) switched to a different episode; PlayerView auto-navigates via `goToEpisode` |
 
 ## Key Types
 
@@ -438,6 +451,7 @@ interface EpisodeMeta {
 | `skipFingerprintCache` | object | `{}` | Per-file Chromaprint fingerprint cache, keyed by `animeId:episodeInt:fileSize:mtime` |
 | `enableLocalSkipDetection` | boolean | `true` | Run Chromaprint OP/ED detection in the background after each download/merge completes; turn off to disable background CPU usage |
 | `calendarView` | string | `'week'` | Default time range for the Airing Calendar tab: `week` (1×7 grid) or `month` (4×7 grid). Toggle in Settings > General |
+| `syncplay` | object | `{ lastHost:'syncplay.pl', lastPort:8999, lastRoom:'', username:'', autoReconnect:true }` | Watch Together session intent (host/port/room/username + auto-reconnect toggle; TLS is always on). The connection itself is NOT persisted — users must rejoin after restart |
 
 ## Watch Progress & Resume
 
@@ -612,6 +626,56 @@ Shown when user is logged in AND anime has `myAnimeListId`. Displays:
 ### Series Chronology
 
 Below the Shikimori panel, `AnimeDetailView` renders a Chronology list of the entire franchise sourced from `GET /api/animes/:id/franchise` (a public, unauthenticated endpoint, so the panel renders for logged-out users too). The main-process handler `shikimori:get-related` fetches the franchise graph (`{ nodes, links, current_id }`), then does a BFS from `current_id` through a whitelist of canonical relation edges (sequel/prequel/side_story/parent_story/alternative_version/summary/full_story/spin_off/alternative_setting) to drop unrelated bridges — e.g. the Isekai-Quartet `"other"` edges that otherwise pull Overlord/Konosuba/Re:Zero into a Youjo Senki franchise query. Reachable nodes are sorted chronologically by release `date`, then `lookupByMalIds` resolves each node's MAL ID to its smotret-anime entry (reusing the persistent `malIdMap` cache). Direct edges from `current_id` are walked to attach a `relation` label (source-side only, since Shikimori emits all current-node links as `source_id`); nodes more than one hop away simply omit the label. Each row shows title, kind badge (TV/movie/OVA/…), release year, relation label (when available), and — cross-referenced against `shikimoriUserRates` — a watch-status badge when the current user tracks that entry. Promos/CMs/music videos are filtered out. The current anime's node is highlighted with a "Current" badge and is non-clickable. Rows where `lookupByMalIds` returned no smotret-anime match display a "Not available" badge and are non-clickable. Clickable rows emit `open-anime` up through `App.vue`, which maintains a per-view navigation stack (`animeHistoryByView`) so Back returns to the previously-opened anime in the same tab rather than the list view. The panel is collapsed by default on every mount (header chevron toggles the body) so the page opens compact; users expand it on demand.
+
+## Watch Together (Syncplay)
+
+Two (or more) users watching the same anime together over the Internet, staying in lockstep on playback position. Compatible with the [Syncplay](https://syncplay.pl) protocol — connects to community servers (`syncplay.pl:8999` default) and interoperates with the reference `syncplay.pl` desktop client (mpv/VLC), so a friend can watch along from any player Syncplay supports.
+
+### Module: `src/main/syncplay.ts`
+
+Standalone TCP/TLS client. **TLS-only:** `net.Socket` opens the TCP connection, the very first message we send is the Syncplay TLS probe `{TLS:{option:'send'}}`, and only after the server replies `{TLS:{startTLS:'true'}}` and `tls.connect({ socket })` finishes its handshake (with `rejectUnauthorized` left at its default `true`) do we send the `Hello` message containing username/password. Servers that do not support STARTTLS — or whose certificate fails verification against `host` — drop the connection with a clear error. Line-delimited JSON (each message is one JSON object followed by `\r\n`). All protocol-level concerns live here — the renderer only emits high-level playback events.
+
+State machine: `idle → connecting → tls-probing → tls-handshake → hello-sent → ready → (reconnecting) → disconnected`. On transport error: exponential backoff reconnect, max 5 attempts. On protocol error (wrong password, bad handshake, server refused TLS): abort without retry.
+
+### File Identity
+
+Syncplay clients identify "are we watching the same thing?" by file name + duration. We canonicalize our label to `"{animeName} - {episodeInt}"` so mpv/VLC users see a human-readable name, and duration is the HTML5 `<video>` `duration` rounded to the nearest second. For app-to-app sync (two instances of this app), we additionally stamp `features.animeDlAppMeta = { animeId, malId, episodeInt, translationId }` on outbound `Set.file` messages — the remote side uses this to auto-navigate when the other user advances to the next episode. Users on mpv/VLC don't emit this field, so auto-nav is a best-effort upgrade and the app falls back to identity-by-name for them.
+
+### `ignoringOnTheFly` Bookkeeping
+
+The protocol's anti-echo counter. Two independent counters (client-side and server-side) ride along on `State` messages. Local play/pause/seek increments `clientIgnoreCounter` and sends it on the next `State`; the server reflects the counter back. Until `pendingClientAck` drops to zero, inbound `State` messages that would override our local intent are dropped. This is the authoritative echo-suppression mechanism.
+
+Belt-and-suspenders: the renderer also sets `suppressNextLocalEventUntil = Date.now() + 250` after applying a remote state, so any `play`/`pause`/`seeked` events fired synchronously by the HTMLMediaElement during the apply don't bounce back to the server in the brief window before the counter round-trip completes.
+
+### Heartbeat + RTT Compensation
+
+A 1 s heartbeat (`setInterval` in main) sends the current `{paused, position}` regardless of local user input — this is how a stable idle state propagates and stays calibrated. Position source is a renderer-pushed snapshot via unthrottled `syncplay:local-snapshot` IPC on 1 s cadence, so main never pokes into renderer video state.
+
+Each outbound `State` stamps `clientLatencyCalculation = now / 1000`. The server echoes it back in its next `State`; `serverRtt = now − lastClientLatencyCalculation`. Inbound remote positions are shifted by `+ serverRtt / 2` before applying, to account for wire delay.
+
+### Apply Rule
+
+On inbound `State`, the renderer compares remote vs. local:
+- `paused` differs → call `play()` / `pause()`.
+- `state.doSeek === true` **or** `|remote.position − local.currentTime| > 3.0` → set `currentTime = remote.position`. The 3 s tolerance prevents drift jitter from causing constant micro-seeks.
+
+### Readiness Gate (Buffer Sync)
+
+When either user runs out of MSE buffer (HTML5 `waiting` event, or the MSE respawn path's `waitForBufferAhead`), the renderer calls `syncplay:set-ready(false)` which emits `Set: {ready: {isReady:false, manuallyInitiated:false}}`. Main tracks readiness per user from `Set: {user:{X:{isReady:{…}}}}` broadcasts and from `List` messages. A user dot turns amber in the popover's member list.
+
+Renderer gates playback locally: if any room member (including self) is `isReady: false`, `applySyncplayReadyGate()` calls `v.pause()` even when the last remote `State` said `paused: false`. The last remote play intent is remembered in `syncplayLastRemotePlaying`; when the last not-ready user flips back to ready, the gate calls `v.play()` automatically. This keeps two app instances locked together when one falls behind on download/decode, rather than ping-ponging pause/play broadcasts.
+
+### Remote Episode Auto-Nav
+
+When the remote user advances to a new episode (detected by `features.animeDlAppMeta.episodeInt` change on inbound `Set.file`), main broadcasts `syncplay:remote-episode-change` with `{ animeId, episodeInt, translationId }`. PlayerView checks `animeId` against its current anime:
+- **Match** — walks `goToEpisode('next'|'prev')` in a loop until `activeEpisodeIndex` reaches the target. Reuses the normal episode-switch path (including translation resolution).
+- **Mismatch or episode not in list** — toast only. The app can't navigate to an anime that isn't loaded in the current view.
+
+### IPC Surface
+
+Main-side handlers (see IPC Handlers table): `connect`, `disconnect`, `set-file`, `local-state`, `local-snapshot`, `get-status`. Broadcasts: `connection-status`, `remote-state`, `room-users`, `room-event`, `remote-episode-change`. Settings tab "Watch Together" in `SettingsView.vue` persists host/port/room/username/autoReconnect under the `syncplay` electron-store key — session state (currently-connected room, password) is **not** persisted across restarts.
+
+Debug tracing gated by `SYNCPLAY_DEBUG=1` env var — dumps every inbound/outbound JSON message and state transition to the main process log.
 
 ## FFmpeg
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,6 +21,16 @@ import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, EpisodeDetail, Tra
 import { ensureFpcalc, getFpcalcPath } from './fpcalc-binaries'
 import { analyzeShow } from './skip-detector'
 import type { EpisodeInput, ShowSkipDetections, CachedFingerprint, AnalyzeProgress } from './skip-detector'
+import { syncplay } from './syncplay'
+import type {
+  SyncplayConfig,
+  SyncplayFileInfo,
+  SyncplayRemoteState,
+  SyncplayRoomUser,
+  SyncplayRoomEvent,
+  SyncplayRemoteEpisode,
+  SyncplayStatus
+} from './syncplay'
 
 // Enable WebGPU (Anime4K shaders) and platform HEVC decoding (HEVC MKV via MSE).
 // PlatformHEVCDecoderSupport gates Chromium's HEVC path in <video> and MSE;
@@ -99,7 +109,20 @@ const store = new Store({
     skipDetections: {} as Record<string, ShowSkipDetections>,
     skipFingerprintCache: {} as Record<string, CachedFingerprint>,
     enableLocalSkipDetection: true,
-    calendarView: 'week' as 'week' | 'month'
+    calendarView: 'week' as 'week' | 'month',
+    syncplay: {
+      lastHost: 'syncplay.pl',
+      lastPort: 8999,
+      lastRoom: '',
+      username: '',
+      autoReconnect: true
+    } as {
+      lastHost: string
+      lastPort: number
+      lastRoom: string
+      username: string
+      autoReconnect: boolean
+    }
   }
 })
 
@@ -3474,6 +3497,44 @@ function registerIpcHandlers(): void {
       }
     } catch { /* ignore */ }
   })
+
+  ipcMain.handle('syncplay:connect', (_event, cfg: SyncplayConfig) => {
+    const persisted = store.get('syncplay')
+    store.set('syncplay', {
+      ...persisted,
+      lastHost: cfg.host,
+      lastPort: cfg.port,
+      lastRoom: cfg.room,
+      username: cfg.username,
+      autoReconnect: Boolean(cfg.autoReconnect)
+    })
+    syncplay.connect(cfg)
+  })
+
+  ipcMain.handle('syncplay:disconnect', () => {
+    syncplay.disconnect()
+  })
+
+  ipcMain.handle('syncplay:set-file', (_event, file: SyncplayFileInfo) => {
+    syncplay.setFile(file)
+  })
+
+  ipcMain.handle(
+    'syncplay:local-state',
+    (_event, payload: { paused: boolean; position: number; cause: 'play' | 'pause' | 'seek' }) => {
+      syncplay.sendLocalState(payload)
+    }
+  )
+
+  ipcMain.handle('syncplay:local-snapshot', (_event, snap: { position: number; paused: boolean }) => {
+    syncplay.updateSnapshot(snap)
+  })
+
+  ipcMain.handle('syncplay:set-ready', (_event, isReady: boolean) => {
+    syncplay.setReady(isReady)
+  })
+
+  ipcMain.handle('syncplay:get-status', () => syncplay.getStatus())
 }
 
 interface MseOpenResult {
@@ -4102,6 +4163,26 @@ app.whenReady().then(async () => {
     }
   }, 30_000)
 
+  syncplay.on('connection-status', (status: SyncplayStatus) => {
+    broadcastToAll('syncplay:connection-status', status)
+  })
+  syncplay.on('remote-state', (state: SyncplayRemoteState) => {
+    broadcastToAll('syncplay:remote-state', state)
+  })
+  syncplay.on('room-users', (users: SyncplayRoomUser[]) => {
+    broadcastToAll('syncplay:room-users', users)
+  })
+  syncplay.on('room-event', (ev: SyncplayRoomEvent) => {
+    broadcastToAll('syncplay:room-event', ev)
+  })
+  syncplay.on('remote-episode-change', (ep: SyncplayRemoteEpisode) => {
+    broadcastToAll('syncplay:remote-episode-change', ep)
+  })
+  syncplay.on('trace', (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => {
+    broadcastToAll('syncplay:trace', entry)
+  })
+
+
   if (getQueueLength() > 0) {
     startSyncTimer()
     void syncShikimoriQueue()
@@ -4157,4 +4238,5 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   downloadManager?.destroy()
+  syncplay.disconnect()
 })

--- a/src/main/syncplay.ts
+++ b/src/main/syncplay.ts
@@ -1,0 +1,724 @@
+import * as net from 'net'
+import * as tls from 'tls'
+import { EventEmitter } from 'events'
+
+const CLIENT_VERSION = '1.6.9'
+const HEARTBEAT_MS = 1000
+const MAX_RECONNECT_ATTEMPTS = 5
+const RECONNECT_BASE_MS = 1000
+const DEBUG = process.env.SYNCPLAY_DEBUG === '1' || process.env.SYNCPLAY_DEBUG === 'true'
+
+function log(...args: unknown[]): void {
+  if (DEBUG) console.log('[syncplay]', ...args)
+}
+
+export interface SyncplayConfig {
+  host: string
+  port: number
+  room: string
+  username: string
+  password?: string
+  autoReconnect: boolean
+}
+
+export type SyncplayState =
+  | 'idle'
+  | 'connecting'
+  | 'tls-probing'
+  | 'tls-handshake'
+  | 'hello-sent'
+  | 'ready'
+  | 'reconnecting'
+  | 'disconnected'
+
+export interface SyncplayStatus {
+  state: SyncplayState
+  host?: string
+  port?: number
+  room?: string
+  username?: string
+  tls?: boolean
+  error?: string
+}
+
+export interface SyncplaySnapshot {
+  position: number
+  paused: boolean
+}
+
+export interface SyncplayFileInfo {
+  animeId: number
+  malId: number | null
+  episodeInt: string
+  translationId: number | null
+  canonicalName: string
+  duration: number
+}
+
+export interface SyncplayRemoteState {
+  paused: boolean
+  position: number
+  setBy: string | null
+  doSeek: boolean
+}
+
+export interface SyncplayRoomUser {
+  username: string
+  file: { name: string; duration: number; size?: number } | null
+  isReady?: boolean
+  animeDlAppMeta?: {
+    animeId: number
+    malId: number | null
+    episodeInt: string
+    translationId: number | null
+  }
+}
+
+export interface SyncplayRemoteEpisode {
+  animeId: number
+  malId: number | null
+  episodeInt: string
+  translationId: number | null
+  canonicalName: string
+  fromUser: string
+}
+
+export interface SyncplayRoomEvent {
+  level: 'info' | 'warn' | 'error' | 'chat'
+  text: string
+}
+
+type JsonObject = Record<string, unknown>
+
+function isObject(v: unknown): v is JsonObject {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+export class SyncplayClient extends EventEmitter {
+  private config: SyncplayConfig | null = null
+  private socket: net.Socket | tls.TLSSocket | null = null
+  private rxBuffer = ''
+  private status: SyncplayStatus = { state: 'idle' }
+
+  private heartbeatTimer: NodeJS.Timeout | null = null
+  private reconnectTimer: NodeJS.Timeout | null = null
+  private reconnectAttempts = 0
+
+  private snapshot: SyncplaySnapshot = { position: 0, paused: true }
+  private currentFile: SyncplayFileInfo | null = null
+  private serverMotd = ''
+  private tlsUpgraded = false
+  private roomUsers: SyncplayRoomUser[] = []
+  private ownIsReady = true
+
+  private clientIgnoreCounter = 0
+  private pendingClientAck = 0
+  private pendingServerAck = 0
+  private lastAppliedRoomEpisode: string | null = null
+
+  private serverRtt = 0
+
+  connect(config: SyncplayConfig): void {
+    this.disconnectInternal(false)
+    this.config = config
+    this.reconnectAttempts = 0
+    this.lastAppliedRoomEpisode = null
+    this.openSocket()
+  }
+
+  disconnect(): void {
+    this.disconnectInternal(true)
+  }
+
+  getStatus(): SyncplayStatus {
+    return { ...this.status }
+  }
+
+  setFile(file: SyncplayFileInfo): void {
+    this.currentFile = file
+    if (this.status.state === 'ready') this.sendSetFile(file)
+  }
+
+  setReady(isReady: boolean): void {
+    this.ownIsReady = isReady
+    if (this.status.state === 'ready') this.sendSetReady(isReady)
+    this.updateOwnReadinessInRoom()
+  }
+
+  private updateOwnReadinessInRoom(): void {
+    if (!this.config) return
+    const me = this.roomUsers.find((u) => u.username === this.config!.username)
+    if (me) {
+      if (me.isReady === this.ownIsReady) return
+      me.isReady = this.ownIsReady
+    } else {
+      this.roomUsers.push({ username: this.config.username, file: null, isReady: this.ownIsReady })
+    }
+    this.emit('room-users', this.roomUsers.slice())
+  }
+
+  sendLocalState(payload: {
+    paused: boolean
+    position: number
+    cause: 'play' | 'pause' | 'seek'
+  }): void {
+    this.snapshot = { position: payload.position, paused: payload.paused }
+    this.clientIgnoreCounter += 1
+    this.pendingClientAck = this.clientIgnoreCounter
+    log('local-state', payload.cause, 'counter=', this.clientIgnoreCounter, 'pos=', payload.position)
+    this.sendStateMessage({ doSeek: payload.cause === 'seek' })
+  }
+
+  updateSnapshot(snap: SyncplaySnapshot): void {
+    this.snapshot = snap
+  }
+
+  private tearDown(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    this.stopHeartbeat()
+    if (this.socket) {
+      try {
+        this.socket.removeAllListeners()
+        this.socket.destroy()
+      } catch {
+        // ignore
+      }
+      this.socket = null
+    }
+    this.rxBuffer = ''
+    this.tlsUpgraded = false
+    this.clientIgnoreCounter = 0
+    this.pendingClientAck = 0
+    this.pendingServerAck = 0
+    this.serverRtt = 0
+    this.roomUsers = []
+    this.ownIsReady = true
+  }
+
+  private disconnectInternal(userInitiated: boolean): void {
+    this.tearDown()
+    if (userInitiated) {
+      this.config = null
+      this.setStatus({ state: 'idle' })
+    }
+  }
+
+  private openSocket(): void {
+    if (!this.config) return
+    const { host, port } = this.config
+    this.setStatus({
+      state: this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting',
+      host,
+      port,
+      room: this.config.room,
+      username: this.config.username,
+      tls: false
+    })
+    log('connecting', host, port)
+
+    const sock = net.createConnection({ host, port })
+    sock.setKeepAlive(true, 30_000)
+    this.socket = sock
+    this.rxBuffer = ''
+
+    sock.on('connect', () => {
+      log('tcp connected — probing TLS')
+      this.setStatus({ state: 'tls-probing' })
+      // TLS-only: probe before sending Hello so credentials are never on the
+      // wire in plaintext. The server replies with {TLS:{startTLS:'true'|'false'}};
+      // anything other than 'true' aborts the connection.
+      this.sendJson({ TLS: { option: 'send' } })
+    })
+    sock.on('data', (chunk) => this.onData(chunk))
+    sock.on('error', (err) => this.onSocketError(err))
+    sock.on('close', () => this.onSocketClose())
+  }
+
+  private onData(chunk: Buffer | string): void {
+    this.rxBuffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+    let idx: number
+    while ((idx = this.rxBuffer.indexOf('\n')) >= 0) {
+      const line = this.rxBuffer.slice(0, idx).trim()
+      this.rxBuffer = this.rxBuffer.slice(idx + 1)
+      if (!line) continue
+      let msg: unknown
+      try {
+        msg = JSON.parse(line)
+      } catch (err) {
+        log('json parse error', err, line.slice(0, 200))
+        continue
+      }
+      if (!isObject(msg)) continue
+      this.dispatch(msg)
+    }
+  }
+
+  private dispatch(msg: JsonObject): void {
+    const keys = Object.keys(msg).join(',')
+    log('<<', keys)
+    if (DEBUG) this.emit('trace', { dir: 'in', keys, msg })
+    if ('Hello' in msg) this.handleHello(msg.Hello)
+    if ('Set' in msg) this.handleSet(msg.Set)
+    if ('List' in msg) this.handleList(msg.List)
+    if ('State' in msg) this.handleState(msg.State)
+    if ('Chat' in msg) this.handleChat(msg.Chat)
+    if ('Error' in msg) this.handleError(msg.Error)
+    if ('TLS' in msg) this.handleTls(msg.TLS)
+  }
+
+  private handleHello(payload: unknown): void {
+    if (!isObject(payload) || !this.config) return
+    const motd = typeof payload.motd === 'string' ? payload.motd : ''
+    this.serverMotd = motd
+
+    const advertisedUsername = typeof payload.username === 'string' ? payload.username : this.config.username
+    if (advertisedUsername !== this.config.username) {
+      this.emit('room-event', {
+        level: 'info',
+        text: `Joined as "${advertisedUsername}" (server rewrote username)`
+      })
+      this.config = { ...this.config, username: advertisedUsername }
+    }
+
+    if (motd) this.emit('room-event', { level: 'info', text: motd })
+
+    this.finishHandshake()
+  }
+
+  private finishHandshake(): void {
+    if (!this.config) return
+    this.setStatus({
+      state: 'ready',
+      host: this.config.host,
+      port: this.config.port,
+      room: this.config.room,
+      username: this.config.username,
+      tls: this.tlsUpgraded
+    })
+    this.reconnectAttempts = 0
+    if (this.currentFile) this.sendSetFile(this.currentFile)
+    this.sendSetReady(this.ownIsReady)
+    this.updateOwnReadinessInRoom()
+    this.startHeartbeat()
+  }
+
+  private handleTls(payload: unknown): void {
+    if (!isObject(payload)) return
+    if (this.tlsUpgraded) {
+      // Spurious post-upgrade TLS message — ignore.
+      return
+    }
+    if (payload.startTLS === 'true' || payload.startTLS === true) {
+      this.upgradeToTls()
+    } else {
+      this.failHandshake('Server does not support TLS — TLS-only mode requires a TLS-capable Syncplay server (1.6.3+).')
+    }
+  }
+
+  private upgradeToTls(): void {
+    if (!this.socket || !this.config) return
+    log('upgrading to TLS')
+    this.setStatus({ state: 'tls-handshake' })
+    const raw = this.socket
+    raw.removeAllListeners('data')
+    raw.removeAllListeners('error')
+    raw.removeAllListeners('close')
+    const tlsSock = tls.connect({
+      socket: raw,
+      servername: this.config.host
+    })
+    this.socket = tlsSock
+    this.rxBuffer = ''
+    tlsSock.on('secureConnect', () => {
+      log('tls secured')
+      this.tlsUpgraded = true
+      this.setStatus({ state: 'hello-sent' })
+      this.sendHello()
+    })
+    tlsSock.on('data', (chunk) => this.onData(chunk))
+    tlsSock.on('error', (err) => this.onSocketError(err))
+    tlsSock.on('close', () => this.onSocketClose())
+  }
+
+  private failHandshake(reason: string): void {
+    log('handshake failed:', reason)
+    this.emit('room-event', { level: 'error', text: reason })
+    // Single broadcast: tear down quietly, then emit one disconnected status
+    // that carries the error. Going through disconnectInternal would emit a
+    // separate 'idle' event afterward and clobber the error for any consumer
+    // that reads status.error after the fact.
+    this.tearDown()
+    this.config = null
+    this.setStatus({ state: 'disconnected', error: reason })
+  }
+
+  private handleSet(payload: unknown): void {
+    if (!isObject(payload)) return
+    let usersDirty = false
+    if (isObject(payload.user)) {
+      for (const [username, data] of Object.entries(payload.user)) {
+        if (!isObject(data)) continue
+        if (isObject(data.event)) {
+          if (data.event.left === true) {
+            this.emit('room-event', { level: 'info', text: `${username} left the room` })
+            this.roomUsers = this.roomUsers.filter((u) => u.username !== username)
+            usersDirty = true
+          } else if (data.event.joined === true) {
+            this.emit('room-event', { level: 'info', text: `${username} joined the room` })
+            if (!this.roomUsers.find((u) => u.username === username)) {
+              this.roomUsers.push({ username, file: null })
+              usersDirty = true
+            }
+          }
+        }
+        if (isObject(data.file)) {
+          this.absorbRemoteFile(username, data.file)
+        }
+        if (isObject(data.isReady) || typeof data.isReady === 'boolean') {
+          const isReady = typeof data.isReady === 'boolean'
+            ? data.isReady
+            : data.isReady.isReady === true
+          let u = this.roomUsers.find((x) => x.username === username)
+          if (!u) {
+            u = { username, file: null }
+            this.roomUsers.push(u)
+          }
+          if (u.isReady !== isReady) {
+            u.isReady = isReady
+            usersDirty = true
+          }
+        }
+      }
+    }
+    if (isObject(payload.room)) {
+      const name = typeof payload.room.name === 'string' ? payload.room.name : undefined
+      if (name && this.config) this.config.room = name
+    }
+    if (usersDirty) this.emit('room-users', this.roomUsers.slice())
+  }
+
+  private absorbRemoteFile(username: string, file: JsonObject): void {
+    const name = typeof file.name === 'string' ? file.name : ''
+    const duration = typeof file.duration === 'number' ? file.duration : 0
+    const size = typeof file.size === 'number' ? file.size : undefined
+    let meta: SyncplayRoomUser['animeDlAppMeta']
+    if (isObject(file.features) && isObject(file.features.animeDlAppMeta)) {
+      const m = file.features.animeDlAppMeta
+      if (typeof m.animeId === 'number' && typeof m.episodeInt === 'string') {
+        meta = {
+          animeId: m.animeId,
+          malId: typeof m.malId === 'number' ? m.malId : null,
+          episodeInt: m.episodeInt,
+          translationId: typeof m.translationId === 'number' ? m.translationId : null
+        }
+      }
+    }
+    let user = this.roomUsers.find((u) => u.username === username)
+    if (!user) {
+      user = { username, file: null }
+      this.roomUsers.push(user)
+    }
+    user.file = { name, duration, size }
+    user.animeDlAppMeta = meta
+
+    this.emit('room-users', this.roomUsers.slice())
+    if (username !== this.config?.username) {
+      this.emit('room-event', {
+        level: 'info',
+        text: `${username} switched to "${name}"`
+      })
+    }
+
+    if (meta && username !== this.config?.username) {
+      const key = `${username}|${meta.animeId}|${meta.episodeInt}`
+      if (key !== this.lastAppliedRoomEpisode) {
+        this.lastAppliedRoomEpisode = key
+        this.emit('remote-episode-change', {
+          animeId: meta.animeId,
+          malId: meta.malId,
+          episodeInt: meta.episodeInt,
+          translationId: meta.translationId,
+          canonicalName: name,
+          fromUser: username
+        })
+      }
+    }
+  }
+
+  private handleList(payload: unknown): void {
+    if (!isObject(payload)) return
+    const users: SyncplayRoomUser[] = []
+    for (const [_roomName, roomEntry] of Object.entries(payload)) {
+      if (!isObject(roomEntry)) continue
+      for (const [username, data] of Object.entries(roomEntry)) {
+        if (!isObject(data)) continue
+        const file = isObject(data.file)
+          ? {
+              name: typeof data.file.name === 'string' ? data.file.name : '',
+              duration: typeof data.file.duration === 'number' ? data.file.duration : 0,
+              size: typeof data.file.size === 'number' ? data.file.size : undefined
+            }
+          : null
+        const isReady = typeof data.isReady === 'boolean' ? data.isReady : undefined
+        users.push({ username, file, isReady })
+      }
+    }
+    if (this.config) {
+      const me = users.find((u) => u.username === this.config!.username)
+      if (me) me.isReady = this.ownIsReady
+      else users.push({ username: this.config.username, file: null, isReady: this.ownIsReady })
+    }
+    this.roomUsers = users
+    this.emit('room-users', users.slice())
+  }
+
+  private handleState(payload: unknown): void {
+    if (!isObject(payload)) return
+    const ps = isObject(payload.playstate) ? payload.playstate : null
+    const ping = isObject(payload.ping) ? payload.ping : null
+    const iotf = isObject(payload.ignoringOnTheFly) ? payload.ignoringOnTheFly : {}
+
+    if (ping) {
+      const myTs = typeof ping.clientLatencyCalculation === 'number' ? ping.clientLatencyCalculation : null
+      if (myTs !== null) {
+        const rtt = Date.now() / 1000 - myTs
+        if (rtt > 0 && rtt < 5) this.serverRtt = rtt
+      }
+    }
+
+    const serverCounter = typeof iotf.server === 'number' ? iotf.server : null
+    const clientEcho = typeof iotf.client === 'number' ? iotf.client : null
+
+    if (serverCounter !== null) {
+      this.pendingServerAck = serverCounter
+    }
+    if (clientEcho !== null) {
+      if (clientEcho === this.pendingClientAck) this.pendingClientAck = 0
+    }
+
+    if (!ps) return
+
+    const setBy = typeof ps.setBy === 'string' ? ps.setBy : null
+    const position = typeof ps.position === 'number' ? ps.position : 0
+    const paused = ps.paused === true
+    const doSeek = ps.doSeek === true
+
+    if (setBy === null) return
+    if (this.config && setBy.toLowerCase() === this.config.username.toLowerCase()) return
+    if (this.pendingClientAck !== 0) {
+      log('drop remote state — local change unacked (counter=', this.pendingClientAck, ')')
+      return
+    }
+
+    const compensated = position + this.serverRtt / 2
+    log('remote-state', { paused, position: compensated, setBy, doSeek })
+    this.emit('remote-state', {
+      paused,
+      position: compensated,
+      setBy,
+      doSeek
+    })
+  }
+
+  private handleChat(payload: unknown): void {
+    if (!isObject(payload)) return
+    const user = typeof payload.username === 'string' ? payload.username : ''
+    const text = typeof payload.message === 'string' ? payload.message : ''
+    if (!text) return
+    this.emit('room-event', { level: 'chat', text: user ? `${user}: ${text}` : text })
+  }
+
+  private handleError(payload: unknown): void {
+    if (!isObject(payload)) return
+    const text = typeof payload.message === 'string' ? payload.message : 'Server error'
+    console.warn('[syncplay] server error:', text)
+    this.emit('room-event', { level: 'error', text })
+    if (/version|password|banned/i.test(text)) {
+      if (this.config) {
+        const prevConfig = this.config
+        this.disconnectInternal(true)
+        this.setStatus({
+          state: 'disconnected',
+          host: prevConfig.host,
+          port: prevConfig.port,
+          room: prevConfig.room,
+          username: prevConfig.username,
+          error: text
+        })
+      }
+    }
+  }
+
+  private sendHello(): void {
+    if (!this.config) return
+    const features: JsonObject = {
+      sharedPlaylists: false,
+      chat: true,
+      featureList: true,
+      readiness: true,
+      managedRooms: true,
+      persistentRooms: false
+    }
+    const hello: JsonObject = {
+      username: this.config.username,
+      room: { name: this.config.room },
+      version: CLIENT_VERSION,
+      features
+    }
+    if (this.config.password) hello.password = this.config.password
+    this.sendJson({ Hello: hello })
+  }
+
+  private sendSetReady(isReady: boolean): void {
+    this.sendJson({ Set: { ready: { isReady, manuallyInitiated: false } } })
+  }
+
+  private sendSetFile(file: SyncplayFileInfo): void {
+    const set: JsonObject = {
+      file: {
+        name: file.canonicalName,
+        duration: file.duration,
+        size: 0,
+        features: {
+          animeDlAppMeta: {
+            animeId: file.animeId,
+            malId: file.malId,
+            episodeInt: file.episodeInt,
+            translationId: file.translationId
+          }
+        }
+      }
+    }
+    this.sendJson({ Set: set })
+  }
+
+  private sendStateMessage(opts: { doSeek: boolean }): void {
+    if (this.status.state !== 'ready') return
+    const msg: JsonObject = {
+      playstate: {
+        position: this.snapshot.position,
+        paused: this.snapshot.paused,
+        doSeek: opts.doSeek
+      },
+      ping: {
+        clientLatencyCalculation: Date.now() / 1000,
+        ...(this.serverRtt > 0 ? { clientRtt: this.serverRtt } : {})
+      }
+    }
+    const iotf: JsonObject = {}
+    if (this.pendingClientAck > 0) iotf.client = this.pendingClientAck
+    if (this.pendingServerAck > 0) {
+      iotf.server = this.pendingServerAck
+      this.pendingServerAck = 0
+    }
+    if (Object.keys(iotf).length > 0) msg.ignoringOnTheFly = iotf
+    this.sendJson({ State: msg })
+  }
+
+  private sendJson(obj: unknown): void {
+    if (!this.socket) return
+    const keys = Object.keys(obj as JsonObject).join(',')
+    try {
+      this.socket.write(JSON.stringify(obj) + '\r\n')
+      log('>>', keys)
+      if (DEBUG) this.emit('trace', { dir: 'out', keys, msg: obj })
+    } catch (err) {
+      console.warn('[syncplay] write error:', err)
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat()
+    this.heartbeatTimer = setInterval(() => {
+      this.sendStateMessage({ doSeek: false })
+    }, HEARTBEAT_MS)
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private onSocketError(err: Error & { code?: string }): void {
+    const code = err.code ? ` (${err.code})` : ''
+    console.warn('[syncplay] socket error:', err.message + code)
+    // TLS / certificate validation failures are not transient — don't burn
+    // five reconnect attempts on a misconfigured server. Disconnect cleanly
+    // with a clear error and stop. Detected by Node TLS error codes (all
+    // cert-trust failures start with `CERT_*` or `*_CERT_*`, plus the
+    // `ERR_TLS_*` family).
+    const code2 = typeof err.code === 'string' ? err.code : ''
+    const isFatalTls =
+      code2.startsWith('ERR_TLS_') ||
+      code2.includes('CERT_') ||
+      code2 === 'EPROTO' ||
+      (code2 === 'ECONNRESET' && this.status.state === 'tls-handshake')
+    if (isFatalTls) {
+      this.failHandshake(`TLS error${code}: ${err.message}`)
+      return
+    }
+    this.emit('room-event', { level: 'warn', text: `Connection error${code}: ${err.message}` })
+  }
+
+  private onSocketClose(): void {
+    console.warn(
+      '[syncplay] socket closed (state=' + this.status.state +
+      ', tls=' + this.tlsUpgraded +
+      ', reconnectAttempts=' + this.reconnectAttempts + ')'
+    )
+    this.stopHeartbeat()
+    if (this.status.state === 'idle') return
+    const cfg = this.config
+    this.socket = null
+    this.rxBuffer = ''
+    if (!cfg) {
+      this.setStatus({ state: 'disconnected' })
+      return
+    }
+    if (!cfg.autoReconnect || this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      const reason = this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS
+        ? 'Max reconnect attempts reached'
+        : 'Auto-reconnect disabled'
+      this.setStatus({
+        state: 'disconnected',
+        host: cfg.host,
+        port: cfg.port,
+        room: cfg.room,
+        username: cfg.username,
+        error: reason
+      })
+      this.emit('room-event', { level: 'warn', text: `Disconnected from Syncplay room: ${reason}` })
+      return
+    }
+    this.reconnectAttempts += 1
+    const delay = RECONNECT_BASE_MS * 2 ** (this.reconnectAttempts - 1)
+    console.warn(`[syncplay] reconnecting to ${cfg.host}:${cfg.port} in ${delay}ms (attempt ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})`)
+    this.setStatus({
+      state: 'reconnecting',
+      host: cfg.host,
+      port: cfg.port,
+      room: cfg.room,
+      username: cfg.username
+    })
+    this.emit('room-event', {
+      level: 'warn',
+      text: `Connection lost — retry ${this.reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS} in ${Math.round(delay / 1000)}s`
+    })
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.openSocket()
+    }, delay)
+  }
+
+  private setStatus(patch: Partial<SyncplayStatus>): void {
+    this.status = { ...this.status, ...patch }
+    this.emit('connection-status', { ...this.status })
+  }
+}
+
+export const syncplay = new SyncplayClient()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,33 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
+
+// Per-channel map of {original-callback → wrapped-handler} so the matching
+// off* helper can call ipcRenderer.removeListener with the actual wrapped
+// function (the one we registered on ipcRenderer.on). Without this map,
+// the only way to remove a listener is removeAllListeners — which would
+// also rip out listeners installed by other components in the same view.
+type SyncplayHandler<T> = (data: T) => void
+type SyncplayWrapped = (event: IpcRendererEvent, data: unknown) => void
+const syncplayWrappers = new Map<string, Map<SyncplayHandler<unknown>, SyncplayWrapped>>()
+
+function syncplayOn<T>(channel: string, cb: SyncplayHandler<T>): void {
+  const wrapped: SyncplayWrapped = (_event, data) => cb(data as T)
+  let bucket = syncplayWrappers.get(channel)
+  if (!bucket) {
+    bucket = new Map()
+    syncplayWrappers.set(channel, bucket)
+  }
+  bucket.set(cb as SyncplayHandler<unknown>, wrapped)
+  ipcRenderer.on(channel, wrapped)
+}
+
+function syncplayOff<T>(channel: string, cb: SyncplayHandler<T>): void {
+  const bucket = syncplayWrappers.get(channel)
+  if (!bucket) return
+  const wrapped = bucket.get(cb as SyncplayHandler<unknown>)
+  if (!wrapped) return
+  ipcRenderer.removeListener(channel, wrapped)
+  bucket.delete(cb as SyncplayHandler<unknown>)
+}
 
 const api = {
   validateToken: () => ipcRenderer.invoke('validate-token'),
@@ -296,6 +325,59 @@ const api = {
   offShikimoriAnimeDetailsUpdated: () => {
     ipcRenderer.removeAllListeners('shikimori:anime-details-updated')
   },
+
+  // Syncplay (Watch Together)
+  syncplayConnect: (cfg: {
+    host: string
+    port: number
+    room: string
+    username: string
+    password?: string
+    autoReconnect: boolean
+  }) => ipcRenderer.invoke('syncplay:connect', cfg) as Promise<void>,
+  syncplayDisconnect: () => ipcRenderer.invoke('syncplay:disconnect') as Promise<void>,
+  syncplaySetFile: (file: {
+    animeId: number
+    malId: number | null
+    episodeInt: string
+    translationId: number | null
+    canonicalName: string
+    duration: number
+  }) => ipcRenderer.invoke('syncplay:set-file', file) as Promise<void>,
+  syncplaySendLocalState: (payload: {
+    paused: boolean
+    position: number
+    cause: 'play' | 'pause' | 'seek'
+  }) => ipcRenderer.invoke('syncplay:local-state', payload) as Promise<void>,
+  syncplaySendLocalSnapshot: (snap: { position: number; paused: boolean }) =>
+    ipcRenderer.invoke('syncplay:local-snapshot', snap) as Promise<void>,
+  syncplaySetReady: (isReady: boolean) =>
+    ipcRenderer.invoke('syncplay:set-ready', isReady) as Promise<void>,
+  syncplayGetStatus: () => ipcRenderer.invoke('syncplay:get-status') as Promise<SyncplayStatus>,
+  onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
+    syncplayOn('syncplay:connection-status', callback),
+  offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
+    syncplayOff('syncplay:connection-status', callback),
+  onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
+    syncplayOn('syncplay:remote-state', callback),
+  offSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
+    syncplayOff('syncplay:remote-state', callback),
+  onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
+    syncplayOn('syncplay:room-users', callback),
+  offSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
+    syncplayOff('syncplay:room-users', callback),
+  onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
+    syncplayOn('syncplay:room-event', callback),
+  offSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
+    syncplayOff('syncplay:room-event', callback),
+  onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
+    syncplayOn('syncplay:remote-episode-change', callback),
+  offSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
+    syncplayOff('syncplay:remote-episode-change', callback),
+  onSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) =>
+    syncplayOn('syncplay:trace', callback),
+  offSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) =>
+    syncplayOff('syncplay:trace', callback),
 
   // Updates
   appVersion: () => ipcRenderer.invoke('app:version'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -184,6 +184,27 @@ interface Api {
   ) => void
   offShikimoriAnimeDetailsUpdated: () => void
 
+  // Syncplay (Watch Together)
+  syncplayConnect: (cfg: SyncplayConnectConfig) => Promise<void>
+  syncplayDisconnect: () => Promise<void>
+  syncplaySetFile: (file: SyncplayFilePayload) => Promise<void>
+  syncplaySendLocalState: (payload: { paused: boolean; position: number; cause: 'play' | 'pause' | 'seek' }) => Promise<void>
+  syncplaySendLocalSnapshot: (snap: { position: number; paused: boolean }) => Promise<void>
+  syncplaySetReady: (isReady: boolean) => Promise<void>
+  syncplayGetStatus: () => Promise<SyncplayStatus>
+  onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) => void
+  offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) => void
+  onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) => void
+  offSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) => void
+  onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) => void
+  offSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) => void
+  onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) => void
+  offSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) => void
+  onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) => void
+  offSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) => void
+  onSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) => void
+  offSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) => void
+
   // Updates
   appVersion: () => Promise<string>
   updateCheck: () => Promise<void>
@@ -191,6 +212,75 @@ interface Api {
   updateInstall: () => void
   onUpdateStatus: (callback: (data: UpdateStatus) => void) => void
   offUpdateStatus: () => void
+}
+
+interface SyncplayConnectConfig {
+  host: string
+  port: number
+  room: string
+  username: string
+  password?: string
+  autoReconnect: boolean
+}
+
+interface SyncplayFilePayload {
+  animeId: number
+  malId: number | null
+  episodeInt: string
+  translationId: number | null
+  canonicalName: string
+  duration: number
+}
+
+interface SyncplayStatus {
+  state:
+    | 'idle'
+    | 'connecting'
+    | 'tls-probing'
+    | 'tls-handshake'
+    | 'hello-sent'
+    | 'ready'
+    | 'reconnecting'
+    | 'disconnected'
+  host?: string
+  port?: number
+  room?: string
+  username?: string
+  tls?: boolean
+  error?: string
+}
+
+interface SyncplayRemoteState {
+  paused: boolean
+  position: number
+  setBy: string | null
+  doSeek: boolean
+}
+
+interface SyncplayRoomUser {
+  username: string
+  file: { name: string; duration: number; size?: number } | null
+  isReady?: boolean
+  animeDlAppMeta?: {
+    animeId: number
+    malId: number | null
+    episodeInt: string
+    translationId: number | null
+  }
+}
+
+interface SyncplayRoomEvent {
+  level: 'info' | 'warn' | 'error' | 'chat'
+  text: string
+}
+
+interface SyncplayRemoteEpisode {
+  animeId: number
+  malId: number | null
+  episodeInt: string
+  translationId: number | null
+  canonicalName: string
+  fromUser: string
 }
 
 interface AnimeSearchResult {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -251,6 +251,196 @@ let pendingPrevEpisodeInt = ''
 const resumeToast = ref('')
 let resumeToastTimer: ReturnType<typeof setTimeout> | null = null
 
+// Syncplay (Watch Together) state
+const syncplayStatus = ref<SyncplayStatus>({ state: 'idle' })
+const syncplayRoomUsers = ref<SyncplayRoomUser[]>([])
+const syncplayRoomInput = ref('')
+const syncplayMenuOpen = ref(false)
+const syncplayToast = ref('')
+let syncplayToastTimer: ReturnType<typeof setTimeout> | null = null
+let syncplaySnapshotTimer: ReturnType<typeof setInterval> | null = null
+let suppressNextLocalEventUntil = 0
+let syncplayLocalReady = true
+let syncplayLastRemotePlaying = false
+let syncplayLastAppliedPaused: boolean | null = null
+let syncplayWaitingTimer: ReturnType<typeof setTimeout> | null = null
+const WAITING_DEBOUNCE_MS = 600
+const syncplayPausedBy = ref<string | null>(null)
+
+// Listener functions captured at register-time so onBeforeUnmount can call
+// the matching off* with the same reference — avoids removeAllListeners
+// ripping out listeners installed by other views (e.g. SettingsView's
+// "Test connection" handler).
+let syncplayConnectionStatusHandler: ((status: SyncplayStatus) => void) | null = null
+let syncplayRemoteStateHandler: ((state: SyncplayRemoteState) => void) | null = null
+let syncplayRoomUsersHandler: ((users: SyncplayRoomUser[]) => void) | null = null
+let syncplayRoomEventHandler: ((ev: SyncplayRoomEvent) => void) | null = null
+let syncplayTraceHandler: ((entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) | null = null
+let syncplayRemoteEpisodeChangeHandler: ((ep: SyncplayRemoteEpisode) => void) | null = null
+
+function showSyncplayToast(text: string, ms = 3500): void {
+  syncplayToast.value = text
+  if (syncplayToastTimer) clearTimeout(syncplayToastTimer)
+  syncplayToastTimer = setTimeout(() => { syncplayToast.value = '' }, ms)
+}
+
+function buildCanonicalName(): string {
+  const ep = currentEpisodeInt.value || activeEpisodeLabel.value || ''
+  return ep ? `${props.animeName} - ${ep}` : props.animeName
+}
+
+function pushSyncplayFile(): void {
+  if (syncplayStatus.value.state !== 'ready') return
+  const dur = videoRef.value?.duration || duration.value || 0
+  window.api.syncplaySetFile({
+    animeId: props.animeId,
+    malId: props.malId || null,
+    episodeInt: currentEpisodeInt.value || activeEpisodeLabel.value || '',
+    translationId: activeTranslationId.value ?? null,
+    canonicalName: buildCanonicalName(),
+    duration: dur
+  })
+}
+
+function sendSyncplayLocalState(cause: 'play' | 'pause' | 'seek'): void {
+  if (syncplayStatus.value.state !== 'ready') return
+  if (Date.now() < suppressNextLocalEventUntil) return
+  const v = videoRef.value
+  if (!v) return
+  window.api.syncplaySendLocalState({
+    paused: v.paused,
+    position: v.currentTime,
+    cause
+  })
+}
+
+function onVideoSeeked(): void {
+  sendSyncplayLocalState('seek')
+}
+
+function syncplayAllUsersReady(): boolean {
+  if (!syncplayLocalReady) return false
+  for (const u of syncplayRoomUsers.value) {
+    if (u.isReady === false) return false
+  }
+  return true
+}
+
+function setSyncplayLocalReady(ready: boolean): void {
+  if (syncplayLocalReady === ready) return
+  syncplayLocalReady = ready
+  if (syncplayStatus.value.state === 'ready') {
+    window.api.syncplaySetReady(ready).catch(() => {})
+  }
+  applySyncplayReadyGate()
+}
+
+function applySyncplayReadyGate(): void {
+  if (syncplayStatus.value.state !== 'ready') return
+  const v = videoRef.value
+  if (!v) return
+  const shouldPlay = syncplayLastRemotePlaying && syncplayAllUsersReady()
+  if (!shouldPlay && !v.paused) {
+    suppressNextLocalEventUntil = Date.now() + 1500
+    v.pause()
+  } else if (shouldPlay && v.paused) {
+    suppressNextLocalEventUntil = Date.now() + 1500
+    v.play().catch(() => {})
+  }
+}
+
+function onVideoWaiting(): void {
+  if (syncplayWaitingTimer) clearTimeout(syncplayWaitingTimer)
+  syncplayWaitingTimer = setTimeout(() => {
+    syncplayWaitingTimer = null
+    setSyncplayLocalReady(false)
+  }, WAITING_DEBOUNCE_MS)
+}
+
+function applyRemoteState(state: SyncplayRemoteState): void {
+  const v = videoRef.value
+  if (!v) return
+  syncplayLastRemotePlaying = !state.paused
+  const pausedChanged = syncplayLastAppliedPaused !== state.paused
+  syncplayLastAppliedPaused = state.paused
+  if (pausedChanged) {
+    if (state.paused && state.setBy) syncplayPausedBy.value = state.setBy
+    else if (!state.paused) syncplayPausedBy.value = null
+  }
+  const diff = Math.abs(v.currentTime - state.position)
+  const needsSeek = state.doSeek || diff > 3.0
+  const effectivePaused = state.paused || !syncplayAllUsersReady()
+  const needsPlayPause = effectivePaused !== v.paused
+
+  if (!needsSeek && !needsPlayPause) return
+  suppressNextLocalEventUntil = Date.now() + 1500
+
+  if (needsSeek) {
+    v.currentTime = Math.max(0, state.position)
+  }
+  if (needsPlayPause) {
+    if (effectivePaused) v.pause()
+    else v.play().catch(() => {})
+  }
+  if (state.setBy && needsSeek) {
+    showSyncplayToast(`${state.setBy} seeked to ${formatTime(state.position)}`)
+  }
+}
+
+// Episode/translation switch: re-announce the file to peers but DO NOT reset
+// syncplayLastRemotePlaying. If a peer is currently playing, applySyncplayReadyGate
+// will start the new episode as soon as buffer fills — by design, so a remote
+// "next episode" or local prev/next auto-resumes the binge instead of pausing.
+watch([activeEpisodeIndex, activeTranslationId], () => {
+  pushSyncplayFile()
+})
+
+async function toggleSyncplayConnection(): Promise<void> {
+  const isActive = syncplayStatus.value.state === 'ready'
+    || syncplayStatus.value.state === 'connecting'
+    || syncplayStatus.value.state === 'tls-probing'
+    || syncplayStatus.value.state === 'tls-handshake'
+    || syncplayStatus.value.state === 'hello-sent'
+    || syncplayStatus.value.state === 'reconnecting'
+  if (isActive) {
+    await window.api.syncplayDisconnect()
+    return
+  }
+  const cfg = await window.api.getSetting('syncplay') as {
+    lastHost?: string
+    lastPort?: number
+    lastRoom?: string
+    username?: string
+    autoReconnect?: boolean
+  } | null
+  const host = cfg?.lastHost || 'syncplay.pl'
+  const port = cfg?.lastPort || 8999
+  const room = syncplayRoomInput.value.trim() || cfg?.lastRoom || ''
+  let username = cfg?.username?.trim() || ''
+  if (!username) {
+    const shiki = await window.api.shikimoriGetUser()
+    if (shiki?.nickname) {
+      username = shiki.nickname
+      await window.api.setSetting('syncplay', { ...(cfg || {}), username })
+    }
+  }
+  if (!room) {
+    showSyncplayToast('Enter a room name first')
+    return
+  }
+  if (!username) {
+    showSyncplayToast('Set a username in Settings → Watch Together')
+    return
+  }
+  await window.api.syncplayConnect({
+    host,
+    port,
+    room,
+    username,
+    autoReconnect: cfg?.autoReconnect ?? true
+  })
+}
+
 const WATCH_THRESHOLD_RATIO = 0.8
 const WATCH_THRESHOLD_SECONDS = 180
 const SAVE_INTERVAL_MS = 5000
@@ -679,19 +869,24 @@ function maybeRespawnForUnbufferedPosition(): void {
 
 async function waitForBufferAhead(v: HTMLVideoElement, sb: SourceBuffer, seconds: number, timeoutMs: number): Promise<void> {
   const wasPaused = v.paused
+  setSyncplayLocalReady(false)
   try { v.pause() } catch { /* ignore */ }
   const deadline = performance.now() + timeoutMs
-  while (performance.now() < deadline) {
-    const t = v.currentTime
-    for (let i = 0; i < sb.buffered.length; i++) {
-      if (t >= sb.buffered.start(i) - 0.25 && sb.buffered.end(i) - t >= seconds) {
-        if (!wasPaused) { try { await v.play() } catch { /* ignore */ } }
-        return
+  try {
+    while (performance.now() < deadline) {
+      const t = v.currentTime
+      for (let i = 0; i < sb.buffered.length; i++) {
+        if (t >= sb.buffered.start(i) - 0.25 && sb.buffered.end(i) - t >= seconds) {
+          if (!wasPaused) { try { await v.play() } catch { /* ignore */ } }
+          return
+        }
       }
+      await new Promise<void>((res) => setTimeout(res, 200))
     }
-    await new Promise<void>((res) => setTimeout(res, 200))
+    if (!wasPaused) { try { await v.play() } catch { /* ignore */ } }
+  } finally {
+    setSyncplayLocalReady(true)
   }
-  if (!wasPaused) { try { await v.play() } catch { /* ignore */ } }
 }
 
 async function handleUnbufferedSeek(): Promise<void> {
@@ -940,6 +1135,13 @@ function onPlay(): void {
   playing.value = true
   showControlsBriefly()
   lastTimeUpdateAt = Date.now()
+  if (Date.now() >= suppressNextLocalEventUntil) {
+    syncplayLastRemotePlaying = true
+    syncplayLastAppliedPaused = false
+    syncplayPausedBy.value = null
+  }
+  sendSyncplayLocalState('play')
+  applySyncplayReadyGate()
 }
 
 function onPause(): void {
@@ -948,6 +1150,14 @@ function onPause(): void {
   if (controlsTimer) clearTimeout(controlsTimer)
   lastTimeUpdateAt = 0
   saveProgress(true)
+  if (Date.now() >= suppressNextLocalEventUntil) {
+    syncplayLastRemotePlaying = false
+    syncplayLastAppliedPaused = true
+    if (syncplayStatus.value.state === 'ready' && syncplayStatus.value.username) {
+      syncplayPausedBy.value = syncplayStatus.value.username
+    }
+  }
+  sendSyncplayLocalState('pause')
 }
 
 function onTimeUpdate(): void {
@@ -964,6 +1174,7 @@ function onDurationChange(): void {
   if (videoRef.value) {
     duration.value = videoRef.value.duration
   }
+  pushSyncplayFile()
 }
 
 function onProgress(): void {
@@ -974,6 +1185,11 @@ function onProgress(): void {
 
 function onCanPlay(): void {
   if (mkvBuffering.value) mkvBuffering.value = false
+  if (syncplayWaitingTimer) {
+    clearTimeout(syncplayWaitingTimer)
+    syncplayWaitingTimer = null
+  }
+  setSyncplayLocalReady(true)
 }
 
 function onSeekStart(): void {
@@ -1073,8 +1289,9 @@ function matchesBinding(e: KeyboardEvent, binding: string): boolean {
 
 function onKeyDown(event: KeyboardEvent): void {
   event.stopPropagation()
-  // Don't handle if a preset menu input is focused
-  if ((event.target as HTMLElement)?.tagName === 'SELECT') return
+  const target = event.target as HTMLElement | null
+  const tag = target?.tagName
+  if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return
 
   const prevBinding = playerShortcuts.value.playerPrevEpisode || 'Shift+ArrowLeft'
   const nextBinding = playerShortcuts.value.playerNextEpisode || 'Shift+ArrowRight'
@@ -1765,6 +1982,102 @@ onMounted(async () => {
     if (typeof speed === 'number' && isFinite(speed)) transcodeSpeed.value = speed
   })
 
+  // Syncplay listeners
+  try {
+    syncplayStatus.value = await window.api.syncplayGetStatus()
+  } catch { /* ignore */ }
+  const cfg = await window.api.getSetting('syncplay') as { lastRoom?: string } | null
+  if (cfg?.lastRoom) syncplayRoomInput.value = cfg.lastRoom
+
+  syncplayConnectionStatusHandler = (status): void => {
+    const wasReady = syncplayStatus.value.state === 'ready'
+    console.log('[syncplay] status:', status.state, status.error ? `error=${status.error}` : '')
+    syncplayStatus.value = status
+    if (status.state === 'ready' && !wasReady) {
+      pushSyncplayFile()
+    }
+    if (status.state === 'idle' || status.state === 'disconnected') {
+      syncplayLocalReady = true
+      syncplayLastRemotePlaying = false
+      syncplayLastAppliedPaused = null
+      syncplayPausedBy.value = null
+      if (syncplayWaitingTimer) {
+        clearTimeout(syncplayWaitingTimer)
+        syncplayWaitingTimer = null
+      }
+    }
+    if (status.state === 'reconnecting') {
+      showSyncplayToast('Reconnecting to Syncplay server…', 8000)
+    } else if (status.state === 'disconnected') {
+      showSyncplayToast(status.error ? `Disconnected: ${status.error}` : 'Disconnected from Syncplay', 8000)
+    }
+  }
+  syncplayRemoteStateHandler = (state): void => {
+    applyRemoteState(state)
+  }
+  syncplayRoomUsersHandler = (users): void => {
+    syncplayRoomUsers.value = users
+    applySyncplayReadyGate()
+  }
+  syncplayRoomEventHandler = (ev): void => {
+    if (ev.level === 'warn' || ev.level === 'error') {
+      console.warn('[syncplay]', ev.text)
+    } else {
+      console.log('[syncplay]', ev.text)
+    }
+    const ms = ev.level === 'warn' || ev.level === 'error' ? 8000 : 3500
+    showSyncplayToast(ev.text, ms)
+  }
+  syncplayTraceHandler = (entry): void => {
+    const arrow = entry.dir === 'in' ? '<<' : '>>'
+    let flat: string
+    try {
+      flat = JSON.stringify(entry.msg)
+    } catch {
+      flat = String(entry.msg)
+    }
+    console.log(`[syncplay] ${arrow} ${entry.keys} ${flat}`)
+  }
+  syncplayRemoteEpisodeChangeHandler = (ep): void => {
+    if (ep.animeId !== props.animeId) {
+      showSyncplayToast(`${ep.fromUser} switched to a different anime — not loaded here`)
+      return
+    }
+    const idx = props.allEpisodes.findIndex((e) => e.episodeInt === ep.episodeInt)
+    if (idx < 0) {
+      showSyncplayToast(`${ep.fromUser} moved to episode ${ep.episodeInt} (not available)`)
+      return
+    }
+    if (idx === activeEpisodeIndex.value) return
+    showSyncplayToast(`${ep.fromUser} moved to episode ${ep.episodeInt}`)
+    const dir = idx > activeEpisodeIndex.value ? 'next' : 'prev'
+    // goToEpisode moves one step; step toward target in a loop.
+    const stepTowards = async (): Promise<void> => {
+      while (activeEpisodeIndex.value !== idx && !navigating.value) {
+        await goToEpisode(dir)
+      }
+    }
+    stepTowards()
+  }
+
+  window.api.onSyncplayConnectionStatus(syncplayConnectionStatusHandler)
+  window.api.onSyncplayRemoteState(syncplayRemoteStateHandler)
+  window.api.onSyncplayRoomUsers(syncplayRoomUsersHandler)
+  window.api.onSyncplayRoomEvent(syncplayRoomEventHandler)
+  window.api.onSyncplayTrace(syncplayTraceHandler)
+  window.api.onSyncplayRemoteEpisodeChange(syncplayRemoteEpisodeChangeHandler)
+
+  // 1-second snapshot push so main's heartbeat has fresh position.
+  syncplaySnapshotTimer = setInterval(() => {
+    if (syncplayStatus.value.state !== 'ready') return
+    const v = videoRef.value
+    if (!v) return
+    window.api.syncplaySendLocalSnapshot({
+      position: v.currentTime,
+      paused: v.paused
+    })
+  }, 1000)
+
   // Diagnostic listeners on the video element to see why MSE playback stalls.
   watch(videoRef, (v) => {
     if (!v) return
@@ -1899,6 +2212,42 @@ onBeforeUnmount(() => {
   window.api.offPlayerStreamEnd()
   window.api.offPlayerStreamError()
   window.api.offPlayerStreamProgress()
+  if (syncplayConnectionStatusHandler) {
+    window.api.offSyncplayConnectionStatus(syncplayConnectionStatusHandler)
+    syncplayConnectionStatusHandler = null
+  }
+  if (syncplayRemoteStateHandler) {
+    window.api.offSyncplayRemoteState(syncplayRemoteStateHandler)
+    syncplayRemoteStateHandler = null
+  }
+  if (syncplayRoomUsersHandler) {
+    window.api.offSyncplayRoomUsers(syncplayRoomUsersHandler)
+    syncplayRoomUsersHandler = null
+  }
+  if (syncplayRoomEventHandler) {
+    window.api.offSyncplayRoomEvent(syncplayRoomEventHandler)
+    syncplayRoomEventHandler = null
+  }
+  if (syncplayRemoteEpisodeChangeHandler) {
+    window.api.offSyncplayRemoteEpisodeChange(syncplayRemoteEpisodeChangeHandler)
+    syncplayRemoteEpisodeChangeHandler = null
+  }
+  if (syncplayTraceHandler) {
+    window.api.offSyncplayTrace(syncplayTraceHandler)
+    syncplayTraceHandler = null
+  }
+  if (syncplaySnapshotTimer) {
+    clearInterval(syncplaySnapshotTimer)
+    syncplaySnapshotTimer = null
+  }
+  if (syncplayToastTimer) {
+    clearTimeout(syncplayToastTimer)
+    syncplayToastTimer = null
+  }
+  if (syncplayWaitingTimer) {
+    clearTimeout(syncplayWaitingTimer)
+    syncplayWaitingTimer = null
+  }
   resetMseState()
   // Clean up remuxed temp files / active stream sessions
   if (remuxedPath.value || streamSessionId.value) {
@@ -1987,6 +2336,20 @@ const bufferedProgress = computed(() => {
       <div v-if="resumeToast" class="resume-toast">{{ resumeToast }}</div>
     </transition>
 
+    <!-- Syncplay toast -->
+    <transition name="fade">
+      <div v-if="syncplayToast" class="syncplay-toast">{{ syncplayToast }}</div>
+    </transition>
+
+    <!-- Syncplay: persistent "paused by X" badge while paused -->
+    <div
+      v-if="!playing && syncplayPausedBy && syncplayStatus.state === 'ready'"
+      class="syncplay-paused-by"
+    >
+      <span class="syncplay-paused-icon">⏸</span>
+      Paused by {{ syncplayPausedBy === syncplayStatus.username ? 'you' : syncplayPausedBy }}
+    </div>
+
     <!-- Video wrapper: SubtitlesOctopus inserts its canvas after the <video>, so this
          positioned container ensures the subtitle overlay covers the video area -->
     <div class="video-wrapper">
@@ -1998,10 +2361,12 @@ const bufferedProgress = computed(() => {
         crossorigin="anonymous"
         @play="onPlay"
         @pause="onPause"
+        @seeked="onVideoSeeked"
         @timeupdate="onTimeUpdate"
         @durationchange="onDurationChange"
         @progress="onProgress"
         @canplay="onCanPlay"
+        @waiting="onVideoWaiting"
         @ended="onVideoEnded"
         @click="togglePlay"
         @dblclick="toggleFullscreen"
@@ -2242,6 +2607,50 @@ const bufferedProgress = computed(() => {
             No GPU
           </div>
 
+          <!-- Watch Together (Syncplay) -->
+          <div class="preset-wrapper">
+            <button
+              class="ctrl-btn preset-btn syncplay-btn"
+              :class="{ active: syncplayStatus.state === 'ready' }"
+              @click="syncplayMenuOpen = !syncplayMenuOpen"
+              title="Watch Together"
+            >
+              <span class="sp-dot" :class="'sp-' + syncplayStatus.state"></span>
+              <span class="sp-label">Sync</span>
+            </button>
+            <div v-if="syncplayMenuOpen" class="preset-menu syncplay-menu" @click.stop>
+              <div class="sp-status-line">
+                Status: <strong>{{ syncplayStatus.state }}</strong>
+                <span v-if="syncplayStatus.tls" class="sp-tls-badge">TLS</span>
+              </div>
+              <div v-if="syncplayStatus.error" class="sp-error-line">{{ syncplayStatus.error }}</div>
+              <label class="sp-label-row" for="sp-room-input">Room</label>
+              <input
+                id="sp-room-input"
+                v-model="syncplayRoomInput"
+                type="text"
+                class="sp-input"
+                placeholder="room name"
+                :disabled="syncplayStatus.state !== 'idle' && syncplayStatus.state !== 'disconnected'"
+              />
+              <button class="sp-action-btn" @click="toggleSyncplayConnection()">
+                {{ syncplayStatus.state === 'idle' || syncplayStatus.state === 'disconnected' ? 'Connect' : 'Disconnect' }}
+              </button>
+              <div v-if="syncplayRoomUsers.length > 0" class="sp-users-list">
+                <div class="sp-users-title">In room</div>
+                <div v-for="u in syncplayRoomUsers" :key="u.username" class="sp-user-row">
+                  <span
+                    class="sp-user-dot"
+                    :class="u.isReady === false ? 'sp-user-dot-buffering' : 'sp-user-dot-ready'"
+                    :title="u.isReady === false ? 'Buffering' : 'Ready'"
+                  ></span>
+                  <span class="sp-user-name">{{ u.username }}</span>
+                  <span v-if="u.file" class="sp-user-file" :title="u.file.name">{{ u.file.name }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Fullscreen -->
           <button class="ctrl-btn" @click="toggleFullscreen" :title="isFullscreen ? 'Exit fullscreen' : 'Fullscreen'">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -2352,6 +2761,187 @@ const bufferedProgress = computed(() => {
   font-size: 0.8rem;
   z-index: 10;
   pointer-events: none;
+}
+
+.syncplay-toast {
+  position: absolute;
+  top: 140px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 52, 96, 0.9);
+  color: #e0e0e0;
+  padding: 6px 16px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  z-index: 10;
+  pointer-events: none;
+  max-width: 60vw;
+  text-align: center;
+}
+
+.syncplay-paused-by {
+  position: absolute;
+  top: 72px;
+  left: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(15, 52, 96, 0.85);
+  color: #e0e0e0;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  z-index: 10;
+  pointer-events: none;
+  border: 1px solid rgba(96, 150, 255, 0.4);
+}
+
+.syncplay-paused-icon {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.syncplay-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sp-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #6a6a8a;
+}
+
+.sp-dot.sp-idle,
+.sp-dot.sp-disconnected {
+  background: #6a6a8a;
+}
+
+.sp-dot.sp-connecting,
+.sp-dot.sp-tls-probing,
+.sp-dot.sp-tls-handshake,
+.sp-dot.sp-hello-sent,
+.sp-dot.sp-reconnecting {
+  background: #f0932b;
+}
+
+.sp-dot.sp-ready {
+  background: #6ab04c;
+}
+
+.sp-label {
+  font-size: 0.8rem;
+}
+
+.syncplay-menu {
+  min-width: 240px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sp-status-line {
+  font-size: 0.8rem;
+  color: #a0a0b8;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sp-tls-badge {
+  font-size: 0.65rem;
+  background: #0f3460;
+  color: #e0e0e0;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.sp-error-line {
+  color: #e94560;
+  font-size: 0.75rem;
+}
+
+.sp-label-row {
+  font-size: 0.75rem;
+  color: #a0a0b8;
+  margin-top: 4px;
+}
+
+.sp-input {
+  width: 100%;
+  padding: 6px 8px;
+  background: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  color: #e0e0e0;
+  font-size: 0.8rem;
+}
+
+.sp-input:disabled {
+  opacity: 0.55;
+}
+
+.sp-action-btn {
+  padding: 6px 12px;
+  background: #e94560;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sp-action-btn:hover {
+  background: #d13b53;
+}
+
+.sp-users-list {
+  border-top: 1px solid #0f3460;
+  padding-top: 6px;
+  margin-top: 4px;
+}
+
+.sp-users-title {
+  font-size: 0.75rem;
+  color: #a0a0b8;
+  margin-bottom: 4px;
+}
+
+.sp-user-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 6px;
+  font-size: 0.8rem;
+  padding: 2px 0;
+  align-items: center;
+}
+
+.sp-user-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  grid-row: 1 / span 2;
+}
+
+.sp-user-dot-ready {
+  background: #4ade80;
+}
+
+.sp-user-dot-buffering {
+  background: #f59e0b;
+}
+
+.sp-user-file {
+  grid-column: 2;
+  font-size: 0.7rem;
+  color: #6a6a8a;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Remux overlay */

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -2,7 +2,7 @@
 import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
 import { formatBytes } from '../utils'
 
-const activeTab = ref<'general' | 'storage' | 'connectors' | 'merging' | 'player' | 'shortcuts' | 'debug'>('general')
+const activeTab = ref<'general' | 'storage' | 'connectors' | 'merging' | 'player' | 'shortcuts' | 'watch-together' | 'debug'>('general')
 
 const token = ref('')
 const translationType = ref('subRu')
@@ -145,6 +145,16 @@ const shikimoriCode = ref('')
 const shikimoriConnecting = ref(false)
 const shikimoriError = ref('')
 const shikimoriShowUrl = ref(false)
+
+// Watch Together (Syncplay)
+const syncplayHost = ref('syncplay.pl')
+const syncplayPort = ref(8999)
+const syncplayRoom = ref('')
+const syncplayUsername = ref('')
+const syncplayPassword = ref('')
+const syncplayAutoReconnect = ref(true)
+const syncplayTestStatus = ref<'idle' | 'testing' | 'ok' | 'failed'>('idle')
+const syncplayTestError = ref('')
 
 // Player settings
 const playerMode = ref<'system' | 'builtin'>('system')
@@ -562,6 +572,10 @@ onUnmounted(() => {
     clearInterval(skipQueuePollTimer)
     skipQueuePollTimer = null
   }
+  if (syncplaySaveTimer) {
+    clearTimeout(syncplaySaveTimer)
+    syncplaySaveTimer = null
+  }
 })
 
 const TRANSLATION_TYPES = [
@@ -621,6 +635,25 @@ onMounted(async () => {
   shortcutBindings.value = saved ? { ...DEFAULT_SHORTCUTS, ...saved } : { ...DEFAULT_SHORTCUTS }
 
   shikimoriUser.value = await window.api.shikimoriGetUser()
+
+  // Watch Together settings
+  const sp = (await window.api.getSetting('syncplay')) as {
+    lastHost?: string
+    lastPort?: number
+    lastRoom?: string
+    username?: string
+    autoReconnect?: boolean
+  } | null
+  if (sp) {
+    syncplayHost.value = sp.lastHost || 'syncplay.pl'
+    syncplayPort.value = sp.lastPort || 8999
+    syncplayRoom.value = sp.lastRoom || ''
+    syncplayUsername.value = sp.username || ''
+    syncplayAutoReconnect.value = sp.autoReconnect ?? true
+  }
+  if (!syncplayUsername.value && shikimoriUser.value) {
+    syncplayUsername.value = shikimoriUser.value.nickname
+  }
 
   // Player settings
   playerMode.value = ((await window.api.getSetting('playerMode')) as string as typeof playerMode.value) || 'system'
@@ -790,6 +823,77 @@ watch(playerMode, (val) => { if (loaded.value) autoSave('playerMode', val) })
 watch(anime4kPreset, (val) => { if (loaded.value) autoSave('anime4kPreset', val) })
 watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeOnPlay', val) })
 watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatchedDays', Number(val) || 0) })
+
+function saveSyncplaySettings(): void {
+  if (!loaded.value) return
+  window.api.setSetting('syncplay', {
+    lastHost: syncplayHost.value.trim(),
+    lastPort: Math.max(1, Math.min(65535, Number(syncplayPort.value) || 8999)),
+    lastRoom: syncplayRoom.value.trim(),
+    username: syncplayUsername.value.trim(),
+    autoReconnect: syncplayAutoReconnect.value
+  })
+  showSaved()
+}
+let syncplaySaveTimer: ReturnType<typeof setTimeout> | null = null
+function scheduleSyncplaySave(): void {
+  if (syncplaySaveTimer) clearTimeout(syncplaySaveTimer)
+  syncplaySaveTimer = setTimeout(saveSyncplaySettings, 600)
+}
+watch([syncplayHost, syncplayPort, syncplayRoom, syncplayUsername], () => {
+  if (loaded.value) scheduleSyncplaySave()
+})
+watch(syncplayAutoReconnect, () => {
+  if (loaded.value) saveSyncplaySettings()
+})
+
+async function testSyncplayConnection(): Promise<void> {
+  const host = syncplayHost.value.trim()
+  const port = Number(syncplayPort.value) || 8999
+  const room = syncplayRoom.value.trim() || 'test-room'
+  const username = syncplayUsername.value.trim() || 'anime-dl-user'
+  if (!host) return
+  syncplayTestStatus.value = 'testing'
+  syncplayTestError.value = ''
+
+  const handler = (status: SyncplayStatus): void => {
+    if (status.state === 'ready') {
+      syncplayTestStatus.value = 'ok'
+      window.api.offSyncplayConnectionStatus(handler)
+      window.api.syncplayDisconnect()
+    } else if (status.state === 'disconnected') {
+      if (syncplayTestStatus.value === 'testing') {
+        syncplayTestStatus.value = 'failed'
+        syncplayTestError.value = status.error || 'Connection closed'
+      }
+      window.api.offSyncplayConnectionStatus(handler)
+    }
+  }
+  window.api.onSyncplayConnectionStatus(handler)
+
+  try {
+    await window.api.syncplayConnect({
+      host,
+      port,
+      room,
+      username,
+      password: syncplayPassword.value || undefined,
+      autoReconnect: false
+    })
+    setTimeout(() => {
+      if (syncplayTestStatus.value === 'testing') {
+        syncplayTestStatus.value = 'failed'
+        syncplayTestError.value = 'Timed out after 10s'
+        window.api.offSyncplayConnectionStatus(handler)
+        window.api.syncplayDisconnect()
+      }
+    }, 10_000)
+  } catch (err) {
+    syncplayTestStatus.value = 'failed'
+    syncplayTestError.value = String(err)
+    window.api.offSyncplayConnectionStatus(handler)
+  }
+}
 </script>
 
 <template>
@@ -804,6 +908,10 @@ watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatched
       <button class="tab" :class="{ active: activeTab === 'merging' }" @click="activeTab = 'merging'">Merging</button>
       <button class="tab" :class="{ active: activeTab === 'player' }" @click="activeTab = 'player'">Player</button>
       <button class="tab" :class="{ active: activeTab === 'shortcuts' }" @click="activeTab = 'shortcuts'">Shortcuts</button>
+      <button class="tab" :class="{ active: activeTab === 'watch-together' }" @click="activeTab = 'watch-together'">
+        Watch Together
+        <span class="tab-dev-badge">in development</span>
+      </button>
       <button class="tab" :class="{ active: activeTab === 'debug' }" @click="activeTab = 'debug'; refreshMismatchCount()">Debug</button>
     </div>
     <div class="body">
@@ -1337,6 +1445,78 @@ watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatched
       </template>
 
       <!-- Debug tab -->
+      <template v-if="activeTab === 'watch-together'">
+        <div class="dev-banner">
+          <strong>Feature in development.</strong>
+          Sync, attribution, and reconnect behavior may misfire — especially on
+          rapid arrow-key seeks or shaky connections. Please report quirks with
+          a screen recording or the renderer console log.
+        </div>
+        <div class="setting-group">
+          <label class="setting-label">Watch Together (Syncplay)</label>
+          <p class="setting-hint">
+            Sync play/pause/seek with friends over the Internet via the Syncplay protocol.
+            Works with other Syncplay clients (mpv, VLC) in the same room.
+          </p>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label" for="sp-host">Server</label>
+          <p class="setting-hint">Default: <code>syncplay.pl</code> on port <code>8999</code>.</p>
+          <div class="sp-host-row">
+            <input id="sp-host" v-model="syncplayHost" type="text" class="setting-input" placeholder="syncplay.pl" />
+            <input v-model.number="syncplayPort" type="number" min="1" max="65535" class="setting-input sp-port-input" />
+          </div>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label" for="sp-room">Default room</label>
+          <p class="setting-hint">Preselected room name when you open the Watch Together popover in the player. Any non-empty string is accepted; share it with friends out-of-band.</p>
+          <input id="sp-room" v-model="syncplayRoom" type="text" class="setting-input" placeholder="my-anime-room" />
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label" for="sp-user">Username</label>
+          <p class="setting-hint">Shown to other room members. Defaults to your Shikimori nickname if signed in.</p>
+          <input id="sp-user" v-model="syncplayUsername" type="text" class="setting-input" placeholder="username" />
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label" for="sp-password">Password (optional)</label>
+          <p class="setting-hint">Some servers require a password to log in. Leave empty for public servers.</p>
+          <input id="sp-password" v-model="syncplayPassword" type="password" class="setting-input" placeholder="" />
+        </div>
+
+        <div class="setting-group">
+          <p class="setting-hint">
+            Connections are encrypted with TLS (required). The server must run Syncplay 1.6.3+ and present a
+            valid TLS certificate for its hostname; servers that only accept plaintext are not supported.
+          </p>
+        </div>
+
+        <div class="setting-group">
+          <label class="toggle-row">
+            <input type="checkbox" v-model="syncplayAutoReconnect" />
+            <span>Auto-reconnect on disconnect</span>
+          </label>
+          <p class="setting-hint">Retry with exponential backoff up to 5 times after a network drop.</p>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">Test connection</label>
+          <p class="setting-hint">Connects briefly with the current settings, then disconnects.</p>
+          <button class="merge-all-btn" @click="testSyncplayConnection" :disabled="syncplayTestStatus === 'testing'">
+            {{ syncplayTestStatus === 'testing' ? 'Testing…' : 'Test connection' }}
+          </button>
+          <div v-if="syncplayTestStatus === 'ok'" class="token-result token-valid" style="margin-top: 6px">
+            Connected successfully
+          </div>
+          <div v-if="syncplayTestStatus === 'failed'" class="token-result token-invalid" style="margin-top: 6px">
+            {{ syncplayTestError || 'Connection failed' }}
+          </div>
+        </div>
+      </template>
+
       <template v-if="activeTab === 'debug'">
         <div class="setting-group">
           <label class="setting-label">FFmpeg Info</label>
@@ -1536,6 +1716,35 @@ watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatched
   border-bottom-color: #e94560;
 }
 
+.tab-dev-badge {
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.18);
+  color: #f59e0b;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+.dev-banner {
+  margin-bottom: 18px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.08);
+  color: #e0c382;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.dev-banner strong {
+  color: #f59e0b;
+  margin-right: 4px;
+}
+
 .body {
   flex: 1;
   overflow-y: auto;
@@ -1641,6 +1850,16 @@ watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatched
   align-items: center;
   gap: 8px;
   margin-top: 8px;
+}
+
+.sp-host-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.sp-port-input {
+  max-width: 100px;
 }
 
 .speed-input {


### PR DESCRIPTION
## Summary

Implements Watch Together via the Syncplay protocol. Compatible with the public `syncplay.pl` servers and the reference mpv/VLC Syncplay client, so a friend on any Syncplay-supported player can watch along.

> [!WARNING]
> **Feature in development.** Sync, attribution, and reconnect behavior may misfire — especially on rapid arrow-key seeks or shaky connections. The Settings tab is marked accordingly.

- **Main protocol client** (`src/main/syncplay.ts`): TCP/TLS with Hello handshake, STARTTLS upgrade, line-delimited JSON parser, `ignoringOnTheFly` echo-suppression counters, 1 s heartbeat, RTT compensation, exponential-backoff auto-reconnect.
- **File identity**: canonical `"{animeName} - {episodeInt}"` + duration so instances on different translations/qualities/local-vs-CDN still match; `features.animeDlAppMeta = {animeId, malId, episodeInt, translationId}` rides along so two instances of this app auto-navigate when the other advances episodes.
- **Readiness gate**: when either side's MSE buffer runs out (`waiting` event, debounced 600 ms; or the custom `waitForBufferAhead` path), `Set.ready(false)` keeps both clients paused until everyone's caught up. Member list shows a green/amber dot per user.
- **"Paused by X" badge** in the player while paused; only updates on actual play↔pause transitions to avoid mis-attribution from heartbeats.
- **Settings** → new Watch Together tab (host, port, room, username, password, preferTls, autoReconnect, Test connection). Tab carries an "in development" badge. Persisted under new `syncplay` electron-store key; session state not persisted across restarts.
- **PlayerView** → Syncplay popover button in controls bar, local video events → remote state, remote state applied with 3 s drift tolerance (or `doSeek`), echo suppression via main-side counter + 1.5 s renderer flag, 1 s renderer-pushed position snapshot.
- **Remote episode auto-nav** when `animeId` matches current anime; toast-only for cross-anime or missing episodes.
- `DESIGN.md` updated (Watch Together section, IPC rows, `syncplay:set-ready` row, readiness gate description).
- Rebased onto current `main` (v3.17.0); version bumped to **3.18.0**.

Debug tracing behind `SYNCPLAY_DEBUG=1` env var, plus `syncplay:trace` IPC for renderer-side console logging of every inbound/outbound message.

## Test plan

- [ ] Two instances of this app, same room, same episode — play/pause/seek sync within ~500 ms
- [ ] One instance on CDN stream, other on local MKV of same episode — still syncs on position
- [ ] Seek into unbuffered region on one side — both stay paused via readiness gate, resume together
- [ ] Pause on A — B sees "Paused by A", A sees "Paused by you"; attribution survives 1 s heartbeat
- [ ] Rapid arrow-key seeks — no pause/play ping-pong (still flaky, see warning above)
- [ ] User A advances to next episode — User B auto-navigates
- [ ] User A switches translation mid-episode — position sync continues
- [ ] Interop with mpv + Syncplay reference client in the same room — bidirectional
- [ ] Network drop — toast, auto-reconnect, resume
- [ ] Wrong password — error toast, no retry storm
- [ ] Settings > Watch Together > Test connection — reports OK or the server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)