### PR TITLE
feat: aniskip skip intro/outro overlay (v3.14.0)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,6 +31,7 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/main/smotret-api.ts` | Smotret-Anime API client: search, anime/episode details, embed, subtitles, token validation |
 | `src/main/download-manager.ts` | Download queue, concurrent downloads, progress, ffmpeg merge, scan-merge |
 | `src/main/shikimori.ts` | Shikimori API client: OAuth, token refresh, user rates, anime list |
+| `src/main/aniskip.ts` | Aniskip API client: cache-first skip-intro/skip-outro timestamps (provisional, see "Aniskip Skip-Intro / Skip-Outro") |
 | `src/main/ffmpeg-static.d.ts` | Type declaration for ffbinaries module |
 | `src/preload/index.ts` | contextBridge API exposure to renderer |
 | `src/preload/index.d.ts` | Shared TypeScript interfaces for IPC communication |
@@ -346,6 +347,7 @@ LibraryView shows both with indicators:
 | `player:cleanup-remux` | invoke | Kill any active stream sessions and delete all temp remuxed files |
 | `shell:open-external` | invoke | Open URL in default browser (returns success boolean) |
 | `shell:open-external-file` | invoke | Open a local file with the OS default app via `shell.openPath` (returns `{ ok, error? }`) |
+| `aniskip:get-skip-times` | invoke | Cache-first lookup of OP/ED skip timestamps from aniskip.com (30-day TTL); returns `[]` on miss/error/`malId<=0`. Provider isolated in `src/main/aniskip.ts` for cheap swap |
 
 ## Key Types
 
@@ -420,6 +422,9 @@ interface EpisodeMeta {
 | `shikimoriUserRates` | array | `[]` | Cached Shikimori anime rate entries (served cache-first, background-refreshed) |
 | `shikimoriUpdateQueue` | array | `[]` | Pending rate updates queued when the `update-rate` IPC failed due to a network error (for later sync) |
 | `shikimoriAnimeDetails` | object | `{}` | Pre-fetched per-anime Shikimori details (description, genres, studios) keyed by MAL ID; populated by the throttled background worker |
+| `aniskipCache` | object | `{}` | Cached aniskip.com responses keyed by `malId:episode:roundedDuration`. Each entry: `{ times: SkipTime[]; fetchedAt: number }`. 30-day TTL |
+| `autoSkipIntro` | boolean | `false` | When true, the built-in player automatically jumps past openings using aniskip timestamps (button overlay still shows regardless) |
+| `autoSkipOutro` | boolean | `false` | When true, the built-in player automatically jumps past endings using aniskip timestamps |
 
 ## Watch Progress & Resume
 
@@ -506,6 +511,20 @@ Translation resolution for the target episode: (1) prefer any downloaded transla
 Auto-advance: when video ends and next episode is available, shows a 5-second countdown overlay. User can cancel or let it auto-navigate to the next episode.
 
 Configurable keyboard shortcuts: `playerPrevEpisode` (default Shift+ArrowLeft) and `playerNextEpisode` (default Shift+ArrowRight) in Settings > Shortcuts.
+
+### Aniskip Skip-Intro / Skip-Outro
+
+Crowdsourced opening/ending timestamps from [aniskip.com](https://aniskip.com), keyed by MAL ID + episode number. The provider is isolated to `src/main/aniskip.ts` and a single IPC channel (`aniskip:get-skip-times`) so it can be swapped cheaply later.
+
+- **API**: `GET https://api.aniskip.com/v2/skip-times/{malId}/{episode}?types[]=op&types[]=ed&episodeLength={duration}`. Returns `{ found, results: [{ skipType: 'op'|'ed', interval: { startTime, endTime }, episodeLength, skipId }] }`. 30s `AbortController`. On non-2xx, network error, or `found:false` the module returns `[]` silently — best-effort UX.
+- **Cache**: `aniskipCache` (electron-store) keyed by `${malId}:${episode}:${Math.round(duration)}`. 30-day TTL — expired entries are refetched on next ask. Lookups bail with `[]` for `malId <= 0` or non-finite episode.
+- **Renderer**: `PlayerView` watches `[currentEpisodeInt, duration]` and calls `aniskipGetSkipTimes(malId, parseInt(episodeInt), Math.round(duration))` once both are valid. Fractional `.5` recap episodes are skipped (`String(parseInt(epStr)) !== epStr`). The `currentTime` watcher computes `activeSkip` (`t >= start && t < end - 1`) and renders a bottom-right "Skip Intro" / "Skip Outro" overlay button. Click → `seek(end)`.
+- **Auto-skip**: When `activeSkip` becomes non-null AND the matching toggle (`autoSkipIntro` / `autoSkipOutro`) is on AND `lastAutoSkippedId !== skipId`, a 250 ms grace timer fires `seek(end)` and stamps `lastAutoSkippedId`. The grace prevents an immediate manual seek-back from re-firing; `lastAutoSkippedId` blocks re-skip if the user seeks back into the same interval. Both reset on episode change via `resetEpisodeTracking()`.
+- **Pre-fetch worker**: Module-level FIFO queue + 1 req/s throttle + dedup against the same cache. Triggered when:
+  - **`library-toggle` (add path)**: enqueues `1..min(episodes_aired, 100)` for the just-added anime if a positive MAL ID can be resolved (via `animeCache[id].animeDetail.myAnimeListId`). Episode count comes from cached `shikimoriAnimeDetails.episodes_aired`, falling back to `anime.numberOfEpisodes` or 12.
+  - **`onMergeComplete`**: enqueues just `[parseInt(episodeLabel)]` for the merged episode after resolving MAL ID via `downloadedAnime` lookup.
+  Pre-fetched entries warm the cache for offline playback of library/downloaded anime.
+- **UX caveats**: Aniskip is crowdsourced, so timestamps are occasionally inaccurate. v1 default is button-only; auto-skip is opt-in. Settings hint flags this. End-credits stingers are a known risk — if QA shows `ed` intervals routinely overshoot into stinger territory, `autoSkipOutro` can be ignored at the player level without schema changes.
 
 ### WebGPU Requirements
 

--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,4 @@
 - [x] Conflict-Aware Automatic Sync for Offline Changes
 - [x] Gradual Background Pre-fetching of Shikimori Detailed Info
 - [x] HEVC → H.264 transcode fallback for platforms without an HEVC decoder
+- [x] Auto-Skip Intro / Outro (Aniskip) — manual button overlay with opt-in auto-skip toggles, 30-day cache, library/download pre-fetch worker, encapsulated behind `src/main/aniskip.ts` for easy provider swap (#53)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/aniskip.ts
+++ b/src/main/aniskip.ts
@@ -1,0 +1,67 @@
+// Aniskip API client — provisional skip-times provider.
+// See DESIGN.md "Aniskip Skip-Intro / Skip-Outro" and CLAUDE.md / project memory:
+// keep all aniskip-specific knowledge contained to this file + the
+// `aniskip:get-skip-times` IPC so we can swap providers cheaply later.
+
+const ANISKIP_BASE = 'https://api.aniskip.com/v2'
+const REQUEST_TIMEOUT_MS = 30_000
+
+export type SkipType = 'op' | 'ed'
+
+export interface SkipTime {
+  skipType: SkipType
+  interval: { startTime: number; endTime: number }
+  episodeLength: number
+  skipId: string
+}
+
+interface RawSkipTime {
+  skipType: string
+  interval: { startTime: number; endTime: number }
+  episodeLength: number
+  skipId: string
+}
+
+interface AniskipResponse {
+  found?: boolean
+  results?: RawSkipTime[]
+}
+
+export async function getSkipTimes(
+  malId: number,
+  episode: number,
+  duration: number
+): Promise<SkipTime[]> {
+  if (!Number.isFinite(malId) || malId <= 0) return []
+  if (!Number.isFinite(episode) || episode <= 0) return []
+
+  const params = new URLSearchParams()
+  params.append('types[]', 'op')
+  params.append('types[]', 'ed')
+  if (Number.isFinite(duration) && duration > 0) {
+    params.set('episodeLength', String(Math.round(duration)))
+  }
+  const url = `${ANISKIP_BASE}/skip-times/${malId}/${episode}?${params.toString()}`
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok) return []
+    const json = (await res.json()) as AniskipResponse
+    if (!json.found || !Array.isArray(json.results)) return []
+    return json.results
+      .filter((r): r is RawSkipTime => r && (r.skipType === 'op' || r.skipType === 'ed'))
+      .map((r) => ({
+        skipType: r.skipType as SkipType,
+        interval: { startTime: r.interval.startTime, endTime: r.interval.endTime },
+        episodeLength: r.episodeLength,
+        skipId: r.skipId
+      }))
+  } catch {
+    return []
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import * as os from 'os'
 import Ffmpeg from 'fluent-ffmpeg'
 import { autoUpdater } from 'electron-updater'
 import * as shikimori from './shikimori'
+import { getSkipTimes, type SkipTime } from './aniskip'
 import { pathToFileURL } from 'url'
 import { Readable } from 'stream'
 import { randomUUID } from 'crypto'
@@ -87,7 +88,10 @@ const store = new Store({
     shikimoriUserRates: [] as unknown[],
     shikimoriUpdateQueue: [] as unknown[],
     shikimoriAnimeDetails: {} as Record<string, { details: shikimori.ShikiAnimeDetails; fetchedAt: number }>,
-    recentAnimeMeta: {} as Record<string, AnimeSearchResult>
+    recentAnimeMeta: {} as Record<string, AnimeSearchResult>,
+    aniskipCache: {} as Record<string, { times: SkipTime[]; fetchedAt: number }>,
+    autoSkipIntro: false,
+    autoSkipOutro: false
   }
 })
 
@@ -458,6 +462,98 @@ async function prefetchShikimoriDetails(): Promise<void> {
   } finally {
     prefetchInProgress = false
   }
+}
+
+// --- Aniskip cache + pre-fetch worker ---
+
+const ANISKIP_TTL_MS = 30 * 24 * 60 * 60 * 1000
+const ANISKIP_PREFETCH_INTER_REQUEST_MS = 1000
+const ANISKIP_PREFETCH_MAX_EPISODES = 100
+
+function aniskipCacheKey(malId: number, episode: number, duration: number): string {
+  return `${malId}:${episode}:${Math.round(duration)}`
+}
+
+async function getSkipTimesCached(
+  malId: number,
+  episode: number,
+  duration: number
+): Promise<SkipTime[]> {
+  if (!Number.isFinite(malId) || malId <= 0) return []
+  if (!Number.isFinite(episode) || episode <= 0) return []
+  const key = aniskipCacheKey(malId, episode, duration)
+  const cache = store.get('aniskipCache') as Record<string, { times: SkipTime[]; fetchedAt: number }>
+  const entry = cache[key]
+  const now = Date.now()
+  if (entry && now - entry.fetchedAt < ANISKIP_TTL_MS) {
+    return entry.times
+  }
+  const times = await getSkipTimes(malId, episode, duration)
+  cache[key] = { times, fetchedAt: now }
+  store.set('aniskipCache', cache)
+  return times
+}
+
+const aniskipPrefetchQueue: Array<{ malId: number; episode: number; duration: number }> = []
+let aniskipPrefetchInFlight = false
+
+async function drainAniskipPrefetch(): Promise<void> {
+  if (aniskipPrefetchInFlight) return
+  aniskipPrefetchInFlight = true
+  try {
+    while (aniskipPrefetchQueue.length > 0) {
+      const item = aniskipPrefetchQueue.shift()!
+      try {
+        await getSkipTimesCached(item.malId, item.episode, item.duration)
+      } catch (err) {
+        console.warn('[aniskip prefetch] error', item.malId, item.episode, err)
+      }
+      if (aniskipPrefetchQueue.length > 0) {
+        await sleep(ANISKIP_PREFETCH_INTER_REQUEST_MS)
+      }
+    }
+  } finally {
+    aniskipPrefetchInFlight = false
+  }
+}
+
+function enqueueAniskipPrefetch(malId: number, episodes: number[]): void {
+  if (!Number.isFinite(malId) || malId <= 0) return
+  const now = Date.now()
+  const cache = store.get('aniskipCache') as Record<string, { times: SkipTime[]; fetchedAt: number }>
+  let added = 0
+  for (const ep of episodes.slice(0, ANISKIP_PREFETCH_MAX_EPISODES)) {
+    if (!Number.isFinite(ep) || ep <= 0) continue
+    // Skip if any cached entry for this (malId, ep) is still fresh — keys vary by
+    // duration, so check entries by prefix.
+    const prefix = `${malId}:${ep}:`
+    const fresh = Object.keys(cache).some(
+      (k) => k.startsWith(prefix) && now - cache[k].fetchedAt < ANISKIP_TTL_MS
+    )
+    if (fresh) continue
+    aniskipPrefetchQueue.push({ malId, episode: ep, duration: 0 })
+    added++
+  }
+  if (added > 0) void drainAniskipPrefetch()
+}
+
+function resolveMalIdForSmotretId(smotretId: number): number {
+  if (!Number.isFinite(smotretId) || smotretId <= 0) return 0
+  const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
+  const detail = cache[String(smotretId)]?.animeDetail
+  const malId = detail?.myAnimeListId
+  return typeof malId === 'number' && Number.isFinite(malId) && malId > 0 ? malId : 0
+}
+
+function airedEpisodeCountForMalId(malId: number, fallback: number): number {
+  const details = store.get('shikimoriAnimeDetails') as Record<
+    string,
+    { details: shikimori.ShikiAnimeDetails; fetchedAt: number }
+  >
+  const cached = details[String(malId)]?.details
+  const aired = cached?.episodes_aired ?? cached?.episodes
+  if (typeof aired === 'number' && Number.isFinite(aired) && aired > 0) return aired
+  return fallback
 }
 
 // --- Anime cache helpers (for offline support of downloaded anime) ---
@@ -1226,6 +1322,13 @@ function registerIpcHandlers(): void {
     } else {
       lib[key] = anime
       store.set('library', lib)
+      const malId = resolveMalIdForSmotretId(anime.id)
+      if (malId > 0) {
+        const epCount = airedEpisodeCountForMalId(malId, anime.numberOfEpisodes || 12)
+        const episodes: number[] = []
+        for (let i = 1; i <= epCount; i++) episodes.push(i)
+        enqueueAniskipPrefetch(malId, episodes)
+      }
       return true
     }
   })
@@ -1517,6 +1620,13 @@ function registerIpcHandlers(): void {
   ipcMain.handle('set-setting', (_event, key: string, value: unknown) => {
     store.set(key, value)
   })
+
+  ipcMain.handle(
+    'aniskip:get-skip-times',
+    (_event, malId: number, episode: number, duration: number) => {
+      return getSkipTimesCached(malId, episode, duration)
+    }
+  )
 
   // Watch progress tracking
   ipcMain.handle('watch-progress:save', (_event, animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean) => {
@@ -3268,6 +3378,17 @@ app.whenReady().then(async () => {
     const mode = store.get('notificationMode') as string
     if (mode === 'each') {
       showBackgroundNotification('Merge complete', `${animeName} \u2014 ${episodeLabel}`)
+    }
+    const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+    const matched = Object.entries(downloaded).find(
+      ([, anime]) => anime.title === animeName || anime.titles?.ru === animeName || anime.titles?.romaji === animeName
+    )
+    if (matched) {
+      const malId = resolveMalIdForSmotretId(Number(matched[0]))
+      const epNum = parseInt(episodeLabel, 10)
+      if (malId > 0 && Number.isFinite(epNum) && epNum > 0) {
+        enqueueAniskipPrefetch(malId, [epNum])
+      }
     }
   })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -241,6 +241,10 @@ const api = {
     ipcRenderer.removeAllListeners('shikimori:anime-details-updated')
   },
 
+  // Aniskip
+  aniskipGetSkipTimes: (malId: number, episode: number, duration: number) =>
+    ipcRenderer.invoke('aniskip:get-skip-times', malId, episode, duration) as Promise<SkipTime[]>,
+
   // Updates
   appVersion: () => ipcRenderer.invoke('app:version'),
   updateCheck: () => ipcRenderer.invoke('update:check'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -157,6 +157,9 @@ interface Api {
   ) => void
   offShikimoriAnimeDetailsUpdated: () => void
 
+  // Aniskip
+  aniskipGetSkipTimes: (malId: number, episode: number, duration: number) => Promise<SkipTime[]>
+
   // Updates
   appVersion: () => Promise<string>
   updateCheck: () => Promise<void>
@@ -164,6 +167,13 @@ interface Api {
   updateInstall: () => void
   onUpdateStatus: (callback: (data: UpdateStatus) => void) => void
   offUpdateStatus: () => void
+}
+
+interface SkipTime {
+  skipType: 'op' | 'ed'
+  interval: { startTime: number; endTime: number }
+  episodeLength: number
+  skipId: string
 }
 
 interface AnimeSearchResult {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -155,6 +155,46 @@ const WATCH_THRESHOLD_SECONDS = 180
 const SAVE_INTERVAL_MS = 5000
 const NEXT_MARK_PREV_WATCHED_MS = 60_000
 
+// Aniskip skip-intro / skip-outro state
+const skipTimes = ref<SkipTime[]>([])
+const lastAutoSkippedId = ref<string | null>(null)
+const autoSkipIntro = ref(false)
+const autoSkipOutro = ref(false)
+let pendingAutoSkipId: string | null = null
+let autoSkipTimer: ReturnType<typeof setTimeout> | null = null
+const AUTO_SKIP_GRACE_MS = 250
+const SKIP_OVERLAY_TAIL_S = 1
+
+const activeSkip = computed<SkipTime | null>(() => {
+  const t = currentTime.value
+  for (const s of skipTimes.value) {
+    if (t >= s.interval.startTime && t < s.interval.endTime - SKIP_OVERLAY_TAIL_S) {
+      return s
+    }
+  }
+  return null
+})
+
+function activeSkipLabel(skip: SkipTime): string {
+  return skip.skipType === 'op' ? 'Skip Intro' : 'Skip Outro'
+}
+
+function clearAutoSkipPending(): void {
+  if (autoSkipTimer) {
+    clearTimeout(autoSkipTimer)
+    autoSkipTimer = null
+  }
+  pendingAutoSkipId = null
+}
+
+function onSkipClick(): void {
+  const skip = activeSkip.value
+  if (!skip) return
+  clearAutoSkipPending()
+  lastAutoSkippedId.value = skip.skipId
+  seek(skip.interval.endTime)
+}
+
 function trackProgressDelta(now: number): void {
   if (lastTimeUpdateAt > 0 && playing.value && !seeking.value) {
     const delta = (now - lastTimeUpdateAt) / 1000
@@ -239,7 +279,50 @@ function resetEpisodeTracking(): void {
   lastSaveAt = 0
   watchedReported = false
   episodeOpenedAt = Date.now()
+  skipTimes.value = []
+  lastAutoSkippedId.value = null
+  clearAutoSkipPending()
 }
+
+watch([currentEpisodeInt, duration], async ([epStr, dur]) => {
+  skipTimes.value = []
+  lastAutoSkippedId.value = null
+  clearAutoSkipPending()
+  if (!props.malId || props.malId <= 0) return
+  if (!epStr || !dur || dur <= 0) return
+  const epNum = parseInt(epStr, 10)
+  if (!Number.isFinite(epNum) || epNum <= 0) return
+  if (String(epNum) !== epStr) return // fractional (.5) recap episodes — no aniskip data
+  try {
+    skipTimes.value = await window.api.aniskipGetSkipTimes(props.malId, epNum, Math.round(dur))
+  } catch (err) {
+    console.warn('[player] aniskip lookup failed:', err)
+    skipTimes.value = []
+  }
+})
+
+watch(activeSkip, (skip) => {
+  if (!skip) {
+    clearAutoSkipPending()
+    return
+  }
+  if (lastAutoSkippedId.value === skip.skipId) return
+  if (pendingAutoSkipId === skip.skipId) return
+  const wantSkip =
+    (skip.skipType === 'op' && autoSkipIntro.value) ||
+    (skip.skipType === 'ed' && autoSkipOutro.value)
+  if (!wantSkip) return
+  if (autoSkipTimer) clearTimeout(autoSkipTimer)
+  pendingAutoSkipId = skip.skipId
+  autoSkipTimer = setTimeout(() => {
+    autoSkipTimer = null
+    pendingAutoSkipId = null
+    const current = activeSkip.value
+    if (!current || current.skipId !== skip.skipId) return
+    lastAutoSkippedId.value = current.skipId
+    seek(current.interval.endTime)
+  }, AUTO_SKIP_GRACE_MS)
+})
 
 async function resumeFromSavedPosition(): Promise<void> {
   const video = videoRef.value
@@ -1698,6 +1781,12 @@ onMounted(async () => {
   if (typeof savedMuted === 'boolean') {
     muted.value = savedMuted
   }
+
+  // Aniskip auto-skip toggles (button overlay still shows regardless)
+  const savedAutoSkipIntro = await window.api.getSetting('autoSkipIntro') as boolean | null
+  if (typeof savedAutoSkipIntro === 'boolean') autoSkipIntro.value = savedAutoSkipIntro
+  const savedAutoSkipOutro = await window.api.getSetting('autoSkipOutro') as boolean | null
+  if (typeof savedAutoSkipOutro === 'boolean') autoSkipOutro.value = savedAutoSkipOutro
   await nextTick()
   suppressVolumePersist = false
 
@@ -1757,6 +1846,7 @@ onBeforeUnmount(() => {
     fn('cancel')
   }
   cancelAutoAdvance()
+  clearAutoSkipPending()
   stopAnime4KPipeline()
   destroySubtitles()
   // Pause and release video
@@ -1886,6 +1976,13 @@ const bufferedProgress = computed(() => {
       >
       </video>
     </div>
+
+    <!-- Aniskip skip-intro / skip-outro overlay -->
+    <transition name="fade">
+      <button v-if="activeSkip" class="skip-overlay" @click="onSkipClick">
+        {{ activeSkipLabel(activeSkip) }}
+      </button>
+    </transition>
 
     <!-- Canvas for Anime4K rendering -->
     <canvas
@@ -2197,6 +2294,30 @@ const bufferedProgress = computed(() => {
   font-size: 0.8rem;
   z-index: 10;
   pointer-events: none;
+}
+
+.skip-overlay {
+  position: absolute;
+  bottom: 88px;
+  right: 24px;
+  background: rgba(15, 52, 96, 0.92);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  z-index: 12;
+  transition: background 0.15s, transform 0.1s;
+}
+
+.skip-overlay:hover {
+  background: rgba(233, 69, 96, 0.92);
+}
+
+.skip-overlay:active {
+  transform: translateY(1px);
 }
 
 /* Remux overlay */

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -98,6 +98,8 @@ const playerMode = ref<'system' | 'builtin'>('system')
 const anime4kPreset = ref<'off' | 'mode-a' | 'mode-b' | 'mode-c'>('off')
 const hevcTranscodeOnPlay = ref<'ask' | 'always' | 'never'>('ask')
 const webgpuStatus = ref<{ available: boolean; gpuName: string }>({ available: false, gpuName: '' })
+const autoSkipIntro = ref(false)
+const autoSkipOutro = ref(false)
 
 // GPU benchmark state
 const benchmarking = ref(false)
@@ -451,6 +453,8 @@ onMounted(async () => {
   playerMode.value = ((await window.api.getSetting('playerMode')) as string as typeof playerMode.value) || 'system'
   anime4kPreset.value = ((await window.api.getSetting('anime4kPreset')) as string as typeof anime4kPreset.value) || 'off'
   hevcTranscodeOnPlay.value = ((await window.api.getSetting('hevcTranscodeOnPlay')) as string as typeof hevcTranscodeOnPlay.value) || 'ask'
+  autoSkipIntro.value = ((await window.api.getSetting('autoSkipIntro')) as boolean | null) || false
+  autoSkipOutro.value = ((await window.api.getSetting('autoSkipOutro')) as boolean | null) || false
 
   // Probe WebGPU
   try {
@@ -603,6 +607,8 @@ watch(videoCodec, (val, oldVal) => {
 watch(playerMode, (val) => { if (loaded.value) autoSave('playerMode', val) })
 watch(anime4kPreset, (val) => { if (loaded.value) autoSave('anime4kPreset', val) })
 watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeOnPlay', val) })
+watch(autoSkipIntro, (val) => { if (loaded.value) autoSave('autoSkipIntro', val) })
+watch(autoSkipOutro, (val) => { if (loaded.value) autoSave('autoSkipOutro', val) })
 </script>
 
 <template>
@@ -977,6 +983,21 @@ watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeO
 
         <div class="setting-group">
           <p class="setting-hint">Note: the built-in player supports local MKV playback via the MSE remux pipeline. For non-downloaded episodes, MKV files are streamed from the server — a Play button will appear on those rows when player mode is "Built-in". If a local HEVC MKV can't be decoded by your platform, the fallback above decides what happens.</p>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">Auto-skip intros / outros</label>
+          <p class="setting-hint">Use community-contributed timestamps from <a href="https://aniskip.com" target="_blank" rel="noopener">aniskip.com</a> to jump past openings and endings automatically. Manual "Skip Intro" / "Skip Outro" buttons appear regardless of these toggles. Timestamps are crowdsourced and occasionally inaccurate.</p>
+          <label class="toggle-row">
+            <input type="checkbox" v-model="autoSkipIntro" class="toggle-input" />
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">Auto-skip openings: {{ autoSkipIntro ? 'Enabled' : 'Disabled' }}</span>
+          </label>
+          <label class="toggle-row" style="margin-top: 0.4rem">
+            <input type="checkbox" v-model="autoSkipOutro" class="toggle-input" />
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">Auto-skip endings: {{ autoSkipOutro ? 'Enabled' : 'Disabled' }}</span>
+          </label>
         </div>
       </template>
 


### PR DESCRIPTION
## Summary

Implements issue #53 — built-in player gets a "Skip Intro" / "Skip Outro" overlay sourced from [aniskip.com](https://aniskip.com), plus opt-in auto-skip toggles in Settings → Player. Provider stays isolated behind `src/main/aniskip.ts` + the `aniskip:get-skip-times` IPC (project memory: aniskip is provisional).

- Persistent `aniskipCache` (30-day TTL) keyed by `malId:episode:duration`; cache-first lookup in main.
- Pre-fetch worker (~1 req/s, capped at 100 episodes per show) hooked into `library-toggle` (add path) and `downloadManager.onMergeComplete`, so offline playback of library/downloaded anime keeps overlays.
- 250 ms grace + `lastAutoSkippedId` guard prevents auto-skip from re-firing if the user seeks back into the same interval; both reset on episode change.
- Settings → Player gets two toggles (`autoSkipIntro`, `autoSkipOutro`, default off). Manual button overlay always shows when data exists.
- DESIGN.md updated with new IPC row, three settings rows, and a "Aniskip Skip-Intro / Skip-Outro" subsection covering API, cache, auto-skip semantics, and pre-fetch worker.

Fixes #53

## Test plan

- [x] \`npm run typecheck\` passes
- [x] Verified end-to-end on Jujutsu Kaisen S1 — overlay appears at OP start, click jumps to OP end, auto-skip path gated correctly behind the toggle
- [ ] Tried Frieren S1 ep 2 — aniskip data for that show is timed against a different cut than smotret's encode (consistent ~6 s offset on both ends), so the overlay fires late. Documented as a known limit (crowdsourced data); other shows align fine
- [ ] Confirm pre-fetch warms \`aniskipCache\` after \`library-toggle\` (add) and after a merge completes