### PR TITLE
Probe MP4 faststart on download and open

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -349,7 +349,7 @@ LibraryView shows both with indicators:
 | `storage:move-to-cold-progress` | send | Progress broadcast for move operation |
 | `player:get-stream-url` | invoke | Fetch CDN stream URL + raw ASS subtitle content + all available stream qualities for a translation |
 | `player:get-local-subtitles` | invoke | Read local .ass file alongside video, return raw ASS content |
-| `player:find-local-file` | invoke | Find local file path for a translation by animeName/episodeInt/translationId |
+| `player:find-local-file` | invoke | Find local file path for a translation by animeName/episodeInt/translationId. Renderer also passes the friendly `episodeLabel` so any non-faststart sample recorded from this path uses the same labeling as the download path |
 | `player:remux-mkv` | invoke | Legacy: remux MKV→MP4 via ffmpeg stream copy, await completion before returning (used as fallback when codecs aren't MSE-compatible) |
 | `player:remux-mkv-stream` | invoke | ffprobe MKV + start fragmented-MP4 pipe from ffmpeg; returns `{ sessionId, duration, mimeType, hasSubtitlesPending }` for MSE consumption |
 | `player:remux-mkv-stream-transcode` | invoke | Same as `player:remux-mkv-stream` but re-encodes video to H.264 (and audio to AAC when not already AAC) for platforms with no HEVC decoder |
@@ -373,6 +373,8 @@ LibraryView shows both with indicators:
 | `syncplay:room-users` | send | Current room member list with each member's advertised file info and `animeDlAppMeta` (if available) |
 | `syncplay:room-event` | send | Info/warn/error/chat messages rendered as a toast in the player (join/leave/chat/disconnect) |
 | `syncplay:remote-episode-change` | send | Another room member (same anime) switched to a different episode; PlayerView auto-navigates via `goToEpisode` |
+| `debug:get-mp4-stats` | invoke | Returns the persisted `mp4StreamingStats` snapshot (totals + recent non-faststart samples) for the Settings > Debug panel |
+| `debug:reset-mp4-stats` | invoke | Zeroes `mp4StreamingStats` and clears the in-session de-duplication set so re-opening previously-checked files re-probes them |
 
 ## Key Types
 
@@ -452,6 +454,7 @@ interface EpisodeMeta {
 | `enableLocalSkipDetection` | boolean | `true` | Run Chromaprint OP/ED detection in the background after each download/merge completes; turn off to disable background CPU usage |
 | `calendarView` | string | `'week'` | Default time range for the Airing Calendar tab: `week` (1×7 grid) or `month` (4×7 grid). Toggle in Settings > General |
 | `syncplay` | object | `{ lastHost:'syncplay.pl', lastPort:8999, lastRoom:'', username:'', autoReconnect:true }` | Watch Together session intent (host/port/room/username + auto-reconnect toggle; TLS is always on). The connection itself is NOT persisted — users must rejoin after restart |
+| `mp4StreamingStats` | object | `{ totalChecked:0, faststartCount:0, nonFaststartSamples:[] }` | Telemetry from the MP4 faststart probe: total files scanned, count that had `moov` before `mdat`, and up to 10 most-recent non-faststart samples (anime + episode + path + first non-`ftyp` box). Surfaced in Settings > Debug |
 
 ## Watch Progress & Resume
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.20.0",
+  "version": "3.20.1",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/download-manager.ts
+++ b/src/main/download-manager.ts
@@ -94,6 +94,7 @@ export class DownloadManager {
   private episodeCompleteCallback: ((info: EpisodeCompleteInfo) => void) | null = null
   private mergeCompleteCallback: ((info: { animeName: string; animeId: number; episodeInt: string; episodeLabel: string }) => void) | null = null
   private queueCompleteCallback: (() => void) | null = null
+  private videoDownloadedCallback: ((filePath: string, item: DownloadItem) => void) | null = null
   private merging = false
   private activeFfmpegCmd: ReturnType<typeof Ffmpeg> | null = null
   private activeMergeTranslationId: number | null = null
@@ -180,6 +181,10 @@ export class DownloadManager {
 
   onQueueComplete(callback: () => void): void {
     this.queueCompleteCallback = callback
+  }
+
+  onVideoDownloaded(callback: (filePath: string, item: DownloadItem) => void): void {
+    this.videoDownloadedCallback = callback
   }
 
   setDownloadDir(dir: string): void {
@@ -849,6 +854,12 @@ export class DownloadManager {
       item.status = 'completed'
       item.speed = 0
       this.schedulePersist()
+
+      if (item.kind === 'video' && this.videoDownloadedCallback) {
+        try { this.videoDownloadedCallback(filePath, item) } catch (e) {
+          console.warn('[download] videoDownloaded callback failed:', e)
+        }
+      }
 
       this.checkEpisodeComplete(item.translationId)
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,8 @@ import type {
   SyncplayRemoteEpisode,
   SyncplayStatus
 } from './syncplay'
+import { probeMp4Faststart } from './mp4-faststart'
+import type { Mp4StreamingStats } from './mp4-faststart'
 
 // Enable WebGPU (Anime4K shaders) and platform HEVC decoding (HEVC MKV via MSE).
 // PlatformHEVCDecoderSupport gates Chromium's HEVC path in <video> and MSE;
@@ -122,7 +124,12 @@ const store = new Store({
       lastRoom: string
       username: string
       autoReconnect: boolean
-    }
+    },
+    mp4StreamingStats: {
+      totalChecked: 0,
+      faststartCount: 0,
+      nonFaststartSamples: [] as { animeId: number; animeName: string; episodeInt: string; episodeLabel: string; filePath: string; firstNonFtypBox: string; checkedAt: number }[]
+    } as Mp4StreamingStats
   }
 })
 
@@ -162,6 +169,42 @@ function isNetworkError(err: unknown): boolean {
   const code = errorCode(err)
   if (code && NETWORK_ERROR_CODES.has(code)) return true
   return false
+}
+
+// In-memory set of MP4 paths probed this session, so re-opening the same file
+// in the player doesn't double-count. Stats persist across sessions; this set
+// resets on app restart, which is fine — it's a sampling check, not an exact
+// per-file ledger.
+const mp4FaststartChecked = new Set<string>()
+
+async function recordMp4FaststartCheck(
+  filePath: string,
+  context: { animeId: number; animeName: string; episodeInt: string; episodeLabel: string }
+): Promise<void> {
+  if (mp4FaststartChecked.has(filePath)) return
+  mp4FaststartChecked.add(filePath)
+  const probe = await probeMp4Faststart(filePath)
+  if (!probe) return
+  const stats = store.get('mp4StreamingStats') as Mp4StreamingStats
+  stats.totalChecked += 1
+  if (probe.faststart) {
+    stats.faststartCount += 1
+  } else {
+    stats.nonFaststartSamples.push({
+      animeId: context.animeId,
+      animeName: context.animeName,
+      episodeInt: context.episodeInt,
+      episodeLabel: context.episodeLabel,
+      filePath,
+      firstNonFtypBox: probe.firstNonFtypBox,
+      checkedAt: Date.now()
+    })
+    if (stats.nonFaststartSamples.length > 10) {
+      stats.nonFaststartSamples = stats.nonFaststartSamples.slice(-10)
+    }
+    console.error(`[mp4-faststart] non-faststart MP4 detected: ${context.animeName} — ${context.episodeLabel} (first non-ftyp box: ${probe.firstNonFtypBox}) at ${filePath}`)
+  }
+  store.set('mp4StreamingStats', stats)
 }
 
 interface QueuedShikimoriUpdate {
@@ -1891,6 +1934,14 @@ function registerIpcHandlers(): void {
     return qualityMismatches.size
   })
 
+  ipcMain.handle('debug:get-mp4-stats', () => {
+    return store.get('mp4StreamingStats') as Mp4StreamingStats
+  })
+
+  ipcMain.handle('debug:reset-mp4-stats', () => {
+    store.set('mp4StreamingStats', { totalChecked: 0, faststartCount: 0, nonFaststartSamples: [] })
+  })
+
   ipcMain.handle('dump-quality-mismatches', () => {
     const outPath = path.join(getDownloadDir(), 'quality-mismatches.json')
     const data = [...qualityMismatches.values()]
@@ -3206,6 +3257,17 @@ function registerIpcHandlers(): void {
       if (coldDir) dirsToCheck.push(coldDir)
     }
 
+    const onResolved = (fp: string): void => {
+      if (fp.toLowerCase().endsWith('.mp4')) {
+        void recordMp4FaststartCheck(fp, {
+          animeId: 0,
+          animeName,
+          episodeInt,
+          episodeLabel: `Ep ${episodeInt}`
+        })
+      }
+    }
+
     for (const dir of dirsToCheck) {
       const animeDir = path.join(dir, animeDirName)
       // Try tagged filename first
@@ -3216,6 +3278,7 @@ function registerIpcHandlers(): void {
             const assPath = fp.replace(/\.(mp4|mkv)$/i, '.ass')
             try { return fs.existsSync(assPath) ? fs.readFileSync(assPath, 'utf-8') : null } catch { return null }
           })()
+          onResolved(fp)
           return { filePath: fp, subtitleContent }
         }
       }
@@ -3227,6 +3290,7 @@ function registerIpcHandlers(): void {
             const assPath = fp.replace(/\.(mp4|mkv)$/i, '.ass')
             try { return fs.existsSync(assPath) ? fs.readFileSync(assPath, 'utf-8') : null } catch { return null }
           })()
+          onResolved(fp)
           return { filePath: fp, subtitleContent }
         }
       }
@@ -4135,6 +4199,16 @@ app.whenReady().then(async () => {
     if (mode === 'queue') {
       showBackgroundNotification('Downloads complete', 'All downloads have finished')
     }
+  })
+
+  downloadManager.onVideoDownloaded((filePath, item) => {
+    if (!filePath.toLowerCase().endsWith('.mp4')) return
+    void recordMp4FaststartCheck(filePath, {
+      animeId: item.animeId,
+      animeName: item.animeName,
+      episodeInt: item.episodeInt,
+      episodeLabel: item.episodeLabel
+    })
   })
 
   registerIpcHandlers()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -202,7 +202,7 @@ async function recordMp4FaststartCheck(
     if (stats.nonFaststartSamples.length > 10) {
       stats.nonFaststartSamples = stats.nonFaststartSamples.slice(-10)
     }
-    console.error(`[mp4-faststart] non-faststart MP4 detected: ${context.animeName} — ${context.episodeLabel} (first non-ftyp box: ${probe.firstNonFtypBox}) at ${filePath}`)
+    console.warn(`[mp4-faststart] non-faststart MP4 detected: ${context.animeName} — ${context.episodeLabel} (first non-ftyp box: ${probe.firstNonFtypBox}) at ${filePath}`)
   }
   store.set('mp4StreamingStats', stats)
 }
@@ -1940,6 +1940,7 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('debug:reset-mp4-stats', () => {
     store.set('mp4StreamingStats', { totalChecked: 0, faststartCount: 0, nonFaststartSamples: [] })
+    mp4FaststartChecked.clear()
   })
 
   ipcMain.handle('dump-quality-mismatches', () => {
@@ -3259,6 +3260,10 @@ function registerIpcHandlers(): void {
 
     const onResolved = (fp: string): void => {
       if (fp.toLowerCase().endsWith('.mp4')) {
+        // animeId is 0 here because this handler only receives animeName; resolving
+        // back to an id would require scanning recentAnimeMeta. The stats sample is
+        // for human inspection (anime title + episode + filepath), so the missing
+        // id is acceptable.
         void recordMp4FaststartCheck(fp, {
           animeId: 0,
           animeName,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -177,6 +177,10 @@ function isNetworkError(err: unknown): boolean {
 // per-file ledger.
 const mp4FaststartChecked = new Set<string>()
 
+// Serialize stats read-modify-write so concurrent download finishes can't
+// clobber each other's increments.
+let mp4StatsWriteChain: Promise<void> = Promise.resolve()
+
 async function recordMp4FaststartCheck(
   filePath: string,
   context: { animeId: number; animeName: string; episodeInt: string; episodeLabel: string }
@@ -185,26 +189,30 @@ async function recordMp4FaststartCheck(
   mp4FaststartChecked.add(filePath)
   const probe = await probeMp4Faststart(filePath)
   if (!probe) return
-  const stats = store.get('mp4StreamingStats') as Mp4StreamingStats
-  stats.totalChecked += 1
-  if (probe.faststart) {
-    stats.faststartCount += 1
-  } else {
-    stats.nonFaststartSamples.push({
-      animeId: context.animeId,
-      animeName: context.animeName,
-      episodeInt: context.episodeInt,
-      episodeLabel: context.episodeLabel,
-      filePath,
-      firstNonFtypBox: probe.firstNonFtypBox,
-      checkedAt: Date.now()
-    })
-    if (stats.nonFaststartSamples.length > 10) {
-      stats.nonFaststartSamples = stats.nonFaststartSamples.slice(-10)
+  const next = mp4StatsWriteChain.then(() => {
+    const stats = store.get('mp4StreamingStats') as Mp4StreamingStats
+    stats.totalChecked += 1
+    if (probe.faststart) {
+      stats.faststartCount += 1
+    } else {
+      stats.nonFaststartSamples.push({
+        animeId: context.animeId,
+        animeName: context.animeName,
+        episodeInt: context.episodeInt,
+        episodeLabel: context.episodeLabel,
+        filePath,
+        firstNonFtypBox: probe.firstNonFtypBox,
+        checkedAt: Date.now()
+      })
+      if (stats.nonFaststartSamples.length > 10) {
+        stats.nonFaststartSamples = stats.nonFaststartSamples.slice(-10)
+      }
+      console.warn(`[mp4-faststart] non-faststart MP4 detected: ${context.animeName} — ${context.episodeLabel} (first non-ftyp box: ${probe.firstNonFtypBox}) at ${filePath}`)
     }
-    console.warn(`[mp4-faststart] non-faststart MP4 detected: ${context.animeName} — ${context.episodeLabel} (first non-ftyp box: ${probe.firstNonFtypBox}) at ${filePath}`)
-  }
-  store.set('mp4StreamingStats', stats)
+    store.set('mp4StreamingStats', stats)
+  })
+  mp4StatsWriteChain = next.catch(() => undefined)
+  await next
 }
 
 interface QueuedShikimoriUpdate {
@@ -3230,7 +3238,7 @@ function registerIpcHandlers(): void {
     return null
   })
 
-  ipcMain.handle('player:find-local-file', async (_event, animeName: string, episodeInt: string, translationId: number) => {
+  ipcMain.handle('player:find-local-file', async (_event, animeName: string, episodeInt: string, translationId: number, episodeLabel: string) => {
     const episodes = store.get('downloadedEpisodes') as Record<string, { translationType: string; author: string; quality: number; translationId: number }>
     // Find meta for this translation — try new key format, then scan for legacy
     let meta: { author: string } | null = null
@@ -3268,7 +3276,7 @@ function registerIpcHandlers(): void {
           animeId: 0,
           animeName,
           episodeInt,
-          episodeLabel: `Ep ${episodeInt}`
+          episodeLabel
         })
       }
     }

--- a/src/main/mp4-faststart.ts
+++ b/src/main/mp4-faststart.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs/promises'
+
+export interface Mp4FaststartProbe {
+  faststart: boolean
+  firstNonFtypBox: string
+}
+
+export interface Mp4StreamingStatsSample {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  episodeLabel: string
+  filePath: string
+  firstNonFtypBox: string
+  checkedAt: number
+}
+
+export interface Mp4StreamingStats {
+  totalChecked: number
+  faststartCount: number
+  nonFaststartSamples: Mp4StreamingStatsSample[]
+}
+
+const PEEK_SIZE = 64 * 1024
+
+export async function probeMp4Faststart(filePath: string): Promise<Mp4FaststartProbe | null> {
+  let fh: fs.FileHandle | null = null
+  try {
+    fh = await fs.open(filePath, 'r')
+    const stat = await fh.stat()
+    const len = Math.min(PEEK_SIZE, stat.size)
+    if (len < 16) return null
+    const buf = Buffer.alloc(len)
+    await fh.read(buf, 0, len, 0)
+
+    let offset = 0
+    let firstNonFtypBox: string | null = null
+    while (offset + 8 <= buf.length) {
+      const size = buf.readUInt32BE(offset)
+      const type = buf.toString('ascii', offset + 4, offset + 8)
+      let boxSize = size
+      if (size === 1) {
+        if (offset + 16 > buf.length) break
+        const high = buf.readUInt32BE(offset + 8)
+        const low = buf.readUInt32BE(offset + 12)
+        boxSize = high * 0x100000000 + low
+      } else if (size === 0) {
+        boxSize = stat.size - offset
+      }
+
+      if (type !== 'ftyp' && firstNonFtypBox === null) {
+        firstNonFtypBox = type
+      }
+      if (type === 'moov') {
+        return { faststart: true, firstNonFtypBox: firstNonFtypBox ?? 'moov' }
+      }
+      if (type === 'mdat') {
+        return { faststart: false, firstNonFtypBox: firstNonFtypBox ?? 'mdat' }
+      }
+      if (boxSize < 8) break
+      offset += boxSize
+    }
+    return firstNonFtypBox ? { faststart: false, firstNonFtypBox } : null
+  } catch {
+    return null
+  } finally {
+    if (fh) await fh.close().catch(() => { /* ignore */ })
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,8 @@ const api = {
     ipcRenderer.invoke('report-quality-mismatch', data),
   getQualityMismatchCount: () => ipcRenderer.invoke('get-quality-mismatch-count') as Promise<number>,
   dumpQualityMismatches: () => ipcRenderer.invoke('dump-quality-mismatches') as Promise<{ count: number; path: string }>,
+  debugGetMp4Stats: () => ipcRenderer.invoke('debug:get-mp4-stats') as Promise<Mp4StreamingStats>,
+  debugResetMp4Stats: () => ipcRenderer.invoke('debug:reset-mp4-stats') as Promise<void>,
   getCachedPoster: (animeId: number) => ipcRenderer.invoke('cache-get-poster', animeId) as Promise<string | null>,
   libraryGet: () => ipcRenderer.invoke('library-get'),
   libraryToggle: (anime: unknown) => ipcRenderer.invoke('library-toggle', anime),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -200,8 +200,8 @@ const api = {
     ipcRenderer.invoke('player:get-stream-url', translationId, maxHeight),
   playerGetLocalSubtitles: (filePath: string) =>
     ipcRenderer.invoke('player:get-local-subtitles', filePath) as Promise<string | null>,
-  playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) =>
-    ipcRenderer.invoke('player:find-local-file', animeName, episodeInt, translationId) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
+  playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number, episodeLabel: string) =>
+    ipcRenderer.invoke('player:find-local-file', animeName, episodeInt, translationId, episodeLabel) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
   playerRemuxMkv: (mkvPath: string) =>
     ipcRenderer.invoke('player:remux-mkv', mkvPath) as Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>,
   playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) =>

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -119,7 +119,7 @@ interface Api {
   // Player
   playerGetStreamUrl: (translationId: number, maxHeight: number) => Promise<{ streamUrl: string; subtitleContent: string | null; availableStreams: { height: number; url: string }[] } | null>
   playerGetLocalSubtitles: (filePath: string) => Promise<string | null>
-  playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number) => Promise<{ filePath: string; subtitleContent: string | null } | null>
+  playerFindLocalFile: (animeName: string, episodeInt: string, translationId: number, episodeLabel: string) => Promise<{ filePath: string; subtitleContent: string | null } | null>
   playerRemuxMkv: (mkvPath: string) => Promise<{ mp4Path: string; subtitleContent?: string } | { error: string }>
   playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) => Promise<
     | { sessionId: string; generation: number; duration: number; mimeType: string; hasSubtitlesPending: boolean; initialSeek: number }

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -24,6 +24,8 @@ interface Api {
   reportQualityMismatch: (data: { translationId: number; author: string; type: string; reported: number; actual: number }) => Promise<void>
   getQualityMismatchCount: () => Promise<number>
   dumpQualityMismatches: () => Promise<{ count: number; path: string }>
+  debugGetMp4Stats: () => Promise<Mp4StreamingStats>
+  debugResetMp4Stats: () => Promise<void>
   libraryGet: () => Promise<AnimeSearchResult[]>
   libraryToggle: (anime: AnimeSearchResult) => Promise<boolean>
   libraryHas: (id: number) => Promise<boolean>
@@ -499,6 +501,22 @@ interface SkipDetectorProgress {
   current: number
   total: number
   episodeLabel?: string
+}
+
+interface Mp4StreamingStatsSample {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  episodeLabel: string
+  filePath: string
+  firstNonFtypBox: string
+  checkedAt: number
+}
+
+interface Mp4StreamingStats {
+  totalChecked: number
+  faststartCount: number
+  nonFaststartSamples: Mp4StreamingStatsSample[]
 }
 
 interface ShikiUser {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -1657,7 +1657,9 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
   try {
     // Check if this translation has a local file
     if (activeDownloadedTrIds.value.includes(tr.id)) {
-      const localResult = await window.api.playerFindLocalFile(props.animeName, activeEpisodeLabel.value, tr.id)
+      const currentEp = props.allEpisodes[activeEpisodeIndex.value]
+      const friendlyLabel = currentEp?.episodeFull || activeEpisodeLabel.value
+      const localResult = await window.api.playerFindLocalFile(props.animeName, activeEpisodeLabel.value, tr.id, friendlyLabel)
       if (localResult) {
         activeTranslationId.value = tr.id
 
@@ -1827,7 +1829,7 @@ async function goToEpisode(direction: 'prev' | 'next'): Promise<void> {
 
     // Try local file first if downloaded (forceLocal means we specifically chose a downloaded translation)
     if (forceLocal || targetEp.downloadedTrIds.includes(resolvedTr.id)) {
-      const localResult = await window.api.playerFindLocalFile(props.animeName, targetEp.episodeInt, resolvedTr.id)
+      const localResult = await window.api.playerFindLocalFile(props.animeName, targetEp.episodeInt, resolvedTr.id, targetEp.episodeFull)
       if (localResult) {
         activeFilePath.value = localResult.filePath
         activeStreamUrl.value = ''

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -1660,7 +1660,7 @@ async function testSyncplayConnection(): Promise<void> {
 
         <div class="setting-group">
           <label class="setting-label">MP4 streaming-optimization check</label>
-          <p class="setting-hint">After every video download or when an MP4 is opened in the player, the first ~64 KB are scanned for the MP4 box order. Streaming-optimized files (`moov` before `mdat`) are required to play while still downloading. If a non-faststart file is found, an example is shown below for inspection.</p>
+          <p class="setting-hint">After every video download or when an MP4 is opened in the player, the first ~64 KB are scanned for the MP4 box order. Streaming-optimized files (<code>moov</code> before <code>mdat</code>) are required to play while still downloading. If a non-faststart file is found, an example is shown below for inspection.</p>
           <button class="merge-all-btn" @click="refreshMp4Stats">Refresh</button>
           <button class="merge-all-btn" style="margin-left: 0.5rem" @click="resetMp4Stats" :disabled="!mp4Stats || mp4Stats.totalChecked === 0">Reset</button>
 

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -138,6 +138,14 @@ const dumpingMismatches = ref(false)
 const dumpResult = ref<{ count: number; path: string } | null>(null)
 const mismatchCount = ref(0)
 
+// MP4 streaming-optimization (faststart) check stats
+const mp4Stats = ref<Mp4StreamingStats | null>(null)
+const latestNonFaststart = computed<Mp4StreamingStatsSample | null>(() => {
+  const s = mp4Stats.value
+  if (!s || s.nonFaststartSamples.length === 0) return null
+  return s.nonFaststartSamples[s.nonFaststartSamples.length - 1]
+})
+
 // Shikimori state
 const shikimoriUser = ref<ShikiUser | null>(null)
 const shikimoriAuthUrl = ref('')
@@ -282,6 +290,17 @@ function onFixProgress(data: { current: number; total: number; file: string }): 
 
 async function refreshMismatchCount(): Promise<void> {
   mismatchCount.value = await window.api.getQualityMismatchCount()
+}
+
+async function refreshMp4Stats(): Promise<void> {
+  try {
+    mp4Stats.value = await window.api.debugGetMp4Stats()
+  } catch { /* ignore */ }
+}
+
+async function resetMp4Stats(): Promise<void> {
+  await window.api.debugResetMp4Stats()
+  await refreshMp4Stats()
 }
 
 async function dumpMismatches(): Promise<void> {
@@ -912,7 +931,7 @@ async function testSyncplayConnection(): Promise<void> {
         Watch Together
         <span class="tab-dev-badge">in development</span>
       </button>
-      <button class="tab" :class="{ active: activeTab === 'debug' }" @click="activeTab = 'debug'; refreshMismatchCount()">Debug</button>
+      <button class="tab" :class="{ active: activeTab === 'debug' }" @click="activeTab = 'debug'; refreshMismatchCount(); refreshMp4Stats()">Debug</button>
     </div>
     <div class="body">
       <!-- General tab -->
@@ -1636,6 +1655,27 @@ async function testSyncplayConnection(): Promise<void> {
               Saved {{ dumpResult.count }} mismatch(es)
             </div>
             <div class="scan-error-item">{{ dumpResult.path }}</div>
+          </div>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">MP4 streaming-optimization check</label>
+          <p class="setting-hint">After every video download or when an MP4 is opened in the player, the first ~64 KB are scanned for the MP4 box order. Streaming-optimized files (`moov` before `mdat`) are required to play while still downloading. If a non-faststart file is found, an example is shown below for inspection.</p>
+          <button class="merge-all-btn" @click="refreshMp4Stats">Refresh</button>
+          <button class="merge-all-btn" style="margin-left: 0.5rem" @click="resetMp4Stats" :disabled="!mp4Stats || mp4Stats.totalChecked === 0">Reset</button>
+
+          <div v-if="mp4Stats" class="scan-result" :class="{ 'has-errors': mp4Stats.nonFaststartSamples.length > 0 }">
+            <div class="scan-result-ok">
+              Faststart: {{ mp4Stats.faststartCount }} / {{ mp4Stats.totalChecked }}
+            </div>
+            <div v-if="latestNonFaststart" class="scan-result-errors">
+              <div>Sample non-faststart MP4 (most recent of {{ mp4Stats.nonFaststartSamples.length }}):</div>
+              <div class="scan-error-item">
+                {{ latestNonFaststart.animeName }} — {{ latestNonFaststart.episodeLabel }}
+                (first non-ftyp box: {{ latestNonFaststart.firstNonFtypBox }})
+              </div>
+              <div class="scan-error-item" style="opacity: 0.7">{{ latestNonFaststart.filePath }}</div>
+            </div>
           </div>
         </div>
       </template>


### PR DESCRIPTION
## Summary
- Adds a small MP4 box-header walker (`src/main/mp4-faststart.ts`) that reads the first ~64 KB of a file and reports whether `moov` precedes `mdat`.
- Runs the probe in two places:
  - When a video download finalizes (`.part → .mp4` rename), via a new `onVideoDownloaded` callback on `DownloadManager`.
  - When the player resolves a local MP4 via `player:find-local-file` (so users with already-downloaded files contribute samples too).
- Persists stats in electron-store (`mp4StreamingStats`) — total checked, faststart count, and up to 10 most-recent non-faststart samples (anime + episode + path).
- Shows the stats on the existing Debug tab in Settings, with the most recent non-faststart example and a Reset button.
- An in-memory per-session `Set<string>` keeps the player path from double-counting when the same file is opened multiple times.
- Patch version bump to 3.19.1.
- MKV files are explicitly skipped — both call sites guard on `.mp4` suffix, so the MKV/MSE playback path is untouched.

## Why
Issue #63 (watch episodes while downloading) only works if the CDN serves streaming-optimized MP4s (`moov`-at-start). A spike against one episode confirmed the primary CDN does, but we want background telemetry before that feature ships, so a different show or quality variant served by a non-faststart encoder doesn't surprise us in production.

If a non-faststart file shows up in the wild, the debug panel surfaces a concrete anime + episode + path so it can be reproduced and investigated.

## Test plan
- [ ] Download a fresh episode, confirm `Faststart: 1 / 1` on the Debug tab.
- [ ] Open an already-downloaded MP4 in the built-in player, confirm the count increments.
- [ ] Open the same MP4 again — count should not change (per-session de-dup).
- [ ] Verify MKV opens do not affect the count.
- [ ] Verify stats survive an app restart.