### PR TITLE
feat: storage usage dashboard and auto-cleanup of watched episodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,7 +83,12 @@ const store = new Store({
     playerMuted: false,
     anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
     hevcTranscodeOnPlay: 'ask' as 'ask' | 'always' | 'never',
-    watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>,
+    watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>,
+    watchProgressMigrationV2: false,
+    autoCleanupWatchedDays: 0,
+    autoCleanupConfirm: true,
+    autoCleanupLastRun: null as { ranAt: number; deletedCount: number; freedBytes: number } | null,
+    cleanupLog: [] as { ranAt: number; animeId: number; animeName: string; episodeInt: string; bytes: number }[],
     shikimoriUserRates: [] as unknown[],
     shikimoriUpdateQueue: [] as unknown[],
     shikimoriAnimeDetails: {} as Record<string, { details: shikimori.ShikiAnimeDetails; fetchedAt: number }>,
@@ -837,6 +842,89 @@ function storageDirsForScan(): string[] {
   return dirs
 }
 
+function deleteEpisodeFiles(animeName: string, episodeInt: string, animeId?: number, translationId?: number): { bytesDeleted: number } {
+  fileCheckCache.delete(animeName)
+  const animeDirName = sanitizeFilename(animeName)
+  const dirsToCheck = storageDirsForScan()
+
+  const padded = episodeInt.padStart(2, '0')
+  const base = sanitizeFilename(`${animeName} - ${padded}`)
+
+  let bytesDeleted = 0
+  const trySize = (p: string): number => {
+    try { return fs.statSync(p).size } catch { return 0 }
+  }
+
+  if (translationId && animeId) {
+    // Delete specific translation's files — find by author tag from metadata
+    const episodes = store.get('downloadedEpisodes') as Record<string, { translationType: string; author: string; quality: number; translationId: number }>
+    const metaKey = `${animeId}:${episodeInt}:${translationId}`
+    const legacyKey = `${animeId}:${episodeInt}`
+    const meta = episodes[metaKey] || episodes[legacyKey]
+    if (meta) {
+      const authorTag = sanitizeFilename(meta.author)
+      const taggedBase = `${base} [${authorTag}]`
+      for (const dir of dirsToCheck) {
+        const animeDir = path.join(dir, animeDirName)
+        for (const ext of ['.mkv', '.mp4', '.ass']) {
+          const taggedPath = path.join(animeDir, `${taggedBase}${ext}`)
+          const tSize = trySize(taggedPath)
+          try { fs.unlinkSync(taggedPath); bytesDeleted += tSize } catch { /* ignore */ }
+          const legacyPath = path.join(animeDir, `${base}${ext}`)
+          const lSize = trySize(legacyPath)
+          try { fs.unlinkSync(legacyPath); bytesDeleted += lSize } catch { /* ignore */ }
+        }
+      }
+      delete episodes[metaKey]
+      delete episodes[legacyKey]
+      store.set('downloadedEpisodes', episodes)
+    }
+  } else {
+    for (const dir of dirsToCheck) {
+      const animeDir = path.join(dir, animeDirName)
+      try {
+        const files = fs.readdirSync(animeDir)
+        for (const file of files) {
+          if (file.startsWith(base) && (file.endsWith('.mkv') || file.endsWith('.mp4') || file.endsWith('.ass'))) {
+            const fp = path.join(animeDir, file)
+            const sz = trySize(fp)
+            try { fs.unlinkSync(fp); bytesDeleted += sz } catch { /* ignore */ }
+          }
+        }
+      } catch { /* dir doesn't exist */ }
+    }
+
+    if (animeId) {
+      const episodes = store.get('downloadedEpisodes') as Record<string, unknown>
+      const prefix = `${animeId}:${episodeInt}`
+      for (const key of Object.keys(episodes)) {
+        if (key === prefix || key.startsWith(prefix + ':')) {
+          delete episodes[key]
+        }
+      }
+      store.set('downloadedEpisodes', episodes)
+    }
+  }
+
+  return { bytesDeleted }
+}
+
+function episodeHasInProgressDownload(animeName: string, episodeInt: string): boolean {
+  const animeDirName = sanitizeFilename(animeName)
+  const padded = episodeInt.padStart(2, '0')
+  const base = sanitizeFilename(`${animeName} - ${padded}`)
+  for (const dir of storageDirsForScan()) {
+    const animeDir = path.join(dir, animeDirName)
+    try {
+      const files = fs.readdirSync(animeDir)
+      for (const file of files) {
+        if (file.startsWith(base) && file.endsWith('.part')) return true
+      }
+    } catch { /* dir missing */ }
+  }
+  return false
+}
+
 // Drops `downloadedEpisodes[animeId:episodeInt:translationId]` (and the legacy
 // `animeId:episodeInt` key if it points at the same translation) when no file
 // for that translation exists on disk. Called after cancel / cancel-by-episode.
@@ -1068,6 +1156,337 @@ async function lookupByMalIds(malIds: number[]): Promise<Record<number, AnimeSea
   }
   store.set('malIdMap', cached)
   return result
+}
+
+// Parse episodeInt from a sanitized download filename. Format produced by
+// download-manager.ts: `${name} - ${NN}[ [Author]].(mkv|mp4|ass|part)`.
+const FILENAME_EP_RE = /\s-\s(\d{1,4}(?:\.\d+)?)(?:\s\[[^\]]+\])?\.(mkv|mp4|ass)$/i
+
+function parseEpisodeFromFilename(file: string): { episodeInt: string; ext: 'mkv' | 'mp4' | 'ass' } | null {
+  const m = FILENAME_EP_RE.exec(file)
+  if (!m) return null
+  const raw = m[1]
+  const episodeInt = raw.includes('.') ? raw : String(parseInt(raw, 10))
+  return { episodeInt, ext: m[2].toLowerCase() as 'mkv' | 'mp4' | 'ass' }
+}
+
+interface UsageEpisodeFiles {
+  mkv?: { path: string; size: number }
+  mp4?: { path: string; size: number }
+  ass?: { path: string; size: number }
+}
+
+interface AnimeUsageAccum {
+  animeId: number
+  animeName: string
+  posterUrlSmall: string
+  bytesHot: number
+  bytesCold: number
+  fileCount: number
+  episodes: Map<string, { files: UsageEpisodeFiles; totalBytes: number }>
+}
+
+interface StorageEpisodeUsage {
+  episodeInt: string
+  files: UsageEpisodeFiles
+  totalBytes: number
+  watched: boolean
+  watchedAt?: number
+}
+
+interface StorageAnimeUsage {
+  animeId: number
+  animeName: string
+  posterUrlSmall: string
+  bytes: number
+  bytesHot: number
+  bytesCold: number
+  fileCount: number
+  episodes: StorageEpisodeUsage[]
+}
+
+interface StorageUsage {
+  totalBytes: number
+  bytesHot: number
+  bytesCold: number
+  fileCount: number
+  perAnime: StorageAnimeUsage[]
+}
+
+async function scanStorageUsage(): Promise<StorageUsage> {
+  const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+  const watchProgress = store.get('watchProgress') as Record<string, { watched?: boolean; watchedAt?: number }>
+  // Downloads are written under sanitizeFilename(getAnimeName(anime)), where
+  // getAnimeName prefers titles.romaji, then titles.ru, then title. Register all
+  // three candidates so the scan finds folders regardless of which variant was
+  // current at download time. The "preferred" name (matching the live folder
+  // name) is what we surface to the renderer so delete calls round-trip cleanly.
+  const dirNameToId = new Map<string, string>()
+  const idToDisplayName = new Map<string, string>()
+  for (const id of Object.keys(downloaded)) {
+    const a = downloaded[id]
+    if (!a) continue
+    const preferred = a.titles?.romaji || a.titles?.ru || a.title
+    if (!preferred) continue
+    idToDisplayName.set(id, preferred)
+    const candidates = [preferred, a.titles?.ru, a.titles?.romaji, a.title]
+    for (const name of candidates) {
+      if (!name) continue
+      const key = sanitizeFilename(name)
+      if (!dirNameToId.has(key)) dirNameToId.set(key, id)
+    }
+  }
+
+  const accum = new Map<string, AnimeUsageAccum>()
+  const hotDir = getDownloadDir()
+  const coldDir = isAdvancedStorage() ? getColdStorageDir() : ''
+
+  const dirs: Array<{ root: string; bucket: 'hot' | 'cold' }> = []
+  if (hotDir) dirs.push({ root: hotDir, bucket: 'hot' })
+  if (coldDir && coldDir !== hotDir) dirs.push({ root: coldDir, bucket: 'cold' })
+
+  // First pass: list anime folders so we can emit progress meaningfully
+  const animeFolders: Array<{ root: string; bucket: 'hot' | 'cold'; folder: string }> = []
+  for (const { root, bucket } of dirs) {
+    try {
+      const entries = await fsPromises.readdir(root, { withFileTypes: true })
+      for (const e of entries) {
+        if (e.isDirectory()) animeFolders.push({ root, bucket, folder: e.name })
+      }
+    } catch { /* dir missing */ }
+  }
+
+  const total = animeFolders.length
+  const reportProgress = total > 50
+  let scanned = 0
+
+  for (const { root, bucket, folder } of animeFolders) {
+    const animeId = dirNameToId.get(folder)
+    if (!animeId) {
+      scanned++
+      if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+      continue
+    }
+    const animeRec = downloaded[animeId]
+    let entry = accum.get(animeId)
+    if (!entry) {
+      entry = {
+        animeId: Number(animeId),
+        animeName: idToDisplayName.get(animeId) || animeRec.title,
+        posterUrlSmall: animeRec.posterUrlSmall || '',
+        bytesHot: 0,
+        bytesCold: 0,
+        fileCount: 0,
+        episodes: new Map()
+      }
+      accum.set(animeId, entry)
+    }
+
+    const animeDir = path.join(root, folder)
+    let files: string[]
+    try {
+      files = await fsPromises.readdir(animeDir)
+    } catch {
+      scanned++
+      if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+      continue
+    }
+
+    for (const file of files) {
+      const parsed = parseEpisodeFromFilename(file)
+      if (!parsed) continue
+      const fullPath = path.join(animeDir, file)
+      let size = 0
+      try { size = (await fsPromises.stat(fullPath)).size } catch { continue }
+
+      let ep = entry.episodes.get(parsed.episodeInt)
+      if (!ep) {
+        ep = { files: {}, totalBytes: 0 }
+        entry.episodes.set(parsed.episodeInt, ep)
+      }
+      // Cold storage takes priority when both buckets have the file.
+      const existing = ep.files[parsed.ext]
+      if (existing && bucket === 'hot') continue
+      ep.files[parsed.ext] = { path: fullPath, size }
+      ep.totalBytes = (ep.files.mkv?.size || 0) + (ep.files.mp4?.size || 0) + (ep.files.ass?.size || 0)
+      if (existing) {
+        // Replaced hot with cold — adjust counters.
+        entry.bytesHot -= existing.size
+        entry.fileCount -= 1
+      }
+      if (bucket === 'hot') entry.bytesHot += size
+      else entry.bytesCold += size
+      entry.fileCount += 1
+    }
+
+    scanned++
+    if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+  }
+
+  let totalBytes = 0
+  let totalHot = 0
+  let totalCold = 0
+  let totalFiles = 0
+  const perAnime = [...accum.values()].map((a) => {
+    const bytes = a.bytesHot + a.bytesCold
+    totalBytes += bytes
+    totalHot += a.bytesHot
+    totalCold += a.bytesCold
+    totalFiles += a.fileCount
+    const episodes = [...a.episodes.entries()]
+      .map(([episodeInt, ep]) => {
+        const wp = watchProgress[`${a.animeId}:${episodeInt}`]
+        return {
+          episodeInt,
+          files: ep.files,
+          totalBytes: ep.totalBytes,
+          watched: !!wp?.watched,
+          watchedAt: wp?.watchedAt
+        }
+      })
+      .sort((x, y) => Number(x.episodeInt) - Number(y.episodeInt))
+    return {
+      animeId: a.animeId,
+      animeName: a.animeName,
+      posterUrlSmall: a.posterUrlSmall,
+      bytes,
+      bytesHot: a.bytesHot,
+      bytesCold: a.bytesCold,
+      fileCount: a.fileCount,
+      episodes
+    }
+  }).sort((x, y) => y.bytes - x.bytes)
+
+  return { totalBytes, bytesHot: totalHot, bytesCold: totalCold, fileCount: totalFiles, perAnime }
+}
+
+interface CleanupCandidate {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  bytes: number
+  watchedAt: number
+}
+
+function findCleanupCandidates(days: number): CleanupCandidate[] {
+  if (!days || days <= 0) return []
+  const watchProgress = store.get('watchProgress') as Record<string, { watched?: boolean; watchedAt?: number }>
+  const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+  const cutoff = Date.now() - days * 86400_000
+  const candidates: CleanupCandidate[] = []
+
+  for (const [key, entry] of Object.entries(watchProgress)) {
+    if (!entry.watched || !entry.watchedAt || entry.watchedAt > cutoff) continue
+    const sep = key.indexOf(':')
+    if (sep < 0) continue
+    const animeId = key.slice(0, sep)
+    const episodeInt = key.slice(sep + 1)
+    const anime = downloaded[animeId]
+    if (!anime) continue
+    const animeName = anime.titles?.romaji || anime.titles?.ru || anime.title
+    if (!animeName) continue
+    if (episodeHasInProgressDownload(animeName, episodeInt)) continue
+
+    const animeDirName = sanitizeFilename(animeName)
+    const padded = episodeInt.padStart(2, '0')
+    const base = sanitizeFilename(`${animeName} - ${padded}`)
+    let bytes = 0
+    let hasFile = false
+    for (const dir of storageDirsForScan()) {
+      const animeDir = path.join(dir, animeDirName)
+      try {
+        const files = fs.readdirSync(animeDir)
+        for (const file of files) {
+          if (file.startsWith(base) && (file.endsWith('.mkv') || file.endsWith('.mp4') || file.endsWith('.ass'))) {
+            hasFile = true
+            try { bytes += fs.statSync(path.join(animeDir, file)).size } catch { /* ignore */ }
+          }
+        }
+      } catch { /* dir missing */ }
+    }
+    if (!hasFile) continue
+    candidates.push({
+      animeId: Number(animeId),
+      animeName,
+      episodeInt,
+      bytes,
+      watchedAt: entry.watchedAt
+    })
+  }
+  return candidates
+}
+
+let cleanupRunning = false
+
+async function runWatchedCleanup(force = false): Promise<{
+  ranAt: number
+  deletedCount: number
+  freedBytes: number
+  items: CleanupCandidate[]
+}> {
+  const ranAt = Date.now()
+  if (cleanupRunning) return { ranAt, deletedCount: 0, freedBytes: 0, items: [] }
+  cleanupRunning = true
+  try {
+    const days = store.get('autoCleanupWatchedDays') as number
+    if ((!days || days <= 0) && !force) {
+      return { ranAt, deletedCount: 0, freedBytes: 0, items: [] }
+    }
+    const candidates = findCleanupCandidates(days)
+    if (candidates.length === 0) {
+      return { ranAt, deletedCount: 0, freedBytes: 0, items: [] }
+    }
+
+    const requireConfirm = store.get('autoCleanupConfirm') as boolean
+    if (requireConfirm && !force) {
+      broadcastToAll('storage:cleanup-pending', { candidates })
+      return { ranAt, deletedCount: 0, freedBytes: 0, items: [] }
+    }
+
+    const affectedAnime = new Set<string>()
+    let freedBytes = 0
+    const log = store.get('cleanupLog') as Array<{ ranAt: number; animeId: number; animeName: string; episodeInt: string; bytes: number }>
+    const items: CleanupCandidate[] = []
+
+    for (const c of candidates) {
+      const { bytesDeleted } = deleteEpisodeFiles(c.animeName, c.episodeInt, c.animeId)
+      freedBytes += bytesDeleted
+      affectedAnime.add(c.animeName)
+      log.unshift({ ranAt, animeId: c.animeId, animeName: c.animeName, episodeInt: c.episodeInt, bytes: bytesDeleted })
+      items.push({ ...c, bytes: bytesDeleted })
+    }
+
+    while (log.length > 100) log.pop()
+    store.set('cleanupLog', log)
+
+    const result = { ranAt, deletedCount: items.length, freedBytes, items }
+    store.set('autoCleanupLastRun', { ranAt, deletedCount: result.deletedCount, freedBytes: result.freedBytes })
+
+    for (const animeName of affectedAnime) {
+      try {
+        const data = scanEpisodeFiles(animeName)
+        broadcastToAll('file:episodes-changed', animeName, data)
+      } catch { /* ignore */ }
+    }
+    broadcastToAll('storage:cleanup-finished', result)
+    return result
+  } finally {
+    cleanupRunning = false
+  }
+}
+
+function migrateWatchProgressV2(): void {
+  if (store.get('watchProgressMigrationV2') as boolean) return
+  const all = store.get('watchProgress') as Record<string, { updatedAt: number; watched?: boolean; watchedAt?: number; position: number; duration: number }>
+  let changed = false
+  for (const entry of Object.values(all)) {
+    if (entry.watched && !entry.watchedAt) {
+      entry.watchedAt = entry.updatedAt
+      changed = true
+    }
+  }
+  if (changed) store.set('watchProgress', all)
+  store.set('watchProgressMigrationV2', true)
 }
 
 function registerIpcHandlers(): void {
@@ -1520,27 +1939,30 @@ function registerIpcHandlers(): void {
 
   // Watch progress tracking
   ipcMain.handle('watch-progress:save', (_event, animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
     const key = `${animeId}:${episodeInt}`
     const prev = all[key]
+    const nowWatched = watched || prev?.watched || false
+    const justWatched = nowWatched && !prev?.watched
     all[key] = {
       position,
       duration,
       updatedAt: Date.now(),
-      watched: watched || prev?.watched || false
+      watched: nowWatched,
+      watchedAt: justWatched ? Date.now() : prev?.watchedAt
     }
     store.set('watchProgress', all)
   })
 
   ipcMain.handle('watch-progress:get', (_event, animeId: number, episodeInt: string) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
     return all[`${animeId}:${episodeInt}`] || null
   })
 
   ipcMain.handle('watch-progress:get-all', (_event, animeId: number) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
     const prefix = `${animeId}:`
-    const out: Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }> = {}
+    const out: Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }> = {}
     for (const [key, val] of Object.entries(all)) {
       if (key.startsWith(prefix)) {
         out[key.slice(prefix.length)] = val
@@ -1863,68 +2285,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('file:delete-episode', (_event, animeName: string, episodeInt: string, animeId?: number, translationId?: number) => {
-    fileCheckCache.delete(animeName)
-    const animeDirName = sanitizeFilename(animeName)
-    const dirsToCheck = [getDownloadDir()]
-    if (isAdvancedStorage()) {
-      const coldDir = getColdStorageDir()
-      if (coldDir) dirsToCheck.push(coldDir)
-    }
-
-    const padded = episodeInt.padStart(2, '0')
-    const base = sanitizeFilename(`${animeName} - ${padded}`)
-
-    if (translationId && animeId) {
-      // Delete specific translation's files — find by author tag from metadata
-      const episodes = store.get('downloadedEpisodes') as Record<string, { translationType: string; author: string; quality: number; translationId: number }>
-      const metaKey = `${animeId}:${episodeInt}:${translationId}`
-      const legacyKey = `${animeId}:${episodeInt}`
-      const meta = episodes[metaKey] || episodes[legacyKey]
-      if (meta) {
-        const authorTag = sanitizeFilename(meta.author)
-        const taggedBase = `${base} [${authorTag}]`
-        for (const dir of dirsToCheck) {
-          const animeDir = path.join(dir, animeDirName)
-          for (const ext of ['.mkv', '.mp4', '.ass']) {
-            // Try tagged filename first
-            const taggedPath = path.join(animeDir, `${taggedBase}${ext}`)
-            try { fs.unlinkSync(taggedPath) } catch { /* ignore */ }
-            // Also try legacy filename (for older downloads)
-            const legacyPath = path.join(animeDir, `${base}${ext}`)
-            try { fs.unlinkSync(legacyPath) } catch { /* ignore */ }
-          }
-        }
-        delete episodes[metaKey]
-        delete episodes[legacyKey]
-        store.set('downloadedEpisodes', episodes)
-      }
-    } else {
-      // Delete all versions of this episode (legacy behavior)
-      for (const dir of dirsToCheck) {
-        const animeDir = path.join(dir, animeDirName)
-        // List directory and delete all matching files for this episode
-        try {
-          const files = fs.readdirSync(animeDir)
-          for (const file of files) {
-            if (file.startsWith(base) && (file.endsWith('.mkv') || file.endsWith('.mp4') || file.endsWith('.ass'))) {
-              try { fs.unlinkSync(path.join(animeDir, file)) } catch { /* ignore */ }
-            }
-          }
-        } catch { /* dir doesn't exist */ }
-      }
-
-      // Clean up all episode metadata for this episode
-      if (animeId) {
-        const episodes = store.get('downloadedEpisodes') as Record<string, unknown>
-        const prefix = `${animeId}:${episodeInt}`
-        for (const key of Object.keys(episodes)) {
-          if (key === prefix || key.startsWith(prefix + ':')) {
-            delete episodes[key]
-          }
-        }
-        store.set('downloadedEpisodes', episodes)
-      }
-    }
+    deleteEpisodeFiles(animeName, episodeInt, animeId, translationId)
   })
 
   ipcMain.handle('download:pick-dir', async () => {
@@ -1976,6 +2337,14 @@ function registerIpcHandlers(): void {
       }
     })
     return result
+  })
+
+  ipcMain.handle('storage:get-usage', async () => {
+    return scanStorageUsage()
+  })
+
+  ipcMain.handle('storage:run-cleanup', async (_event, opts?: { force?: boolean }) => {
+    return runWatchedCleanup(!!opts?.force)
   })
 
   // Shikimori integration
@@ -3279,6 +3648,15 @@ app.whenReady().then(async () => {
   })
 
   registerIpcHandlers()
+
+  migrateWatchProgressV2()
+
+  // Auto-cleanup of watched episodes — opt-in. Run 60s after launch (warmup),
+  // then once every 24h. First run that finds candidates while
+  // `autoCleanupConfirm` is still true emits `storage:cleanup-pending` instead
+  // of deleting; the renderer's confirm modal then calls back with force=true.
+  setTimeout(() => { void runWatchedCleanup() }, 60_000)
+  setInterval(() => { void runWatchedCleanup() }, 24 * 60 * 60 * 1000)
 
   if (getQueueLength() > 0) {
     startSyncTimer()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -79,6 +79,27 @@ const api = {
   offStorageMoveToColdProgress: () => {
     ipcRenderer.removeAllListeners('storage:move-to-cold-progress')
   },
+  storageGetUsage: () => ipcRenderer.invoke('storage:get-usage') as Promise<StorageUsage>,
+  storageRunCleanup: (opts?: { force?: boolean }) =>
+    ipcRenderer.invoke('storage:run-cleanup', opts) as Promise<CleanupResult>,
+  onStorageUsageProgress: (callback: (data: { scanned: number; total: number }) => void) => {
+    ipcRenderer.on('storage:usage-progress', (_event, data) => callback(data))
+  },
+  offStorageUsageProgress: () => {
+    ipcRenderer.removeAllListeners('storage:usage-progress')
+  },
+  onStorageCleanupPending: (callback: (data: { candidates: CleanupCandidate[] }) => void) => {
+    ipcRenderer.on('storage:cleanup-pending', (_event, data) => callback(data))
+  },
+  offStorageCleanupPending: () => {
+    ipcRenderer.removeAllListeners('storage:cleanup-pending')
+  },
+  onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => {
+    ipcRenderer.on('storage:cleanup-finished', (_event, data) => callback(data))
+  },
+  offStorageCleanupFinished: () => {
+    ipcRenderer.removeAllListeners('storage:cleanup-finished')
+  },
 
   downloadScanMerge: () => ipcRenderer.invoke('download:scan-merge'),
   downloadFixMetadata: () => ipcRenderer.invoke('download:fix-metadata'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -69,6 +69,14 @@ interface Api {
   storageMoveToCold: () => Promise<{ moved: number; failed: string[] }>
   onStorageMoveToColdProgress: (callback: (data: { current: number; total: number; file: string }) => void) => void
   offStorageMoveToColdProgress: () => void
+  storageGetUsage: () => Promise<StorageUsage>
+  storageRunCleanup: (opts?: { force?: boolean }) => Promise<CleanupResult>
+  onStorageUsageProgress: (callback: (data: { scanned: number; total: number }) => void) => void
+  offStorageUsageProgress: () => void
+  onStorageCleanupPending: (callback: (data: { candidates: CleanupCandidate[] }) => void) => void
+  offStorageCleanupPending: () => void
+  onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => void
+  offStorageCleanupFinished: () => void
   // File management
   fileCheckEpisodes: (animeName: string, episodeInts: string[]) =>
     Promise<Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>>
@@ -219,6 +227,57 @@ interface WatchProgressEntry {
   duration: number
   updatedAt: number
   watched?: boolean
+  watchedAt?: number
+}
+
+interface StorageEpisodeUsage {
+  episodeInt: string
+  files: { mkv?: { path: string; size: number }; mp4?: { path: string; size: number }; ass?: { path: string; size: number } }
+  totalBytes: number
+  watched: boolean
+  watchedAt?: number
+}
+
+interface StorageAnimeUsage {
+  animeId: number
+  animeName: string
+  posterUrlSmall: string
+  bytes: number
+  bytesHot: number
+  bytesCold: number
+  fileCount: number
+  episodes: StorageEpisodeUsage[]
+}
+
+interface StorageUsage {
+  totalBytes: number
+  bytesHot: number
+  bytesCold: number
+  fileCount: number
+  perAnime: StorageAnimeUsage[]
+}
+
+interface CleanupCandidate {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  bytes: number
+  watchedAt: number
+}
+
+interface CleanupResult {
+  ranAt: number
+  deletedCount: number
+  freedBytes: number
+  items: CleanupCandidate[]
+}
+
+interface CleanupLogEntry {
+  ranAt: number
+  animeId: number
+  animeName: string
+  episodeInt: string
+  bytes: number
 }
 
 interface ContinueWatchingEntry {

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import { formatBytes } from '../utils'
 
 const activeTab = ref<'general' | 'storage' | 'connectors' | 'merging' | 'player' | 'shortcuts' | 'debug'>('general')
 
@@ -13,6 +14,19 @@ const autoMoveToCold = ref(false)
 const movingToCold = ref(false)
 const moveProgress = ref<{ current: number; total: number; file: string } | null>(null)
 const moveResult = ref<{ moved: number; failed: string[] } | null>(null)
+
+// Storage usage + auto-cleanup state
+const storageUsage = ref<StorageUsage | null>(null)
+const usageScanning = ref(false)
+const usageProgress = ref<{ scanned: number; total: number } | null>(null)
+const expandedAnime = ref<Set<number>>(new Set())
+const autoCleanupDays = ref(0)
+const autoCleanupLastRun = ref<{ ranAt: number; deletedCount: number; freedBytes: number } | null>(null)
+const cleanupLog = ref<CleanupLogEntry[]>([])
+const cleanupRunning = ref(false)
+const cleanupResult = ref<CleanupResult | null>(null)
+const cleanupPending = ref<CleanupCandidate[] | null>(null)
+const cleanupLogExpanded = ref(false)
 const loaded = ref(false)
 const savedVisible = ref(false)
 let savedTimeout: ReturnType<typeof setTimeout> | null = null
@@ -375,11 +389,118 @@ async function moveToCold(): Promise<void> {
   }
 }
 
+async function refreshStorageUsage(): Promise<void> {
+  if (usageScanning.value) return
+  usageScanning.value = true
+  usageProgress.value = null
+  try {
+    storageUsage.value = await window.api.storageGetUsage()
+  } catch (err) {
+    console.error('storage:get-usage failed', err)
+  } finally {
+    usageScanning.value = false
+    usageProgress.value = null
+  }
+}
+
+function toggleAnimeExpand(animeId: number): void {
+  const next = new Set(expandedAnime.value)
+  if (next.has(animeId)) next.delete(animeId)
+  else next.add(animeId)
+  expandedAnime.value = next
+}
+
+async function deleteEpisode(animeName: string, episodeInt: string, animeId: number): Promise<void> {
+  await window.api.fileDeleteEpisode(animeName, episodeInt, animeId)
+  await refreshStorageUsage()
+}
+
+async function runCleanupNow(): Promise<void> {
+  if (cleanupRunning.value) return
+  cleanupRunning.value = true
+  cleanupResult.value = null
+  try {
+    const result = await window.api.storageRunCleanup()
+    if (result.deletedCount > 0 || result.items.length === 0) {
+      cleanupResult.value = result
+      autoCleanupLastRun.value = { ranAt: result.ranAt, deletedCount: result.deletedCount, freedBytes: result.freedBytes }
+      await reloadCleanupLog()
+      await refreshStorageUsage()
+    }
+    // If candidates exist + confirm gate is up, main broadcasts
+    // storage:cleanup-pending instead — handled by onCleanupPending below.
+  } catch (err) {
+    console.error('storage:run-cleanup failed', err)
+  } finally {
+    cleanupRunning.value = false
+  }
+}
+
+async function confirmCleanup(): Promise<void> {
+  if (!cleanupPending.value) return
+  await window.api.setSetting('autoCleanupConfirm', false)
+  cleanupPending.value = null
+  cleanupRunning.value = true
+  try {
+    const result = await window.api.storageRunCleanup({ force: true })
+    cleanupResult.value = result
+    autoCleanupLastRun.value = { ranAt: result.ranAt, deletedCount: result.deletedCount, freedBytes: result.freedBytes }
+    await reloadCleanupLog()
+    await refreshStorageUsage()
+  } finally {
+    cleanupRunning.value = false
+  }
+}
+
+function dismissCleanupPending(): void {
+  cleanupPending.value = null
+}
+
+async function reloadCleanupLog(): Promise<void> {
+  const log = (await window.api.getSetting('cleanupLog')) as CleanupLogEntry[] | null
+  cleanupLog.value = log || []
+}
+
+function onUsageProgress(data: { scanned: number; total: number }): void {
+  usageProgress.value = data
+}
+
+function onCleanupPending(data: { candidates: CleanupCandidate[] }): void {
+  cleanupPending.value = data.candidates
+}
+
+function onCleanupFinished(data: CleanupResult): void {
+  cleanupResult.value = data
+  autoCleanupLastRun.value = { ranAt: data.ranAt, deletedCount: data.deletedCount, freedBytes: data.freedBytes }
+  reloadCleanupLog()
+}
+
+function formatRelativeTime(ts: number): string {
+  if (!ts) return ''
+  const diff = Date.now() - ts
+  if (diff < 0) return 'in the future'
+  const sec = Math.floor(diff / 1000)
+  if (sec < 60) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} min ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  if (day < 30) return `${day}d ago`
+  const mo = Math.floor(day / 30)
+  if (mo < 12) return `${mo}mo ago`
+  const yr = Math.floor(day / 365)
+  return `${yr}y ago`
+}
+
 onMounted(async () => {
   window.api.onScanMergeProgress(onScanProgress)
   window.api.onFixMetadataProgress(onFixProgress)
   window.api.onUpdateStatus(onUpdateStatus)
   window.api.onStorageMoveToColdProgress(onMoveProgress)
+  window.api.onStorageUsageProgress(onUsageProgress)
+  window.api.onStorageCleanupPending(onCleanupPending)
+  window.api.onStorageCleanupFinished(onCleanupFinished)
   refreshMismatchCount()
 
   appVersion.value = await window.api.appVersion()
@@ -390,6 +511,9 @@ onUnmounted(() => {
   window.api.offFixMetadataProgress()
   window.api.offUpdateStatus()
   window.api.offStorageMoveToColdProgress()
+  window.api.offStorageUsageProgress()
+  window.api.offStorageCleanupPending()
+  window.api.offStorageCleanupFinished()
 })
 
 const TRANSLATION_TYPES = [
@@ -451,6 +575,11 @@ onMounted(async () => {
   playerMode.value = ((await window.api.getSetting('playerMode')) as string as typeof playerMode.value) || 'system'
   anime4kPreset.value = ((await window.api.getSetting('anime4kPreset')) as string as typeof anime4kPreset.value) || 'off'
   hevcTranscodeOnPlay.value = ((await window.api.getSetting('hevcTranscodeOnPlay')) as string as typeof hevcTranscodeOnPlay.value) || 'ask'
+
+  // Storage cleanup settings
+  autoCleanupDays.value = ((await window.api.getSetting('autoCleanupWatchedDays')) as number) || 0
+  autoCleanupLastRun.value = (await window.api.getSetting('autoCleanupLastRun')) as { ranAt: number; deletedCount: number; freedBytes: number } | null
+  await reloadCleanupLog()
 
   // Probe WebGPU
   try {
@@ -603,6 +732,7 @@ watch(videoCodec, (val, oldVal) => {
 watch(playerMode, (val) => { if (loaded.value) autoSave('playerMode', val) })
 watch(anime4kPreset, (val) => { if (loaded.value) autoSave('anime4kPreset', val) })
 watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeOnPlay', val) })
+watch(autoCleanupDays, (val) => { if (loaded.value) autoSave('autoCleanupWatchedDays', Number(val) || 0) })
 </script>
 
 <template>
@@ -810,6 +940,111 @@ watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeO
             </div>
           </div>
         </template>
+
+        <div class="setting-group">
+          <label class="setting-label">Storage usage</label>
+          <p class="setting-hint">Disk space used by downloaded episodes. Click an anime to expand its episode list.</p>
+
+          <div class="usage-actions">
+            <button class="merge-all-btn" :disabled="usageScanning" @click="refreshStorageUsage">
+              {{ usageScanning ? 'Scanning...' : (storageUsage ? 'Rescan' : 'Scan storage') }}
+            </button>
+          </div>
+
+          <div v-if="usageProgress" class="scan-progress">
+            <div class="scan-progress-header">
+              <span>{{ usageProgress.scanned }} / {{ usageProgress.total }}</span>
+            </div>
+            <div class="progress-bar-wrap">
+              <div class="progress-bar" :style="{ width: (usageProgress.total > 0 ? Math.round(usageProgress.scanned / usageProgress.total * 100) : 0) + '%' }"></div>
+            </div>
+          </div>
+
+          <div v-if="storageUsage" class="usage-summary">
+            <div class="usage-total">
+              <span class="usage-total-label">Total</span>
+              <span class="usage-total-value">{{ formatBytes(storageUsage.totalBytes) }}</span>
+              <span class="usage-total-meta">{{ storageUsage.fileCount }} file(s) across {{ storageUsage.perAnime.length }} title(s)</span>
+            </div>
+            <div v-if="storageMode === 'advanced'" class="usage-buckets">
+              <span class="usage-bucket"><span class="bucket-label">Hot</span> {{ formatBytes(storageUsage.bytesHot) }}</span>
+              <span class="usage-bucket"><span class="bucket-label">Cold</span> {{ formatBytes(storageUsage.bytesCold) }}</span>
+            </div>
+          </div>
+
+          <div v-if="storageUsage && storageUsage.perAnime.length > 0" class="usage-list">
+            <div v-for="anime in storageUsage.perAnime" :key="anime.animeId" class="usage-anime">
+              <div class="usage-anime-row" @click="toggleAnimeExpand(anime.animeId)">
+                <img v-if="anime.posterUrlSmall" :src="anime.posterUrlSmall" class="usage-poster" />
+                <div class="usage-anime-name">{{ anime.animeName }}</div>
+                <div class="usage-anime-meta">
+                  <span>{{ anime.fileCount }} file(s)</span>
+                  <span class="usage-anime-size">{{ formatBytes(anime.bytes) }}</span>
+                </div>
+                <span class="usage-chevron" :class="{ open: expandedAnime.has(anime.animeId) }">›</span>
+              </div>
+              <div v-if="expandedAnime.has(anime.animeId)" class="usage-episodes">
+                <div v-for="ep in anime.episodes" :key="ep.episodeInt" class="usage-episode">
+                  <span class="usage-ep-num">Ep {{ ep.episodeInt }}</span>
+                  <span class="usage-ep-tags">
+                    <span v-if="ep.files.mkv" class="usage-tag">MKV</span>
+                    <span v-if="ep.files.mp4" class="usage-tag">MP4</span>
+                    <span v-if="ep.files.ass" class="usage-tag">ASS</span>
+                    <span v-if="ep.watched" class="usage-tag usage-tag-watched">Watched{{ ep.watchedAt ? ` ${formatRelativeTime(ep.watchedAt)}` : '' }}</span>
+                  </span>
+                  <span class="usage-ep-size">{{ formatBytes(ep.totalBytes) }}</span>
+                  <button class="usage-ep-delete" @click.stop="deleteEpisode(anime.animeName, ep.episodeInt, anime.animeId)">Delete</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-else-if="storageUsage && !usageScanning" class="usage-empty">No downloaded files found.</div>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">Auto-cleanup watched episodes</label>
+          <p class="setting-hint">Delete episode files marked as watched once they've sat for the chosen number of days. Set to 0 to disable.</p>
+          <div class="custom-speed-row">
+            <input
+              type="number"
+              min="0"
+              step="1"
+              class="setting-input speed-input"
+              v-model.number="autoCleanupDays"
+            />
+            <span class="speed-unit">day(s) after watched</span>
+          </div>
+
+          <div class="usage-actions" style="margin-top: 12px">
+            <button class="merge-all-btn" :disabled="cleanupRunning" @click="runCleanupNow">
+              {{ cleanupRunning ? 'Cleaning...' : 'Run cleanup now' }}
+            </button>
+          </div>
+
+          <div v-if="autoCleanupLastRun" class="usage-meta-row">
+            Last run: {{ formatRelativeTime(autoCleanupLastRun.ranAt) }} —
+            {{ autoCleanupLastRun.deletedCount }} file(s), {{ formatBytes(autoCleanupLastRun.freedBytes) }} freed
+          </div>
+
+          <div v-if="cleanupResult && cleanupResult.deletedCount === 0 && cleanupResult.items.length === 0" class="usage-meta-row">
+            Nothing to clean up.
+          </div>
+
+          <div v-if="cleanupLog.length > 0" class="cleanup-log">
+            <button class="cleanup-log-toggle" @click="cleanupLogExpanded = !cleanupLogExpanded">
+              {{ cleanupLogExpanded ? 'Hide history' : `Show history (${cleanupLog.length})` }}
+            </button>
+            <div v-if="cleanupLogExpanded" class="cleanup-log-list">
+              <div v-for="(entry, i) in cleanupLog" :key="i" class="cleanup-log-row">
+                <span class="cleanup-log-time">{{ formatRelativeTime(entry.ranAt) }}</span>
+                <span class="cleanup-log-name">{{ entry.animeName }}</span>
+                <span class="cleanup-log-ep">Ep {{ entry.episodeInt }}</span>
+                <span class="cleanup-log-size">{{ formatBytes(entry.bytes) }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
       </template>
 
       <!-- Connectors tab -->
@@ -1143,6 +1378,27 @@ watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeO
     <transition name="saved-fade">
       <div v-if="savedVisible" class="saved-toast">Saved</div>
     </transition>
+
+    <div v-if="cleanupPending" class="cleanup-modal-backdrop" @click.self="dismissCleanupPending">
+      <div class="cleanup-modal">
+        <div class="cleanup-modal-title">Auto-cleanup ready</div>
+        <p class="cleanup-modal-hint">
+          {{ cleanupPending.length }} watched episode(s) are eligible for deletion.
+          Confirming will delete them now and skip this prompt on future runs.
+        </p>
+        <div class="cleanup-modal-list">
+          <div v-for="c in cleanupPending" :key="`${c.animeId}:${c.episodeInt}`" class="cleanup-modal-row">
+            <span class="cleanup-modal-name">{{ c.animeName }}</span>
+            <span class="cleanup-modal-ep">Ep {{ c.episodeInt }}</span>
+            <span class="cleanup-modal-size">{{ formatBytes(c.bytes) }}</span>
+          </div>
+        </div>
+        <div class="cleanup-modal-actions">
+          <button class="test-token-btn" @click="dismissCleanupPending">Cancel</button>
+          <button class="merge-all-btn" @click="confirmCleanup">Delete and remember</button>
+        </div>
+      </div>
+    </div>
   </main>
 </template>
 
@@ -1737,5 +1993,357 @@ watch(hevcTranscodeOnPlay, (val) => { if (loaded.value) autoSave('hevcTranscodeO
 .status-line.warn {
   color: #f0932b;
   background: rgba(240, 147, 43, 0.1);
+}
+
+/* Storage usage dashboard */
+.usage-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.usage-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 12px;
+  padding: 12px 14px;
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 8px;
+}
+
+.usage-total {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.usage-total-label {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.usage-total-value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #e0e0e0;
+}
+
+.usage-total-meta {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.usage-buckets {
+  display: flex;
+  gap: 12px;
+}
+
+.usage-bucket {
+  font-size: 0.85rem;
+  color: #a0a0b8;
+}
+
+.bucket-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6a6a8a;
+  margin-right: 4px;
+}
+
+.usage-list {
+  margin-top: 10px;
+  border: 1px solid #0f3460;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.usage-anime {
+  border-bottom: 1px solid #0f3460;
+}
+
+.usage-anime:last-child {
+  border-bottom: none;
+}
+
+.usage-anime-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background-color 0.12s;
+}
+
+.usage-anime-row:hover {
+  background-color: rgba(15, 52, 96, 0.4);
+}
+
+.usage-poster {
+  width: 32px;
+  height: 44px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.usage-anime-name {
+  flex: 1;
+  font-size: 0.9rem;
+  color: #e0e0e0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.usage-anime-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.usage-anime-size {
+  color: #a0a0b8;
+  font-weight: 600;
+  min-width: 70px;
+  text-align: right;
+}
+
+.usage-chevron {
+  color: #6a6a8a;
+  font-size: 1.1rem;
+  transition: transform 0.15s;
+  width: 14px;
+  text-align: center;
+}
+
+.usage-chevron.open {
+  transform: rotate(90deg);
+}
+
+.usage-episodes {
+  background-color: rgba(15, 52, 96, 0.2);
+  padding: 4px 0;
+}
+
+.usage-episode {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px 6px 54px;
+  font-size: 0.85rem;
+}
+
+.usage-ep-num {
+  color: #e0e0e0;
+  min-width: 50px;
+}
+
+.usage-ep-tags {
+  display: flex;
+  gap: 4px;
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.usage-tag {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 2px 6px;
+  background: rgba(15, 52, 96, 0.7);
+  color: #a0a0b8;
+  border-radius: 3px;
+  letter-spacing: 0.03em;
+}
+
+.usage-tag-watched {
+  background: rgba(106, 176, 76, 0.18);
+  color: #8fc26d;
+}
+
+.usage-ep-size {
+  color: #a0a0b8;
+  min-width: 70px;
+  text-align: right;
+}
+
+.usage-ep-delete {
+  padding: 4px 10px;
+  background-color: transparent;
+  border: 1px solid #e94560;
+  border-radius: 6px;
+  color: #e94560;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.usage-ep-delete:hover {
+  background-color: rgba(233, 69, 96, 0.12);
+}
+
+.usage-empty {
+  margin-top: 10px;
+  font-size: 0.85rem;
+  color: #6a6a8a;
+}
+
+.usage-meta-row {
+  margin-top: 10px;
+  font-size: 0.8rem;
+  color: #a0a0b8;
+}
+
+.cleanup-log {
+  margin-top: 12px;
+}
+
+.cleanup-log-toggle {
+  background: none;
+  border: none;
+  color: #a0a0b8;
+  font-size: 0.8rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cleanup-log-toggle:hover {
+  color: #e0e0e0;
+  text-decoration: underline;
+}
+
+.cleanup-log-list {
+  margin-top: 8px;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+}
+
+.cleanup-log-row {
+  display: flex;
+  gap: 10px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  border-bottom: 1px solid rgba(15, 52, 96, 0.5);
+}
+
+.cleanup-log-row:last-child {
+  border-bottom: none;
+}
+
+.cleanup-log-time {
+  color: #6a6a8a;
+  width: 90px;
+  flex-shrink: 0;
+}
+
+.cleanup-log-name {
+  color: #e0e0e0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cleanup-log-ep {
+  color: #a0a0b8;
+  width: 60px;
+  flex-shrink: 0;
+}
+
+.cleanup-log-size {
+  color: #a0a0b8;
+  width: 70px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.cleanup-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.cleanup-modal {
+  width: 480px;
+  max-width: calc(100% - 40px);
+  max-height: calc(100% - 60px);
+  display: flex;
+  flex-direction: column;
+  background-color: #1a1a2e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 18px 20px;
+}
+
+.cleanup-modal-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #e0e0e0;
+  margin-bottom: 6px;
+}
+
+.cleanup-modal-hint {
+  font-size: 0.85rem;
+  color: #a0a0b8;
+  margin-bottom: 12px;
+}
+
+.cleanup-modal-list {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 14px;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+}
+
+.cleanup-modal-row {
+  display: flex;
+  gap: 10px;
+  padding: 6px 10px;
+  font-size: 0.8rem;
+  border-bottom: 1px solid rgba(15, 52, 96, 0.5);
+}
+
+.cleanup-modal-row:last-child {
+  border-bottom: none;
+}
+
+.cleanup-modal-name {
+  flex: 1;
+  color: #e0e0e0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cleanup-modal-ep {
+  color: #a0a0b8;
+  width: 60px;
+}
+
+.cleanup-modal-size {
+  color: #a0a0b8;
+  width: 70px;
+  text-align: right;
+}
+
+.cleanup-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 </style>


### PR DESCRIPTION
Closes #54.

Implements the Storage Dashboard & Auto-Cleanup proposal in full: disk-usage scanner, opt-in cleanup-after-watched policy with a first-run confirm gate, plus the `watchProgress` schema bump and migration. UI lives in a new section on the existing Settings → Storage tab (no separate tab — it shares space with hot/cold config since they're related concerns).

## Scope vs. issue plan

- ✅ `watchedAt` schema bump and one-time `watchProgressMigrationV2` (item 1).
- ✅ `storage:get-usage` with hot/cold split, per-anime/per-episode breakdown, file map by extension, and `storage:usage-progress` events for libraries >50 anime (item 2).
- ✅ `runWatchedCleanup` worker: warmup at 60s, then every 24h, plus on-demand `storage:run-cleanup`. Honors `autoCleanupConfirm` first-run gate via `storage:cleanup-pending` → renderer modal → `force: true` callback (item 3).
- ✅ Preload bindings + types (item 4).
- ✅ Renderer dashboard with poster/title rows, expandable episode lists, format tags, watched indicator, per-episode delete, auto-cleanup days input, "Run now" button, last-run status, and rolling 100-entry history log (items 5, 6).
- ✅ Reuses the existing `file:delete-episode` deletion path (refactored into a shared `deleteEpisodeFiles` helper) so manual and automated paths stay in lockstep — addresses the "cleanup trust" risk.
- ✅ Skips episodes with in-progress `.part` files via `episodeHasInProgressDownload` — addresses the in-progress-download risk.
- ⏭️ DESIGN.md update (item 7) deferred to a follow-up — happy to add in this PR if preferred.

## Folder-name fix

Surfaced during testing: the scanner originally keyed folders by `sanitizeFilename(anime.title)`, but downloads are written under `sanitizeFilename(getAnimeName(anime))`, which prefers `titles.romaji → titles.ru → title`. Result: scans showed 0 B for most libraries because folders were named after the romaji/ru title. The lookup map now registers all three candidates and surfaces the preferred name (matching the on-disk folder) so subsequent delete calls round-trip cleanly. Same fix applied to `findCleanupCandidates`.

## Test plan

- [ ] Open Settings → Storage, click **Scan storage**: verify totals, hot/cold breakdown (advanced mode), per-anime expansion, episode tags, and per-episode delete.
- [ ] Mark some episodes watched, set auto-cleanup days low, click **Run cleanup now**: verify confirm modal lists candidates; confirm and check files are deleted, history populates, and storage rescan reflects freed space.
- [ ] Confirm subsequent cleanup runs (after the first confirm) skip the modal.
- [ ] Verify nothing is deleted while a `.part` download is in progress for the same episode.
- [ ] Verify advanced-mode cold-storage entries take priority over hot duplicates in usage totals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
