### PR TITLE
feat: remember selected translation per episode

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -278,7 +278,7 @@ LibraryView shows both with indicators:
 | `downloaded-episodes-get` | invoke | Get translation metadata per episode (array of metas per episode, supports multiple translations) |
 | `get-setting` | invoke | Read setting value |
 | `set-setting` | invoke | Write setting value |
-| `watch-progress:save` | invoke | Save playback position + optional watched flag for an episode |
+| `watch-progress:save` | invoke | Save playback position + optional watched flag + optional remembered translationId for an episode |
 | `watch-progress:get` | invoke | Fetch saved progress for a single episode |
 | `watch-progress:get-all` | invoke | Fetch all saved progress entries for an anime (keyed by episodeInt) |
 | `download:enqueue` | invoke | Queue download requests + save episode metadata |
@@ -445,7 +445,7 @@ interface EpisodeMeta {
 | `playerMode` | string | `'system'` | Default player: `system` (OS default) or `builtin` (in-app HTML5 player) |
 | `anime4kPreset` | string | `'off'` | Anime4K shader preset: `off`, `mode-a` (1080p), `mode-b` (720p), `mode-c` (480p) |
 | `hevcTranscodeOnPlay` | string | `'ask'` | HEVC fallback when the built-in player has no decoder: `ask` (show modal), `always` (transcode to H.264), `never` (open in external player) |
-| `watchProgress` | object | `{}` | Per-episode playback position + watched flag (key: `animeId:episodeInt`) |
+| `watchProgress` | object | `{}` | Per-episode playback position + watched flag + last-used translationId (key: `animeId:episodeInt`) |
 | `shikimoriUserRates` | array | `[]` | Cached Shikimori anime rate entries (served cache-first, background-refreshed) |
 | `shikimoriUpdateQueue` | array | `[]` | Pending rate updates queued when the `update-rate` IPC failed due to a network error (for later sync) |
 | `shikimoriAnimeDetails` | object | `{}` | Pre-fetched per-anime Shikimori details (description, genres, studios) keyed by MAL ID; populated by the throttled background worker |
@@ -465,6 +465,8 @@ The built-in player auto-saves playback position to `watchProgress` (electron-st
 When an episode is marked watched and `malId > 0`, the player fetches the current Shikimori rate and, if `epNum > rate.episodes`, calls `shikimoriUpdateRate` with `'watching'` (or `'rewatching'` if current status was `'completed'`).
 
 `AnimeDetailView` loads all watch-progress entries for the anime on mount via `watchProgressGetAll` and renders a small ✓ badge (watched) or mini progress bar (partial) on each episode row. The view listens on a `watch-progress-updated` window event — dispatched by `PlayerView` after each save — to refresh indicators live.
+
+The active translation choice is persisted into `watchProgress[key].translationId` from two paths: the player (`saveProgress` passes `activeTranslationId` on every save; `selectTranslation` writes it immediately on switch, bypassing the trivial-time guard) and the pre-player dropdown in `AnimeDetailView` (`onEpisodeTranslationChange` calls `watchProgressSave`, reusing any prior `position`/`duration` so partial-watch progress isn't clobbered). When `AnimeDetailView` builds `episodeRows`, the per-episode `selectedTr` is resolved by priority: (1) active queue lock → (2) per-episode override (in-session, sync) → (3) remembered `translationId` from `watchProgress` → (4) any downloaded translation → (5) global type+author default. An explicit user choice — even a stream — therefore wins over a downloaded file. Queue-lock stays at the top because the row UI replaces the dropdown with a "Queued" label while a download is in flight, preventing a race between user switching and the in-flight download.
 
 ## Hot/Cold Storage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -98,7 +98,7 @@ const store = new Store({
     playerMuted: false,
     anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
     hevcTranscodeOnPlay: 'ask' as 'ask' | 'always' | 'never',
-    watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>,
+    watchProgress: {} as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number; translationId?: number }>,
     watchProgressMigrationV2: false,
     autoCleanupWatchedDays: 0,
     autoCleanupConfirm: true,
@@ -2297,8 +2297,8 @@ function registerIpcHandlers(): void {
   })
 
   // Watch progress tracking
-  ipcMain.handle('watch-progress:save', (_event, animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
+  ipcMain.handle('watch-progress:save', (_event, animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean, translationId?: number) => {
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number; translationId?: number }>
     const key = `${animeId}:${episodeInt}`
     const prev = all[key]
     const nowWatched = watched || prev?.watched || false
@@ -2308,20 +2308,21 @@ function registerIpcHandlers(): void {
       duration,
       updatedAt: Date.now(),
       watched: nowWatched,
-      watchedAt: justWatched ? Date.now() : prev?.watchedAt
+      watchedAt: justWatched ? Date.now() : prev?.watchedAt,
+      translationId: translationId !== undefined ? translationId : prev?.translationId
     }
     store.set('watchProgress', all)
   })
 
   ipcMain.handle('watch-progress:get', (_event, animeId: number, episodeInt: string) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number; translationId?: number }>
     return all[`${animeId}:${episodeInt}`] || null
   })
 
   ipcMain.handle('watch-progress:get-all', (_event, animeId: number) => {
-    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }>
+    const all = store.get('watchProgress') as Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number; translationId?: number }>
     const prefix = `${animeId}:`
-    const out: Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number }> = {}
+    const out: Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; watchedAt?: number; translationId?: number }> = {}
     for (const [key, val] of Object.entries(all)) {
       if (key.startsWith(prefix)) {
         out[key.slice(prefix.length)] = val

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,12 +60,12 @@ const api = {
     ipcRenderer.invoke('home:get-continue-watching') as Promise<ContinueWatchingEntry[]>,
 
   // Watch progress
-  watchProgressSave: (animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean) =>
-    ipcRenderer.invoke('watch-progress:save', animeId, episodeInt, position, duration, watched),
+  watchProgressSave: (animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean, translationId?: number) =>
+    ipcRenderer.invoke('watch-progress:save', animeId, episodeInt, position, duration, watched, translationId),
   watchProgressGet: (animeId: number, episodeInt: string) =>
-    ipcRenderer.invoke('watch-progress:get', animeId, episodeInt) as Promise<{ position: number; duration: number; updatedAt: number; watched?: boolean } | null>,
+    ipcRenderer.invoke('watch-progress:get', animeId, episodeInt) as Promise<{ position: number; duration: number; updatedAt: number; watched?: boolean; translationId?: number } | null>,
   watchProgressGetAll: (animeId: number) =>
-    ipcRenderer.invoke('watch-progress:get-all', animeId) as Promise<Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean }>>,
+    ipcRenderer.invoke('watch-progress:get-all', animeId) as Promise<Record<string, { position: number; duration: number; updatedAt: number; watched?: boolean; translationId?: number }>>,
 
   // Downloads
   downloadEnqueue: (requests: unknown[]) => ipcRenderer.invoke('download:enqueue', requests),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -39,7 +39,7 @@ interface Api {
   homeGetContinueWatching: () => Promise<ContinueWatchingEntry[]>
 
   // Watch progress
-  watchProgressSave: (animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean) => Promise<void>
+  watchProgressSave: (animeId: number, episodeInt: string, position: number, duration: number, watched?: boolean, translationId?: number) => Promise<void>
   watchProgressGet: (animeId: number, episodeInt: string) => Promise<WatchProgressEntry | null>
   watchProgressGetAll: (animeId: number) => Promise<Record<string, WatchProgressEntry>>
 
@@ -339,6 +339,7 @@ interface WatchProgressEntry {
   updatedAt: number
   watched?: boolean
   watchedAt?: number
+  translationId?: number
 }
 
 interface StorageEpisodeUsage {

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -265,12 +265,23 @@ const episodeRows = computed((): EpisodeRow[] => {
       }
     }
 
-    // Priority 2: User per-episode override
+    // Priority 2: User per-episode override (in-session, sync; gives instant feedback
+    // after a dropdown click before the persisted watchProgress update lands)
     if (!isLocked && episodeOverrides.value.has(ep.id)) {
       selectedTr = sorted.find(tr => tr.id === episodeOverrides.value.get(ep.id)) || null
     }
 
-    // Priority 3: Prefer any downloaded translation on this episode — avoids silent fallback to
+    // Priority 3: Last-used translation for this episode (persisted in watchProgress).
+    // Sits ABOVE downloaded so an explicit user choice — even a stream — wins over
+    // a downloaded file. Falls through if the remembered id is no longer available.
+    if (!isLocked && !selectedTr) {
+      const remembered = watchProgress.value[ep.episodeInt]?.translationId
+      if (remembered != null) {
+        selectedTr = sorted.find(tr => tr.id === remembered) || null
+      }
+    }
+
+    // Priority 4: Prefer any downloaded translation on this episode — avoids silent fallback to
     // streaming when the global default (type+author) doesn't match what's on disk.
     // Within same-type downloads, honor the user's author preference before picking highest quality.
     if (!isLocked && !selectedTr && downloadedTrIds.size > 0) {
@@ -281,7 +292,7 @@ const episodeRows = computed((): EpisodeRow[] => {
       selectedTr = sameAuthor || bestSameType || downloaded[0] || null
     }
 
-    // Priority 4: Global default (same type + author)
+    // Priority 5: Global default (same type + author)
     if (!isLocked && !selectedTr) {
       const typeFiltered = sorted.filter(tr => tr.type === translationType.value)
       selectedTr = typeFiltered.find(tr => tr.authorsSummary === selectedAuthor.value)
@@ -292,8 +303,20 @@ const episodeRows = computed((): EpisodeRow[] => {
   })
 })
 
-function onEpisodeTranslationChange(episodeId: number, translationId: number): void {
+function onEpisodeTranslationChange(episodeId: number, episodeInt: string, translationId: number): void {
   episodeOverrides.value = new Map(episodeOverrides.value.set(episodeId, translationId))
+  // Persist so the choice survives page reloads and feeds back into Priority 3
+  // resolution. Reuse any existing playback position/duration so we don't clobber
+  // partial-watch progress when the user just changes translation.
+  const prev = watchProgress.value[episodeInt]
+  window.api.watchProgressSave(
+    props.animeId,
+    episodeInt,
+    prev?.position ?? 0,
+    prev?.duration ?? 0,
+    prev?.watched,
+    translationId
+  ).catch(err => console.warn('[anime-detail] failed to persist translation choice:', err))
 }
 
 function onMouseBack(e: MouseEvent): void {
@@ -1627,7 +1650,7 @@ function typeChip(type: string): { short: string; color: string } {
             <select
               class="ep-select"
               :value="row.selectedTr?.id || ''"
-              @change="onEpisodeTranslationChange(row.episode.id, Number(($event.target as HTMLSelectElement).value))"
+              @change="onEpisodeTranslationChange(row.episode.id, row.episode.episodeInt, Number(($event.target as HTMLSelectElement).value))"
             >
               <!-- Show selected type first, then the rest -->
               <template v-for="type in [TRANSLATION_TYPES.find(t => t.value === translationType)!, ...TRANSLATION_TYPES.filter(t => t.value !== translationType)]" :key="type.value">

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -467,10 +467,24 @@ async function saveProgress(force = false): Promise<void> {
   // When watched, clear the position so we don't try to resume near the end later
   const positionToSave = watchedReported ? 0 : video.currentTime
   try {
-    await window.api.watchProgressSave(props.animeId, epInt, positionToSave, duration.value, watchedReported)
+    await window.api.watchProgressSave(props.animeId, epInt, positionToSave, duration.value, watchedReported, activeTranslationId.value ?? undefined)
     window.dispatchEvent(new CustomEvent('watch-progress-updated'))
   } catch (err) {
     console.warn('[player] failed to save watch progress:', err)
+  }
+}
+
+async function persistSelectedTranslation(translationId: number): Promise<void> {
+  const epInt = currentEpisodeInt.value
+  if (!props.animeId || !epInt) return
+  const video = videoRef.value
+  const pos = watchedReported ? 0 : (video?.currentTime ?? 0)
+  const dur = duration.value || (video?.duration ?? 0)
+  try {
+    await window.api.watchProgressSave(props.animeId, epInt, pos, dur, watchedReported, translationId)
+    window.dispatchEvent(new CustomEvent('watch-progress-updated'))
+  } catch (err) {
+    console.warn('[player] failed to persist translation choice:', err)
   }
 }
 
@@ -1662,6 +1676,7 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
       const localResult = await window.api.playerFindLocalFile(props.animeName, activeEpisodeLabel.value, tr.id, friendlyLabel)
       if (localResult) {
         activeTranslationId.value = tr.id
+        persistSelectedTranslation(tr.id)
 
         // Clean up previous remux / stream session if any
         if (remuxedPath.value || streamSessionId.value) {
@@ -1710,6 +1725,7 @@ async function selectTranslation(tr: { id: number; label: string; type: string; 
     }
 
     activeTranslationId.value = tr.id
+    persistSelectedTranslation(tr.id)
 
     // Clean up previous remux / MSE stream if switching from local to stream
     if (remuxedPath.value || streamSessionId.value) {

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -478,8 +478,19 @@ async function persistSelectedTranslation(translationId: number): Promise<void> 
   const epInt = currentEpisodeInt.value
   if (!props.animeId || !epInt) return
   const video = videoRef.value
-  const pos = watchedReported ? 0 : (video?.currentTime ?? 0)
-  const dur = duration.value || (video?.duration ?? 0)
+  const vidDur = video?.duration && !Number.isNaN(video.duration) ? video.duration : 0
+  let pos = watchedReported ? 0 : (video?.currentTime ?? 0)
+  let dur = duration.value || vidDur
+  if (!dur) {
+    // Pre-loadedmetadata switch: avoid clobbering existing resume position with 0/0
+    try {
+      const prev = await window.api.watchProgressGet(props.animeId, epInt)
+      if (prev) {
+        pos = prev.watched ? 0 : prev.position
+        dur = prev.duration
+      }
+    } catch { /* ignore */ }
+  }
   try {
     await window.api.watchProgressSave(props.animeId, epInt, pos, dur, watchedReported, translationId)
     window.dispatchEvent(new CustomEvent('watch-progress-updated'))


### PR DESCRIPTION
## Summary

Persist the active translation id into `watchProgress` so reopening an episode preselects the last-chosen translation. The remembered choice overrides downloaded files — an explicit user pick (even a stream) takes precedence over what's on disk, per the updated requirements in #50.

- `watchProgress` entries gain `translationId`; the save handler preserves the prior value when not passed and overwrites when a value is passed.
- `PlayerView.saveProgress` now passes `activeTranslationId`. A new `persistSelectedTranslation` helper fires immediately on `selectTranslation` (both local-file and stream paths), bypassing the trivial-time guard so the choice survives even a quick switch-then-close.
- `AnimeDetailView.onEpisodeTranslationChange` also persists via `watchProgressSave` (reusing prior `position`/`duration` so partial-watch progress isn't clobbered when only the translation changes).
- `AnimeDetailView.episodeRows` resolves `selectedTr` in the order: queue lock → per-episode override (in-session, sync) → **remembered translationId** → any downloaded translation → global type+author default. Queue-lock stays at the top because the row UI replaces the dropdown with a "Queued" label while a download is in flight.

Fixes #50

## Test plan

- [ ] Open an episode in the built-in player; switch to a non-default translation; close the player. Reopen the same episode from `AnimeDetailView` — the same translation is preselected on the row and in the player.
- [ ] Download a file in a *different* translation than the remembered one; verify the **remembered translation still wins** (it now overrides downloaded files).
- [ ] Change the translation via the episode-list dropdown (without opening the player); navigate away and back — the choice persists.
- [ ] An in-flight download still locks the row to the queued translation (the dropdown is replaced with a \"Queued\" label).
- [ ] Marking a previous episode as watched (auto-advance scenario) does not clobber that episode's remembered \`translationId\`.
- [ ] \`npm run typecheck\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)