### PR TITLE
ci: rewrite paths-filter as allowlist of build-relevant paths

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,14 +29,18 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
+          # Allowlist: build only when files that actually feed into the
+          # electron-vite + electron-builder output change. Anything outside
+          # this list (docs, .github/, LICENSE, scripts unrelated to the bundle)
+          # is treated as a no-op and skips the artifact build.
           filters: |
             code:
-              - '**'
-              - '!**/*.md'
-              - '!*.md'
-              - '!LICENSE'
-              - '!.gitignore'
-              - '!.gitattributes'
+              - 'src/**'
+              - 'resources/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'electron.vite.config.*'
+              - 'tsconfig*.json'
 
   build:
     needs: changes


### PR DESCRIPTION
## Summary

PR #44 tried to skip the multi-platform artifact build on docs-only PRs but didn't actually work. PR #45 (a markdown-only test PR) still triggered all three builds. The workflow run showed `dorny/paths-filter` evaluating `code = true` and listing `TEST_BOT_REVIEW.md` as a matching file.

## Root cause

The previous denylist relied on negated patterns under `paths-filter`'s default `predicate-quantifier: some` (OR). With `some`, a file matches the filter if **any** rule matches:

- `**` always matches every file → `true`
- `!**/*.md` is a separate inverse rule → `false` only for `.md` files

Since `**` is always `true`, the negations never excluded anything.

## Fix

Switch to an explicit allowlist of paths that feed into `electron-vite` + `electron-builder`:

- `src/**`
- `resources/**`
- `package.json`
- `package-lock.json`
- `electron.vite.config.*`
- `tsconfig*.json`

Anything outside this list — `.github/` workflow edits, `*.md` docs, `LICENSE`, `scripts/`, root configs — is now a no-op for the build. The `/build` comment escape hatch still bypasses the filter when needed.

## Test plan

- [x] Reproduced bug on PR #45 (markdown-only branch built all three platforms).
- [ ] This PR is itself a `.github/` change → with the new filter, the `build` jobs should be skipped (only `changes` runs).
- [ ] Follow-up scratch PR touching `src/main/index.ts` only should still trigger the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)