### PR TITLE
feat: cache-first AnimeDetailView load with 24h TTL

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,7 +98,8 @@ translation type and author selections across re-mounts.
 ### Episode Loading & Translation Selection
 
 ```
-AnimeDetailView  -->  getAnime(id) --> full anime with episode list
+AnimeDetailView  -->  getAnimeCache(id) --> instant render if cached and fresh
+                 -->  getAnime(id) --> full anime with episode list (background-refresh)
                  -->  getEpisode(id) x N (batches of 5) --> translations per episode
                  -->  all active translations shown (no quality minimum)
                  -->  best quality per author+type deduplication
@@ -108,6 +109,15 @@ AnimeDetailView  -->  getAnime(id) --> full anime with episode list
 Episode list is paginated (30 per page) when anime has >30 TV episodes.
 Only translations for the visible page are fetched (in batches of 5).
 Cached translations are reused when revisiting a page.
+
+For starred or downloaded anime, the full AnimeDetail payload is cached in
+`animeCache[animeId].animeDetail` with a 24h TTL. AnimeDetailView calls
+`getAnimeCache(id)` on mount: on a hit, the page renders instantly from the
+cache while a background `getAnime(id)` refreshes the data; on miss, the
+spinner stays up until the API responds. A per-mount generation counter +
+`disposed` flag prevent stale background fetches from polluting state when
+the user rapidly switches anime. Cache writes are gated on starred OR
+downloaded; unstarring evicts the cache entry if the anime isn't downloaded.
 
 Per-episode translation selector with priority chain:
   1. In download queue → locked to queued translation
@@ -262,6 +272,8 @@ LibraryView shows both with indicators:
 | `validate-token` | invoke | Validate API token against smotret-anime.ru |
 | `search-anime` | invoke | Search anime by query |
 | `get-anime` | invoke | Fetch anime details by ID |
+| `get-anime-cache` | invoke | Read cached AnimeDetail for fast first paint (returns null if missing or older than 24h) |
+| `set-anime-cache` | invoke | Write AnimeDetail to cache (no-op if anime is neither starred nor downloaded) |
 | `get-episode` | invoke | Fetch episode translations |
 | `probe-embed-quality` | invoke | Probe embed API for actual stream height |
 | `report-quality-mismatch` | invoke | Report a detected quality mismatch (stored in memory) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.20.2",
+  "version": "3.20.3",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -553,11 +553,22 @@ async function prefetchShikimoriDetails(): Promise<void> {
   }
 }
 
-// --- Anime cache helpers (for offline support of downloaded anime) ---
+// --- Anime cache helpers (for offline support + fast-loading detail view) ---
+
+const ANIME_DETAIL_CACHE_TTL_MS = 24 * 60 * 60 * 1000
 
 function isDownloadedAnime(animeId: number): boolean {
   const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
   return !!downloaded[String(animeId)]
+}
+
+function isStarredAnime(animeId: number): boolean {
+  const lib = store.get('library') as Record<string, AnimeSearchResult>
+  return !!lib[String(animeId)]
+}
+
+function isCachableAnime(animeId: number): boolean {
+  return isDownloadedAnime(animeId) || isStarredAnime(animeId)
 }
 
 type FileCheckResult = Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>
@@ -754,7 +765,7 @@ function ensureCacheEntry(animeId: number): AnimeCacheEntry {
 }
 
 function updateAnimeDetailCache(animeId: number, detail: AnimeDetail): void {
-  if (!isDownloadedAnime(animeId)) return
+  if (!isCachableAnime(animeId)) return
   const entry = ensureCacheEntry(animeId)
   entry.animeDetail = detail
   entry.cachedAt = Date.now()
@@ -769,7 +780,7 @@ function updateAnimeDetailCache(animeId: number, detail: AnimeDetail): void {
 }
 
 function updateEpisodeCache(animeId: number, episodeId: number, detail: EpisodeDetail): void {
-  if (!isDownloadedAnime(animeId)) return
+  if (!isCachableAnime(animeId)) return
   const entry = ensureCacheEntry(animeId)
   entry.episodes[episodeId] = detail
   entry.cachedAt = Date.now()
@@ -777,7 +788,7 @@ function updateEpisodeCache(animeId: number, episodeId: number, detail: EpisodeD
 }
 
 function updateQualityProbeCache(animeId: number, translationId: number, height: number): void {
-  if (!isDownloadedAnime(animeId)) return
+  if (!isCachableAnime(animeId)) return
   const entry = ensureCacheEntry(animeId)
   entry.qualityProbes[translationId] = height
   setCacheEntry(animeId, entry)
@@ -786,9 +797,10 @@ function updateQualityProbeCache(animeId: number, translationId: number, height:
 function cleanupStaleCache(): void {
   const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
   const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+  const lib = store.get('library') as Record<string, AnimeSearchResult>
   let changed = false
   for (const key of Object.keys(cache)) {
-    if (!downloaded[key]) {
+    if (!downloaded[key] && !lib[key]) {
       delete cache[key]
       const posterPath = getPosterCachePath(Number(key))
       try { fs.unlinkSync(posterPath) } catch { /* ignore */ }
@@ -1998,12 +2010,26 @@ function registerIpcHandlers(): void {
     if (lib[key]) {
       delete lib[key]
       store.set('library', lib)
+      if (!isDownloadedAnime(anime.id)) deleteCacheEntry(anime.id)
       return false
     } else {
       lib[key] = anime
       store.set('library', lib)
       return true
     }
+  })
+
+  ipcMain.handle('get-anime-cache', (_event, id: number) => {
+    const entry = getCacheEntry(id)
+    if (!entry?.animeDetail || !entry.cachedAt) return null
+    if (Date.now() - entry.cachedAt > ANIME_DETAIL_CACHE_TTL_MS) return null
+    return { data: entry.animeDetail, cachedAt: entry.cachedAt }
+  })
+
+  ipcMain.handle('set-anime-cache', (_event, id: number, data: AnimeDetail) => {
+    if (!isCachableAnime(id)) return false
+    updateAnimeDetailCache(id, data)
+    return true
   })
 
   ipcMain.handle('library-has', (_event, id: number) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -33,6 +33,10 @@ const api = {
   validateToken: () => ipcRenderer.invoke('validate-token'),
   searchAnime: (query: string) => ipcRenderer.invoke('search-anime', query),
   getAnime: (id: number) => ipcRenderer.invoke('get-anime', id),
+  getAnimeCache: (id: number) =>
+    ipcRenderer.invoke('get-anime-cache', id) as Promise<{ data: AnimeDetail; cachedAt: number } | null>,
+  setAnimeCache: (id: number, data: AnimeDetail) =>
+    ipcRenderer.invoke('set-anime-cache', id, data) as Promise<boolean>,
   getEpisode: (id: number, animeId?: number) => ipcRenderer.invoke('get-episode', id, animeId),
   probeEmbedQuality: (translationId: number, animeId?: number) => ipcRenderer.invoke('probe-embed-quality', translationId, animeId) as Promise<number | null>,
   probeFullScanNeeded: (animeId: number, episodeCount: number) =>

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -16,6 +16,8 @@ interface Api {
   validateToken: () => Promise<{ valid: boolean; error?: string }>
   searchAnime: (query: string) => Promise<{ data: AnimeSearchResult[] }>
   getAnime: (id: number) => Promise<ApiResponse<AnimeDetail>>
+  getAnimeCache: (id: number) => Promise<{ data: AnimeDetail; cachedAt: number } | null>
+  setAnimeCache: (id: number, data: AnimeDetail) => Promise<boolean>
   getEpisode: (id: number, animeId?: number) => Promise<ApiResponse<EpisodeDetail>>
   probeEmbedQuality: (translationId: number, animeId?: number) => Promise<number | null>
   getCachedPoster: (animeId: number) => Promise<string | null>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -26,6 +26,9 @@ const selectedAuthor = ref('')
 const dataSource = ref<'api' | 'cache' | null>(null)
 const isOffline = computed(() => dataSource.value === 'cache')
 
+let loadGeneration = 0
+let disposed = false
+
 const isStarred = ref(false)
 
 const episodeOverrides = ref<Map<number, number>>(new Map()) // episodeId -> translationId
@@ -486,50 +489,42 @@ onMounted(async () => {
 
   window.api.libraryHas(props.animeId).then((v) => { isStarred.value = v }).catch(() => {})
 
+  const gen = ++loadGeneration
+  let renderedFromCache = false
   try {
-    const res = await window.api.getAnime(props.animeId)
-    anime.value = res.data
-    dataSource.value = res.source
-    await loadPageEpisodes()
-    await checkFileStatus()
-    // If the user hasn't explicitly picked a translation type on this anime
-    // before, and something is already downloaded, prefer the (type, author)
-    // of the downloaded file(s) over the global settings default.
-    if (!props.initialPrefs?.translationType) {
-      const counts = new Map<string, number>()
-      for (const metaArr of Object.values(episodeMeta.value)) {
-        for (const m of metaArr) {
-          const key = `${m.translationType}\u0000${m.author}`
-          counts.set(key, (counts.get(key) || 0) + 1)
-        }
-      }
-      if (counts.size > 0) {
-        let bestKey = ''
-        let bestCount = 0
-        for (const [key, count] of counts) {
-          if (count > bestCount) { bestKey = key; bestCount = count }
-        }
-        if (bestKey) {
-          const [bestType, bestAuthor] = bestKey.split('\u0000')
-          translationType.value = bestType
-          // Only override selectedAuthor if the downloaded author is still
-          // offered for this type — the translation may have been deactivated
-          // or removed upstream, which would leave the <select> blank.
-          if (bestAuthor && availableAuthors.value.some(([a]) => a === bestAuthor)) {
-            selectedAuthor.value = bestAuthor
-          }
-        }
-      }
+    const cached = await window.api.getAnimeCache(props.animeId)
+    if (cached && !disposed && gen === loadGeneration) {
+      anime.value = cached.data
+      dataSource.value = 'cache'
+      loading.value = false
+      renderedFromCache = true
+      await loadPageEpisodes()
+      await checkFileStatus()
+      if (!props.initialPrefs?.translationType) applyDownloadedTranslationDefault()
     }
   } catch (err) {
-    console.error('Failed to load anime detail view:', err)
-  } finally {
-    loading.value = false
+    console.error('Failed to read anime cache:', err)
   }
 
-  // If served from cache, try a background refresh
-  if (dataSource.value === 'cache') {
-    backgroundRefresh()
+  try {
+    const res = await window.api.getAnime(props.animeId)
+    if (disposed || gen !== loadGeneration) return
+    anime.value = res.data
+    dataSource.value = res.source
+    if (res.source === 'api') {
+      window.api.setAnimeCache(props.animeId, res.data).catch(() => {})
+    }
+    await loadPageEpisodes()
+    if (disposed || gen !== loadGeneration) return
+    await checkFileStatus()
+    if (disposed || gen !== loadGeneration) return
+    if (!renderedFromCache && !props.initialPrefs?.translationType) {
+      applyDownloadedTranslationDefault()
+    }
+  } catch (err) {
+    if (!renderedFromCache) console.error('Failed to load anime detail view:', err)
+  } finally {
+    if (!disposed && gen === loadGeneration) loading.value = false
   }
 
   // Subscribe to download progress
@@ -634,6 +629,8 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  disposed = true
+  loadGeneration++
   window.removeEventListener('mouseup', onMouseBack)
   window.removeEventListener('watch-progress-updated', loadWatchProgress)
   window.api.offDownloadProgress()
@@ -688,6 +685,28 @@ async function shikiSave(): Promise<void> {
     shikiError.value = String(err)
   } finally {
     shikiSaving.value = false
+  }
+}
+
+function applyDownloadedTranslationDefault(): void {
+  const counts = new Map<string, { type: string; author: string; count: number }>()
+  for (const metaArr of Object.values(episodeMeta.value)) {
+    for (const m of metaArr) {
+      const key = `${m.translationType}|${m.author}`
+      const existing = counts.get(key)
+      if (existing) existing.count++
+      else counts.set(key, { type: m.translationType, author: m.author, count: 1 })
+    }
+  }
+  if (counts.size === 0) return
+  let best: { type: string; author: string; count: number } | null = null
+  for (const entry of counts.values()) {
+    if (!best || entry.count > best.count) best = entry
+  }
+  if (!best) return
+  translationType.value = best.type
+  if (best.author && availableAuthors.value.some(([a]) => a === best!.author)) {
+    selectedAuthor.value = best.author
   }
 }
 
@@ -1098,19 +1117,6 @@ watch([translationType, selectedAuthor], () => {
   emit('prefsChanged', props.animeId, translationType.value, selectedAuthor.value)
   probeSelectedQualities()
 })
-
-async function backgroundRefresh(): Promise<void> {
-  try {
-    const res = await window.api.getAnime(props.animeId)
-    if (res.source === 'api') {
-      anime.value = res.data
-      dataSource.value = 'api'
-      await loadPageEpisodes()
-    }
-  } catch {
-    // Stay on cached data
-  }
-}
 
 const posterSrc = ref('')
 const posterFallbackAttempted = ref(false)


### PR DESCRIPTION
## Summary

Eliminates the multi-second blank state when opening a starred or downloaded anime. The detail view now renders instantly from a local cache (24h TTL) and refreshes in the background.

Fixes #66.

## What changed

**Main process (`src/main/index.ts`)**
- `isCachableAnime(id)` = downloaded OR starred. Detail / episode / quality-probe caches are now gated on this instead of "downloaded only".
- `cleanupStaleCache` keeps entries that are downloaded *or* in the library.
- Unstarring a non-downloaded anime evicts its cache entry.
- New IPC: `get-anime-cache` (returns `{ data, cachedAt }` if fresh, else `null`) and `set-anime-cache` (writes only if cachable).

**Preload (`src/preload/index.ts`, `types.d.ts`)**
- `window.api.getAnimeCache(id)` and `setAnimeCache(id, data)`.

**Renderer (`AnimeDetailView.vue`)**
- On mount: read cache → if fresh, render immediately and load episodes / file status. Then fire the live `get-anime` request and reconcile.
- Module-scoped `loadGeneration` counter + `disposed` flag guard against rapid anime switching: late responses from the previous anime are dropped instead of clobbering the new view.
- Extracted the translation-default logic into `applyDownloadedTranslationDefault()` so the cache-render and live-render paths share it.

**Docs**
- `DESIGN.md` updated with the new IPC handlers and the cache-first flow.

## Test plan

- [x] `npm run typecheck` clean (node + web)
- [x] Verified locally: opening a starred anime renders instantly; switching rapidly between anime does not leak stale data into the new view
- [ ] Verify on a fresh install that a never-opened anime still goes through the live path (no cache yet)
- [ ] Verify unstarring a non-downloaded anime evicts its cache (next open should hit the API)

## Out of scope

The Shikimori panel (`get-rate`, `get-friends-rates`, `get-related`) is still uncached and remains the slow part of the page. See follow-up plan in the comment below.
