### PR TITLE
[TEST] Local Bot API artifact attach — will close without merging

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,10 @@ import { randomUUID } from 'crypto'
 import { SmotretApi } from './smotret-api'
 import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, EpisodeDetail, Translation } from './smotret-api'
 
+// Local Bot API artifact-attach validation marker — remove when closing test PR.
+const __ARTIFACT_ATTACH_TEST__ = '2026-04-23'
+void __ARTIFACT_ATTACH_TEST__
+
 // Enable WebGPU (Anime4K shaders) and platform HEVC decoding (HEVC MKV via MSE).
 // PlatformHEVCDecoderSupport gates Chromium's HEVC path in <video> and MSE;
 // without it, MediaSource.isTypeSupported('…hvc1…') returns false even on


### PR DESCRIPTION
Test PR to validate that the Telegram notification bot can now attach full build artifacts (>50 MB) directly to Telegram after switching from the cloud Bot API to a local `aiogram/telegram-bot-api` container.

Will be closed without merging once the artifact-attach path is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)