### PR TITLE
Fix auto-advance timer leak triggering multi-episode skip

### DIFF
--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -1575,6 +1575,7 @@ function cancelAutoAdvance(): void {
 
 function onVideoEnded(): void {
   if (!canNext.value) return
+  if (autoAdvanceTimer) return
   autoAdvanceCountdown.value = 5
   autoAdvanceTimer = setInterval(() => {
     autoAdvanceCountdown.value--


### PR DESCRIPTION
## Summary
- Guard `onVideoEnded` against re-entry while a countdown is already active in `src/renderer/src/components/PlayerView.vue`.
- Prevents stacked `setInterval` timers from leaking and triggering rapid sequential episode skips.

Fixes #40

## Root cause
Multiple `ended` events (e.g. from MediaSource stutter or seekbar clicks near the end) each created a new `setInterval` and overwrote `autoAdvanceTimer`, leaving prior intervals unreferenced. A leaked timer's countdown reaches zero while `navigating` is locked, then fires immediately once the next episode loads — cascading through the season.

## Test plan
- [x] Open episode in built-in player, seek to last 1–2s, click seekbar end repeatedly, confirm only one countdown overlay appears and only one episode advance happens.
- [x] Cancel button still aborts the countdown.
- [x] Normal end-of-episode auto-advance still works.