### PR TITLE
ci: skip PR artifact build when only docs changed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,10 +19,12 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,9 +8,35 @@ on:
     types: [created]
 
 jobs:
-  build:
+  changes:
+    # Detect whether a PR touches anything other than docs. Output is consumed by
+    # the build job to skip the artifact build (and the artifacts comment) when
+    # only documentation changed. /build comments bypass this check entirely.
     if: >
-      github.event_name == 'pull_request' || 
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!*.md'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.gitattributes'
+
+  build:
+    needs: changes
+    if: >
+      (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
     strategy:
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     # Detect whether a PR touches anything other than docs. Output is consumed by


### PR DESCRIPTION
## Summary
PR #43 (a TODO-only docs change) triggered the full 3-platform artifact build, which is wasted CI for changes that touch no shipping code. This PR adds a `changes` job using `dorny/paths-filter` to detect whether a PR touches anything other than docs, and gates the `build` matrix on the result.

- Docs-only PRs (only `*.md`, `LICENSE`, `.gitignore`, `.gitattributes`) → `build` and `comment-artifacts` skip cleanly. Both report as "skipped" rather than failed, so required-status-check semantics are preserved.
- Code PRs → unchanged behavior: full build + artifacts comment.
- `/build` issue-comment override → still forces a build regardless of touched paths (so reviewers can manually request artifacts on a docs PR if needed).

## Test plan
- [ ] Open a docs-only PR after merge; confirm the build matrix is skipped and no artifacts comment is posted.
- [ ] Open a code PR after merge; confirm the build matrix runs as before and the artifacts comment posts.
- [ ] Comment `/build` on a docs PR; confirm the override still triggers a build.