### PR TITLE
feat: auto-download newly aired episodes for subscribed shows (#76)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -357,6 +357,14 @@ LibraryView shows both with indicators:
 | `shikimori:get-friends-activity` | invoke | Fetch recent anime history for all Shikimori friends, merged + sorted, MAL IDs resolved |
 | `shikimori:get-calendar` | invoke | Fetch Shikimori `/api/calendar`, filter to MAL IDs the user tracks as `watching`/`rewatching`/`planned`, resolve each via `lookupByMalIds`. 5-min in-memory main-side cache invalidated on `shikimori:rate-updated`/`shikimori:rates-refreshed`/logout. Optional `force` flag bypasses the cache |
 | `shikimori:get-related` | invoke | Fetch franchise chronology for an anime via `/api/animes/:id/franchise`, resolve each related MAL ID to a smotret-anime entry |
+| `auto-dl:get-subscription` | invoke | Get the auto-download subscription for a smotret-anime ID, or `null` |
+| `auto-dl:set-subscription` | invoke | Toggle auto-download for a show. On enable, stamps `lastEnqueuedEpisodeInt` to the current `episodes_aired` (forward-only) and kicks a manual tick |
+| `auto-dl:list-subscriptions` | invoke | List all current auto-download subscriptions |
+| `auto-dl:trigger` | invoke | Run an auto-download tick now (manual reason) and return the result |
+| `auto-dl:get-status` | invoke | Returns `{ lastResult, locked, enabled }` for the auto-downloader |
+| `auto-dl:get-enabled` / `auto-dl:set-enabled` | invoke | Read/write the global master toggle |
+| `auto-dl:tick-result` | send | Broadcast after each tick: `{ ranAt, reason, enqueued, skipped, errors, details }` |
+| `auto-dl:enqueued` | send | Broadcast each time the tick enqueues an episode: `{ animeId, episodeInt, animeName }` |
 | `storage:pick-hot-dir` | invoke | Open folder picker for hot storage directory |
 | `storage:pick-cold-dir` | invoke | Open folder picker for cold storage directory |
 | `storage:move-to-cold` | invoke | Move all finished files from hot to cold storage |
@@ -469,6 +477,8 @@ interface EpisodeMeta {
 | `calendarView` | string | `'week'` | Default time range for the Airing Calendar tab: `week` (1×7 grid) or `month` (4×7 grid). Toggle in Settings > General |
 | `syncplay` | object | `{ lastHost:'syncplay.pl', lastPort:8999, lastRoom:'', username:'', autoReconnect:true }` | Watch Together session intent (host/port/room/username + auto-reconnect toggle; TLS is always on). The connection itself is NOT persisted — users must rejoin after restart |
 | `mp4StreamingStats` | object | `{ totalChecked:0, faststartCount:0, nonFaststartSamples:[] }` | Telemetry from the MP4 faststart probe: total files scanned, count that had `moov` before `mdat`, and up to 10 most-recent non-faststart samples (anime + episode + path + first non-`ftyp` box). Surfaced in Settings > Debug |
+| `autoDownloadSubscriptions` | object | `{}` | Per-show auto-download subscriptions keyed by smotret-anime ID. Each entry: `{ animeId, malId, animeName, subscribedAt, lastEnqueuedEpisodeInt, lastCheckedAt }`. `lastEnqueuedEpisodeInt` is stamped to current `episodes_aired` at subscribe time so newly-subscribed shows never backfill |
+| `autoDownloadEnabled` | boolean | `true` | Master toggle that gates the auto-download worker. When false, all ticks become no-ops; subscriptions are preserved |
 
 ## Watch Progress & Resume
 
@@ -647,6 +657,16 @@ Shown when user is logged in AND anime has `myAnimeListId`. Displays:
 ### Series Chronology
 
 Below the Shikimori panel, `AnimeDetailView` renders a Chronology list of the entire franchise sourced from `GET /api/animes/:id/franchise` (a public, unauthenticated endpoint, so the panel renders for logged-out users too). The main-process handler `shikimori:get-related` fetches the franchise graph (`{ nodes, links, current_id }`), then does a BFS from `current_id` through a whitelist of canonical relation edges (sequel/prequel/side_story/parent_story/alternative_version/summary/full_story/spin_off/alternative_setting) to drop unrelated bridges — e.g. the Isekai-Quartet `"other"` edges that otherwise pull Overlord/Konosuba/Re:Zero into a Youjo Senki franchise query. Reachable nodes are sorted chronologically by release `date`, then `lookupByMalIds` resolves each node's MAL ID to its smotret-anime entry (reusing the persistent `malIdMap` cache). Direct edges from `current_id` are walked to attach a `relation` label (source-side only, since Shikimori emits all current-node links as `source_id`); nodes more than one hop away simply omit the label. Each row shows title, kind badge (TV/movie/OVA/…), release year, relation label (when available), and — cross-referenced against `shikimoriUserRates` — a watch-status badge when the current user tracks that entry. Promos/CMs/music videos are filtered out. The current anime's node is highlighted with a "Current" badge and is non-clickable. Rows where `lookupByMalIds` returned no smotret-anime match display a "Not available" badge and are non-clickable. Clickable rows emit `open-anime` up through `App.vue`, which maintains a per-view navigation stack (`animeHistoryByView`) so Back returns to the previously-opened anime in the same tab rather than the list view. The panel is collapsed by default on every mount (header chevron toggles the body) so the page opens compact; users expand it on demand.
+
+### Auto-download
+
+`src/main/auto-downloader.ts` runs a forward-only worker that auto-queues newly-aired episodes for shows the user has explicitly subscribed to. Subscriptions live in `autoDownloadSubscriptions` and are managed per show from `AnimeDetailView` (an "Auto-download" pill next to "Add to Library", visible only when the show has a MAL ID, the user is logged into Shikimori, and `shikiDetails.status !== 'released'`).
+
+`runAutoDownloadTick(reason)` is invoked from four places: ~30s after `app.whenReady` (`'startup'`), every 15 minutes (`'timer'`), inside `refreshShikimoriRatesInBackground` after the broadcast fires (`'rates-refreshed'`), and via the `auto-dl:trigger` IPC ("Run now" button — `'manual'`). A 60s reentrancy lock + an in-flight flag coalesces overlapping triggers.
+
+Each tick walks every subscription, reads `episodes_aired` from the existing `shikimoriAnimeDetails[malId]` cache (skips the show silently if the cache is empty — the existing detail-prefetch worker will populate it), and walks integer episodes from `lastEnqueuedEpisodeInt + 1` to `episodes_aired`. For each candidate it dedupes against `downloadedEpisodes` (both `animeId:episodeInt:translationId` and legacy `animeId:episodeInt` keys), the live `downloadManager.getEpisodeGroups()` queue, and an in-tick set; resolves the translation by preferring the most-recent entry in `downloadedEpisodes` for the same `animeId` (falling back to the global `translationType` default with any author); probes the real height via `getEmbed`; and calls `downloadManager.enqueue(...)`. `lastEnqueuedEpisodeInt` is bumped after each successful enqueue or already-downloaded/already-queued detection (never on `no-translation`, so a not-yet-uploaded episode is retried next tick).
+
+Hard cap of `MAX_ENQUEUES_PER_TICK = 10` per worker run protects against pathological cases (e.g. a show that suddenly reports `episodes_aired = 200`). At subscribe time, `lastEnqueuedEpisodeInt` is stamped to the current `episodes_aired`, so newly-subscribed shows never backfill — they only catch episodes that air *after* the subscription click. After each tick, `auto-dl:tick-result` broadcasts `{ ranAt, reason, enqueued, skipped, errors, details }`; per-episode `auto-dl:enqueued` fires with `{ animeId, episodeInt, animeName }`. `CalendarView` shows a ↻ chip on subscribed entries (hydrated once per mount via `auto-dl:list-subscriptions`); the master toggle, "Run now" button, and subscription list live in `Settings > General > Auto-download`. Disabling the master toggle makes ticks no-ops without dropping subscriptions.
 
 ## Watch Together (Syncplay)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/auto-downloader.ts
+++ b/src/main/auto-downloader.ts
@@ -102,11 +102,11 @@ export function getSubscription(animeId: number): AutoDownloadSubscription | nul
   return map[String(animeId)] ?? null
 }
 
-export function setSubscription(
+export async function setSubscription(
   animeId: number,
   enabled: boolean,
   meta?: { malId: number; animeName: string }
-): AutoDownloadSubscription | null {
+): Promise<AutoDownloadSubscription | null> {
   if (!deps) return null
   const map = { ...(deps.store.get('autoDownloadSubscriptions') as Record<string, AutoDownloadSubscription>) }
   const key = String(animeId)
@@ -123,9 +123,22 @@ export function setSubscription(
     return existing
   }
   // Stamp lastEnqueuedEpisodeInt to the current episodes_aired so we never backfill.
+  // If the cache is missing or stale, inline-refresh first — otherwise an empty cache
+  // would leave the stamp at 0 and the next tick would download the entire show.
   const cache = deps.store.get('shikimoriAnimeDetails') as Record<string, ShikiAnimeDetailsCacheEntry>
-  const cacheEntry = cache[String(meta.malId)]
+  let cacheEntry = cache[String(meta.malId)]
+  const cacheAge = cacheEntry ? Date.now() - cacheEntry.fetchedAt : Infinity
+  if (!cacheEntry || cacheAge > DETAILS_FRESHNESS_MS) {
+    const fresh = await deps.refreshShikimoriDetails(meta.malId)
+    if (fresh) {
+      cacheEntry = { details: fresh, fetchedAt: Date.now() }
+    }
+  }
   const aired = cacheEntry?.details?.episodes_aired ?? 0
+  if (aired <= 0) {
+    // Refuse rather than silently arming a backfill. Caller surfaces this to the user.
+    return null
+  }
   const sub: AutoDownloadSubscription = {
     animeId,
     malId: meta.malId,
@@ -408,6 +421,6 @@ export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlT
     return result
   } finally {
     tickRunning = false
-    lockReleaseAt = 0
+    // Keep lockReleaseAt as the cooldown deadline so manual triggers actually wait REENTRANCY_LOCK_MS.
   }
 }

--- a/src/main/auto-downloader.ts
+++ b/src/main/auto-downloader.ts
@@ -1,0 +1,413 @@
+import type Store from 'electron-store'
+import type { SmotretApi, EpisodeDetail, Translation } from './smotret-api'
+import type { DownloadManager, DownloadRequest } from './download-manager'
+import type { AutoDownloadSubscription } from './index'
+import type * as shikimori from './shikimori'
+
+export type AutoDlReason = 'startup' | 'timer' | 'rates-refreshed' | 'manual'
+
+export interface AutoDlOutcome {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  outcome:
+    | 'enqueued'
+    | 'no-translation'
+    | 'no-episode'
+    | 'already-downloaded'
+    | 'already-queued'
+    | 'embed-failed'
+    | 'no-episodes-aired'
+    | 'cap-reached'
+    | 'error'
+  message?: string
+}
+
+export interface AutoDlTickResult {
+  ranAt: number
+  reason: AutoDlReason
+  enqueued: number
+  skipped: number
+  errors: number
+  details: AutoDlOutcome[]
+}
+
+interface DownloadedEpisodeMeta {
+  translationType: string
+  author: string
+  quality: number
+  translationId: number
+}
+
+interface ShikiAnimeDetailsCacheEntry {
+  details: shikimori.ShikiAnimeDetails
+  fetchedAt: number
+}
+
+interface AutoDownloaderDeps {
+  store: Store<Record<string, unknown>>
+  smotretApi: SmotretApi
+  downloadManager: DownloadManager
+  broadcast: (channel: string, ...args: unknown[]) => void
+  isShikimoriLoggedIn: () => boolean
+  refreshShikimoriDetails: (malId: number) => Promise<shikimori.ShikiAnimeDetails | null>
+}
+
+const MAX_ENQUEUES_PER_TICK = 10
+const REENTRANCY_LOCK_MS = 60_000
+const TICK_INTERVAL_MS = 15 * 60 * 1000
+const DETAILS_FRESHNESS_MS = 6 * 60 * 60 * 1000
+
+let deps: AutoDownloaderDeps | null = null
+let lastTickResult: AutoDlTickResult | null = null
+let tickRunning = false
+let lockReleaseAt = 0
+let timerHandle: ReturnType<typeof setInterval> | null = null
+
+export function initAutoDownloader(d: AutoDownloaderDeps): void {
+  deps = d
+}
+
+export function startAutoDownloaderTimer(): void {
+  if (timerHandle) return
+  timerHandle = setInterval(() => {
+    void runAutoDownloadTick('timer').catch((err) => {
+      console.warn('[auto-dl] timer tick failed:', err)
+    })
+  }, TICK_INTERVAL_MS)
+}
+
+export function getAutoDownloaderStatus(): {
+  lastResult: AutoDlTickResult | null
+  locked: boolean
+  enabled: boolean
+} {
+  const enabled = deps ? Boolean(deps.store.get('autoDownloadEnabled')) : false
+  return {
+    lastResult: lastTickResult,
+    locked: tickRunning || Date.now() < lockReleaseAt,
+    enabled
+  }
+}
+
+export function listSubscriptions(): AutoDownloadSubscription[] {
+  if (!deps) return []
+  const map = deps.store.get('autoDownloadSubscriptions') as Record<string, AutoDownloadSubscription>
+  return Object.values(map)
+}
+
+export function getSubscription(animeId: number): AutoDownloadSubscription | null {
+  if (!deps) return null
+  const map = deps.store.get('autoDownloadSubscriptions') as Record<string, AutoDownloadSubscription>
+  return map[String(animeId)] ?? null
+}
+
+export function setSubscription(
+  animeId: number,
+  enabled: boolean,
+  meta?: { malId: number; animeName: string }
+): AutoDownloadSubscription | null {
+  if (!deps) return null
+  const map = { ...(deps.store.get('autoDownloadSubscriptions') as Record<string, AutoDownloadSubscription>) }
+  const key = String(animeId)
+  if (!enabled) {
+    if (key in map) {
+      delete map[key]
+      deps.store.set('autoDownloadSubscriptions', map)
+    }
+    return null
+  }
+  if (!meta) {
+    const existing = map[key]
+    if (!existing) return null
+    return existing
+  }
+  // Stamp lastEnqueuedEpisodeInt to the current episodes_aired so we never backfill.
+  const cache = deps.store.get('shikimoriAnimeDetails') as Record<string, ShikiAnimeDetailsCacheEntry>
+  const cacheEntry = cache[String(meta.malId)]
+  const aired = cacheEntry?.details?.episodes_aired ?? 0
+  const sub: AutoDownloadSubscription = {
+    animeId,
+    malId: meta.malId,
+    animeName: meta.animeName,
+    subscribedAt: Date.now(),
+    lastEnqueuedEpisodeInt: aired,
+    lastCheckedAt: 0
+  }
+  map[key] = sub
+  deps.store.set('autoDownloadSubscriptions', map)
+  return sub
+}
+
+function pickTranslation(
+  episode: EpisodeDetail,
+  preferred: { type: string; author?: string } | null,
+  globalType: string
+): Translation | null {
+  const active = episode.translations.filter((t) => t.isActive === 1)
+  if (active.length === 0) return null
+
+  const byHeightDesc = (a: Translation, b: Translation): number => b.height - a.height
+
+  if (preferred) {
+    if (preferred.author) {
+      const exact = active
+        .filter((t) => t.type === preferred.type && t.authorsSummary === preferred.author)
+        .sort(byHeightDesc)
+      if (exact[0]) return exact[0]
+    }
+    const sameType = active.filter((t) => t.type === preferred.type).sort(byHeightDesc)
+    if (sameType[0]) return sameType[0]
+  }
+
+  const globalMatch = active.filter((t) => t.type === globalType).sort(byHeightDesc)
+  if (globalMatch[0]) return globalMatch[0]
+  return null
+}
+
+function mostRecentDownloadedTranslation(
+  store: Store<Record<string, unknown>>,
+  animeId: number
+): { type: string; author: string } | null {
+  const all = store.get('downloadedEpisodes') as Record<string, DownloadedEpisodeMeta>
+  const prefix = `${animeId}:`
+  for (const [key, meta] of Object.entries(all)) {
+    if (!key.startsWith(prefix)) continue
+    if (!meta?.translationType) continue
+    return { type: meta.translationType, author: meta.author ?? '' }
+  }
+  return null
+}
+
+function isAlreadyDownloaded(
+  store: Store<Record<string, unknown>>,
+  animeId: number,
+  episodeInt: string
+): boolean {
+  const all = store.get('downloadedEpisodes') as Record<string, DownloadedEpisodeMeta>
+  const newPrefix = `${animeId}:${episodeInt}:`
+  const legacyKey = `${animeId}:${episodeInt}`
+  if (legacyKey in all) return true
+  for (const key of Object.keys(all)) {
+    if (key.startsWith(newPrefix)) return true
+  }
+  return false
+}
+
+function isAlreadyQueued(downloadManager: DownloadManager, animeId: number, episodeInt: string): boolean {
+  const groups = downloadManager.getEpisodeGroups()
+  return groups.some((g) => g.animeId === animeId && g.episodeInt === episodeInt)
+}
+
+async function probeHeight(api: SmotretApi, tr: Translation): Promise<number> {
+  try {
+    const embed = await api.getEmbed(tr.id)
+    const streams = embed.stream || []
+    if (streams.length > 0) {
+      return streams.reduce((a, b) => (a.height > b.height ? a : b)).height
+    }
+  } catch {
+    // fall through
+  }
+  return tr.height
+}
+
+export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlTickResult> {
+  const result: AutoDlTickResult = {
+    ranAt: Date.now(),
+    reason,
+    enqueued: 0,
+    skipped: 0,
+    errors: 0,
+    details: []
+  }
+
+  if (!deps) return result
+
+  const now = Date.now()
+  if (tickRunning || now < lockReleaseAt) {
+    return result
+  }
+  tickRunning = true
+  lockReleaseAt = now + REENTRANCY_LOCK_MS
+
+  try {
+    if (!deps.store.get('autoDownloadEnabled')) {
+      lastTickResult = result
+      deps.broadcast('auto-dl:tick-result', result)
+      return result
+    }
+
+    const map = { ...(deps.store.get('autoDownloadSubscriptions') as Record<string, AutoDownloadSubscription>) }
+    const subscriptions = Object.values(map)
+    if (subscriptions.length === 0) {
+      lastTickResult = result
+      deps.broadcast('auto-dl:tick-result', result)
+      return result
+    }
+
+    if (!deps.isShikimoriLoggedIn()) {
+      lastTickResult = result
+      deps.broadcast('auto-dl:tick-result', result)
+      return result
+    }
+
+    const globalTranslationType = (deps.store.get('translationType') as string) || 'subRu'
+
+    const enqueuedThisTick = new Set<string>()
+    let mapDirty = false
+
+    for (const sub of subscriptions) {
+      sub.lastCheckedAt = Date.now()
+      mapDirty = true
+
+      const detailsCache = deps.store.get('shikimoriAnimeDetails') as Record<string, ShikiAnimeDetailsCacheEntry>
+      let cacheEntry = detailsCache[String(sub.malId)]
+      const cacheAge = cacheEntry ? Date.now() - cacheEntry.fetchedAt : Infinity
+      if (cacheAge > DETAILS_FRESHNESS_MS) {
+        const fresh = await deps.refreshShikimoriDetails(sub.malId)
+        if (fresh) {
+          cacheEntry = { details: fresh, fetchedAt: Date.now() }
+        }
+      }
+      const aired = cacheEntry?.details?.episodes_aired ?? 0
+      const totalEpisodes = cacheEntry?.details?.episodes ?? 0
+      if (aired <= 0) {
+        result.details.push({
+          animeId: sub.animeId,
+          animeName: sub.animeName,
+          episodeInt: '',
+          outcome: 'no-episodes-aired'
+        })
+        continue
+      }
+
+      let candidate = sub.lastEnqueuedEpisodeInt + 1
+      while (candidate <= aired) {
+        if (totalEpisodes > 0 && candidate > totalEpisodes) break
+        if (result.enqueued >= MAX_ENQUEUES_PER_TICK) {
+          result.details.push({
+            animeId: sub.animeId,
+            animeName: sub.animeName,
+            episodeInt: String(candidate),
+            outcome: 'cap-reached'
+          })
+          break
+        }
+
+        const episodeInt = String(candidate)
+        const dedupKey = `${sub.animeId}:${episodeInt}`
+        if (enqueuedThisTick.has(dedupKey)) {
+          candidate += 1
+          continue
+        }
+
+        if (isAlreadyDownloaded(deps.store, sub.animeId, episodeInt)) {
+          result.details.push({
+            animeId: sub.animeId,
+            animeName: sub.animeName,
+            episodeInt,
+            outcome: 'already-downloaded'
+          })
+          sub.lastEnqueuedEpisodeInt = candidate
+          candidate += 1
+          continue
+        }
+
+        if (isAlreadyQueued(deps.downloadManager, sub.animeId, episodeInt)) {
+          result.details.push({
+            animeId: sub.animeId,
+            animeName: sub.animeName,
+            episodeInt,
+            outcome: 'already-queued'
+          })
+          sub.lastEnqueuedEpisodeInt = candidate
+          candidate += 1
+          continue
+        }
+
+        try {
+          const animeData = await deps.smotretApi.getAnime(sub.animeId)
+          const epSummary = animeData.data.episodes.find((e) => e.episodeInt === episodeInt)
+          if (!epSummary) {
+            result.details.push({
+              animeId: sub.animeId,
+              animeName: sub.animeName,
+              episodeInt,
+              outcome: 'no-episode'
+            })
+            result.skipped += 1
+            break
+          }
+
+          const epDetail = (await deps.smotretApi.getEpisode(epSummary.id)).data
+          const preferred = mostRecentDownloadedTranslation(deps.store, sub.animeId)
+          const translation = pickTranslation(epDetail, preferred, globalTranslationType)
+          if (!translation) {
+            result.details.push({
+              animeId: sub.animeId,
+              animeName: sub.animeName,
+              episodeInt,
+              outcome: 'no-translation'
+            })
+            result.skipped += 1
+            break
+          }
+
+          const height = await probeHeight(deps.smotretApi, translation)
+          const request: DownloadRequest = {
+            translationId: translation.id,
+            height,
+            animeName: sub.animeName,
+            episodeLabel: epDetail.episodeFull,
+            episodeInt,
+            animeId: sub.animeId,
+            translationType: translation.type,
+            author: translation.authorsSummary
+          }
+
+          await deps.downloadManager.enqueue([request])
+          enqueuedThisTick.add(dedupKey)
+          sub.lastEnqueuedEpisodeInt = candidate
+          result.enqueued += 1
+          result.details.push({
+            animeId: sub.animeId,
+            animeName: sub.animeName,
+            episodeInt,
+            outcome: 'enqueued'
+          })
+          deps.broadcast('auto-dl:enqueued', {
+            animeId: sub.animeId,
+            episodeInt,
+            animeName: sub.animeName
+          })
+        } catch (err) {
+          result.errors += 1
+          result.details.push({
+            animeId: sub.animeId,
+            animeName: sub.animeName,
+            episodeInt,
+            outcome: 'error',
+            message: err instanceof Error ? err.message : String(err)
+          })
+          break
+        }
+
+        candidate += 1
+      }
+
+      map[String(sub.animeId)] = sub
+    }
+
+    if (mapDirty) {
+      deps.store.set('autoDownloadSubscriptions', map)
+    }
+
+    lastTickResult = result
+    deps.broadcast('auto-dl:tick-result', result)
+    return result
+  } finally {
+    tickRunning = false
+    lockReleaseAt = 0
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,15 @@ import { is } from '@electron-toolkit/utils'
 import Store from 'electron-store'
 import { DownloadManager, sanitizeFilename } from './download-manager'
 import type { DownloadRequest } from './download-manager'
+import {
+  initAutoDownloader,
+  startAutoDownloaderTimer,
+  runAutoDownloadTick,
+  getAutoDownloaderStatus,
+  listSubscriptions as autoDlListSubscriptions,
+  getSubscription as autoDlGetSubscription,
+  setSubscription as autoDlSetSubscription
+} from './auto-downloader'
 import * as fs from 'fs'
 import * as fsPromises from 'fs/promises'
 import * as path from 'path'
@@ -60,6 +69,15 @@ interface AnimeCacheEntry {
   fullProbeEpisodeCount?: number
 }
 
+export interface AutoDownloadSubscription {
+  animeId: number
+  malId: number
+  animeName: string
+  subscribedAt: number
+  lastEnqueuedEpisodeInt: number
+  lastCheckedAt: number
+}
+
 const store = new Store({
   defaults: {
     token: '',
@@ -107,6 +125,8 @@ const store = new Store({
     shikimoriUserRates: [] as unknown[],
     shikimoriUpdateQueue: [] as unknown[],
     shikimoriAnimeDetails: {} as Record<string, { details: shikimori.ShikiAnimeDetails; fetchedAt: number }>,
+    autoDownloadSubscriptions: {} as Record<string, AutoDownloadSubscription>,
+    autoDownloadEnabled: true,
     recentAnimeMeta: {} as Record<string, AnimeSearchResult>,
     skipDetections: {} as Record<string, ShowSkipDetections>,
     skipFingerprintCache: {} as Record<string, CachedFingerprint>,
@@ -489,6 +509,37 @@ function getStaleOrMissingMalIds(): number[] {
     }
   }
   return result
+}
+
+async function refreshShikimoriDetailsForMalId(malId: number): Promise<shikimori.ShikiAnimeDetails | null> {
+  const creds = store.get('shikimoriCredentials') as shikimori.ShikiCredentials | null
+  const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
+  if (!creds || !user) return null
+  let accessToken: string
+  try {
+    accessToken = await shikimori.ensureFreshToken(store)
+  } catch (err) {
+    if (!isNetworkError(err)) {
+      console.warn('[shikimori] single-show refresh auth failed:', err)
+    }
+    return null
+  }
+  try {
+    const details = await shikimori.getAnimeDetails(accessToken, malId)
+    const cache = store.get('shikimoriAnimeDetails') as Record<
+      string,
+      { details: shikimori.ShikiAnimeDetails; fetchedAt: number }
+    >
+    cache[String(malId)] = { details, fetchedAt: Date.now() }
+    store.set('shikimoriAnimeDetails', cache)
+    broadcastToAll('shikimori:anime-details-updated', { malId, details })
+    return details
+  } catch (err) {
+    if (!isNetworkError(err)) {
+      console.warn('[shikimori] single-show refresh failed for', malId, err)
+    }
+    return null
+  }
 }
 
 async function prefetchShikimoriDetails(): Promise<void> {
@@ -3033,6 +3084,9 @@ function registerIpcHandlers(): void {
         broadcastToAll('shikimori:rates-refreshed', entries)
         void syncShikimoriQueue()
         void prefetchShikimoriDetails()
+        void runAutoDownloadTick('rates-refreshed').catch((err) =>
+          console.warn('[auto-dl] rates-refreshed tick failed:', err)
+        )
       })
       .catch((err) => console.warn('[shikimori] background refresh failed:', err))
   }
@@ -3718,6 +3772,41 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('syncplay:get-status', () => syncplay.getStatus())
+
+  // Auto-downloader
+  ipcMain.handle('auto-dl:get-subscription', (_event, animeId: number) => {
+    return autoDlGetSubscription(animeId)
+  })
+
+  ipcMain.handle(
+    'auto-dl:set-subscription',
+    (_event, animeId: number, enabled: boolean, meta?: { malId: number; animeName: string }) => {
+      const sub = autoDlSetSubscription(animeId, enabled, meta)
+      if (enabled && sub) {
+        // Fire a tick shortly after subscribing so the user sees the system catch up
+        // (forward-only stamp ensures nothing backfills, this just exercises the path).
+        setTimeout(() => {
+          void runAutoDownloadTick('manual')
+        }, 1000)
+      }
+      return sub
+    }
+  )
+
+  ipcMain.handle('auto-dl:list-subscriptions', () => autoDlListSubscriptions())
+
+  ipcMain.handle('auto-dl:trigger', async () => {
+    return runAutoDownloadTick('manual')
+  })
+
+  ipcMain.handle('auto-dl:get-status', () => getAutoDownloaderStatus())
+
+  ipcMain.handle('auto-dl:get-enabled', () => Boolean(store.get('autoDownloadEnabled')))
+
+  ipcMain.handle('auto-dl:set-enabled', (_event, enabled: boolean) => {
+    store.set('autoDownloadEnabled', Boolean(enabled))
+    return Boolean(enabled)
+  })
 }
 
 interface MseOpenResult {
@@ -4370,6 +4459,21 @@ app.whenReady().then(async () => {
   })
 
   registerIpcHandlers()
+
+  initAutoDownloader({
+    store,
+    smotretApi,
+    downloadManager,
+    broadcast: broadcastToAll,
+    isShikimoriLoggedIn: () => Boolean(store.get('shikimoriCredentials')),
+    refreshShikimoriDetails: refreshShikimoriDetailsForMalId
+  })
+  startAutoDownloaderTimer()
+  setTimeout(() => {
+    void runAutoDownloadTick('startup').catch((err) =>
+      console.warn('[auto-dl] startup tick failed:', err)
+    )
+  }, 30_000)
 
   migrateWatchProgressV2()
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3780,8 +3780,8 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     'auto-dl:set-subscription',
-    (_event, animeId: number, enabled: boolean, meta?: { malId: number; animeName: string }) => {
-      const sub = autoDlSetSubscription(animeId, enabled, meta)
+    async (_event, animeId: number, enabled: boolean, meta?: { malId: number; animeName: string }) => {
+      const sub = await autoDlSetSubscription(animeId, enabled, meta)
       if (enabled && sub) {
         // Fire a tick shortly after subscribing so the user sees the system catch up
         // (forward-only stamp ensures nothing backfills, this just exercises the path).

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -394,6 +394,36 @@ const api = {
   offSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) =>
     syncplayOff('syncplay:trace', callback),
 
+  // Auto-downloader
+  autoDlGetSubscription: (animeId: number) =>
+    ipcRenderer.invoke('auto-dl:get-subscription', animeId) as Promise<AutoDownloadSubscription | null>,
+  autoDlSetSubscription: (animeId: number, enabled: boolean, meta?: { malId: number; animeName: string }) =>
+    ipcRenderer.invoke('auto-dl:set-subscription', animeId, enabled, meta) as Promise<AutoDownloadSubscription | null>,
+  autoDlListSubscriptions: () =>
+    ipcRenderer.invoke('auto-dl:list-subscriptions') as Promise<AutoDownloadSubscription[]>,
+  autoDlTrigger: () => ipcRenderer.invoke('auto-dl:trigger') as Promise<AutoDlTickResult>,
+  autoDlGetStatus: () =>
+    ipcRenderer.invoke('auto-dl:get-status') as Promise<{
+      lastResult: AutoDlTickResult | null
+      locked: boolean
+      enabled: boolean
+    }>,
+  autoDlGetEnabled: () => ipcRenderer.invoke('auto-dl:get-enabled') as Promise<boolean>,
+  autoDlSetEnabled: (enabled: boolean) =>
+    ipcRenderer.invoke('auto-dl:set-enabled', enabled) as Promise<boolean>,
+  onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => {
+    ipcRenderer.on('auto-dl:tick-result', (_event, result) => callback(result))
+  },
+  offAutoDlTickResult: () => {
+    ipcRenderer.removeAllListeners('auto-dl:tick-result')
+  },
+  onAutoDlEnqueued: (callback: (data: { animeId: number; episodeInt: string; animeName: string }) => void) => {
+    ipcRenderer.on('auto-dl:enqueued', (_event, data) => callback(data))
+  },
+  offAutoDlEnqueued: () => {
+    ipcRenderer.removeAllListeners('auto-dl:enqueued')
+  },
+
   // Updates
   appVersion: () => ipcRenderer.invoke('app:version'),
   updateCheck: () => ipcRenderer.invoke('update:check'),

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -216,6 +216,27 @@ interface Api {
   onSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) => void
   offSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) => void
 
+  // Auto-downloader
+  autoDlGetSubscription: (animeId: number) => Promise<AutoDownloadSubscription | null>
+  autoDlSetSubscription: (
+    animeId: number,
+    enabled: boolean,
+    meta?: { malId: number; animeName: string }
+  ) => Promise<AutoDownloadSubscription | null>
+  autoDlListSubscriptions: () => Promise<AutoDownloadSubscription[]>
+  autoDlTrigger: () => Promise<AutoDlTickResult>
+  autoDlGetStatus: () => Promise<{
+    lastResult: AutoDlTickResult | null
+    locked: boolean
+    enabled: boolean
+  }>
+  autoDlGetEnabled: () => Promise<boolean>
+  autoDlSetEnabled: (enabled: boolean) => Promise<boolean>
+  onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => void
+  offAutoDlTickResult: () => void
+  onAutoDlEnqueued: (callback: (data: { animeId: number; episodeInt: string; animeName: string }) => void) => void
+  offAutoDlEnqueued: () => void
+
   // Updates
   appVersion: () => Promise<string>
   updateCheck: () => Promise<void>
@@ -223,6 +244,41 @@ interface Api {
   updateInstall: () => void
   onUpdateStatus: (callback: (data: UpdateStatus) => void) => void
   offUpdateStatus: () => void
+}
+
+interface AutoDownloadSubscription {
+  animeId: number
+  malId: number
+  animeName: string
+  subscribedAt: number
+  lastEnqueuedEpisodeInt: number
+  lastCheckedAt: number
+}
+
+interface AutoDlOutcome {
+  animeId: number
+  animeName: string
+  episodeInt: string
+  outcome:
+    | 'enqueued'
+    | 'no-translation'
+    | 'no-episode'
+    | 'already-downloaded'
+    | 'already-queued'
+    | 'embed-failed'
+    | 'no-episodes-aired'
+    | 'cap-reached'
+    | 'error'
+  message?: string
+}
+
+interface AutoDlTickResult {
+  ranAt: number
+  reason: 'startup' | 'timer' | 'rates-refreshed' | 'manual'
+  enqueued: number
+  skipped: number
+  errors: number
+  details: AutoDlOutcome[]
 }
 
 interface SyncplayConnectConfig {

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -30,6 +30,8 @@ let loadGeneration = 0
 let disposed = false
 
 const isStarred = ref(false)
+const autoDlSubscription = ref<AutoDownloadSubscription | null>(null)
+const autoDlSaving = ref(false)
 
 const episodeOverrides = ref<Map<number, number>>(new Map()) // episodeId -> translationId
 const realQuality = ref<Map<number, number>>(new Map()) // translationId -> actual height from embed
@@ -528,6 +530,7 @@ onMounted(async () => {
   }
 
   window.api.libraryHas(props.animeId).then((v) => { isStarred.value = v }).catch(() => {})
+  window.api.autoDlGetSubscription(props.animeId).then((s) => { autoDlSubscription.value = s }).catch(() => {})
 
   const gen = ++loadGeneration
   let renderedFromCache = false
@@ -1008,6 +1011,50 @@ async function toggleStar(): Promise<void> {
   isStarred.value = await window.api.libraryToggle(JSON.parse(JSON.stringify(stripped)))
 }
 
+const isShowFinished = computed<boolean>(() => {
+  const status = shikiDetails.value?.status
+  return status === 'released'
+})
+
+const canAutoDl = computed<boolean>(() => {
+  if (!anime.value?.myAnimeListId) return false
+  if (!shikiUser.value) return false
+  if (isShowFinished.value) return false
+  return true
+})
+
+const autoDlTooltip = computed<string>(() => {
+  if (!anime.value?.myAnimeListId) return 'Auto-download requires a Shikimori entry'
+  if (!shikiUser.value) return 'Connect to Shikimori to enable auto-download'
+  if (isShowFinished.value) return 'Show is fully aired — no new episodes to auto-download'
+  if (autoDlSubscription.value) {
+    const next = autoDlSubscription.value.lastEnqueuedEpisodeInt + 1
+    return `Will auto-download new episodes from Ep ${next} onward`
+  }
+  return 'Auto-download new episodes as they air'
+})
+
+async function toggleAutoDl(): Promise<void> {
+  if (!anime.value || autoDlSaving.value) return
+  if (!canAutoDl.value && !autoDlSubscription.value) return
+  autoDlSaving.value = true
+  try {
+    const enable = !autoDlSubscription.value
+    const result = await window.api.autoDlSetSubscription(
+      anime.value.id,
+      enable,
+      enable && anime.value.myAnimeListId
+        ? { malId: anime.value.myAnimeListId, animeName: getAnimeName() }
+        : undefined
+    )
+    autoDlSubscription.value = result
+  } catch (err) {
+    console.error('Failed to toggle auto-download:', err)
+  } finally {
+    autoDlSaving.value = false
+  }
+}
+
 const episodeMeta = ref<Record<string, EpisodeMeta[]>>({})
 const downloadGroups = ref<Map<string, EpisodeGroup>>(new Map())
 const downloading = ref(false)
@@ -1343,6 +1390,19 @@ function typeChip(type: string): { short: string; color: string } {
               <path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" />
             </svg>
             {{ isStarred ? 'In Library' : 'Add to Library' }}
+          </button>
+          <button
+            v-if="canAutoDl || autoDlSubscription"
+            class="library-btn auto-dl-btn"
+            :class="{ active: !!autoDlSubscription }"
+            :disabled="autoDlSaving || (!canAutoDl && !autoDlSubscription)"
+            :title="autoDlTooltip"
+            @click="toggleAutoDl"
+          >
+            <svg viewBox="0 0 24 24" :fill="autoDlSubscription ? 'currentColor' : 'none'" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12c0 4.142-3.358 7.5-7.5 7.5S4.5 16.142 4.5 12 7.858 4.5 12 4.5c1.747 0 3.354.6 4.625 1.604M19.5 4.5v3.75h-3.75" />
+            </svg>
+            {{ autoDlSubscription ? 'Auto-download on' : 'Auto-download' }}
           </button>
         </div>
         <div class="anime-info">

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -1047,6 +1047,10 @@ async function toggleAutoDl(): Promise<void> {
         ? { malId: anime.value.myAnimeListId, animeName: getAnimeName() }
         : undefined
     )
+    if (enable && !result) {
+      alert("Couldn't read this show's airing data from Shikimori. Please try again in a moment.")
+      return
+    }
     autoDlSubscription.value = result
   } catch (err) {
     console.error('Failed to toggle auto-download:', err)

--- a/src/renderer/src/components/CalendarView.vue
+++ b/src/renderer/src/components/CalendarView.vue
@@ -9,6 +9,7 @@ const entries = ref<CalendarEntry[]>([])
 const loading = ref(false)
 const error = ref('')
 const weeksPerPage = ref(1)
+const subscribedAnimeIds = ref<Set<number>>(new Set())
 
 const DAY_LABELS_MON_FIRST = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 const DAY_LABELS_SUN_FIRST = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -180,9 +181,19 @@ function onCalendarViewChanged(): void {
   void loadViewSetting()
 }
 
+async function loadAutoDlSubscriptions(): Promise<void> {
+  try {
+    const subs = await window.api.autoDlListSubscriptions()
+    subscribedAnimeIds.value = new Set(subs.map((s) => s.animeId))
+  } catch (err) {
+    console.warn('Failed to load auto-dl subscriptions:', err)
+  }
+}
+
 onMounted(() => {
   window.addEventListener('calendar-view-changed', onCalendarViewChanged)
   load()
+  loadAutoDlSubscriptions()
 })
 
 onBeforeUnmount(() => {
@@ -286,6 +297,12 @@ onBeforeUnmount(() => {
                     }}</span>
                     <span v-if="entry.animeId === null" class="chip chip-na"
                       >Not on smotret-anime</span
+                    >
+                    <span
+                      v-if="entry.animeId !== null && subscribedAnimeIds.has(entry.animeId)"
+                      class="chip chip-auto-dl"
+                      title="Auto-download is on for this show"
+                      >↻ Auto-DL</span
                     >
                   </div>
                 </div>
@@ -550,6 +567,11 @@ onBeforeUnmount(() => {
 .chip-na {
   background: rgba(80, 80, 100, 0.4);
   color: #8a8aa8;
+}
+
+.chip-auto-dl {
+  background: rgba(40, 90, 60, 0.7);
+  color: #8fd6a8;
 }
 
 .status-text {

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -40,6 +40,11 @@ const updateStatus = ref<{ status: 'idle' | 'checking' | 'up-to-date' | 'availab
 
 const notificationMode = ref('off')
 const calendarView = ref<'week' | 'month'>('week')
+const autoDownloadEnabled = ref(true)
+const autoDlSubscriptions = ref<AutoDownloadSubscription[]>([])
+const autoDlSubscriptionsExpanded = ref(false)
+const autoDlRunning = ref(false)
+const autoDlLastResult = ref<AutoDlTickResult | null>(null)
 const speedLimitPreset = ref('0')
 const customSpeedLimit = ref(1)
 const concurrentDownloads = ref(2)
@@ -587,6 +592,7 @@ onUnmounted(() => {
   window.api.offStorageUsageProgress()
   window.api.offStorageCleanupPending()
   window.api.offStorageCleanupFinished()
+  window.api.offAutoDlTickResult()
   if (skipQueuePollTimer) {
     clearInterval(skipQueuePollTimer)
     skipQueuePollTimer = null
@@ -678,6 +684,16 @@ onMounted(async () => {
   playerMode.value = ((await window.api.getSetting('playerMode')) as string as typeof playerMode.value) || 'system'
   anime4kPreset.value = ((await window.api.getSetting('anime4kPreset')) as string as typeof anime4kPreset.value) || 'off'
   hevcTranscodeOnPlay.value = ((await window.api.getSetting('hevcTranscodeOnPlay')) as string as typeof hevcTranscodeOnPlay.value) || 'ask'
+
+  // Auto-download
+  autoDownloadEnabled.value = await window.api.autoDlGetEnabled()
+  await refreshAutoDlSubscriptions()
+  const autoDlStatus = await window.api.autoDlGetStatus()
+  autoDlLastResult.value = autoDlStatus.lastResult
+  window.api.onAutoDlTickResult((result) => {
+    autoDlLastResult.value = result
+    void refreshAutoDlSubscriptions()
+  })
 
   // Storage cleanup settings
   autoCleanupDays.value = ((await window.api.getSetting('autoCleanupWatchedDays')) as number) || 0
@@ -807,6 +823,44 @@ watch(customSpeedLimit, (val) => {
 watch(storageMode, (val) => { if (loaded.value) autoSave('storageMode', val) })
 watch(autoMoveToCold, (val) => { if (loaded.value) autoSave('autoMoveToCold', val) })
 watch(autoMerge, (val) => { if (loaded.value) autoSave('autoMerge', val) })
+watch(autoDownloadEnabled, (val) => {
+  if (loaded.value) {
+    void window.api.autoDlSetEnabled(val).then(() => showSaved())
+  }
+})
+
+async function refreshAutoDlSubscriptions(): Promise<void> {
+  try {
+    autoDlSubscriptions.value = await window.api.autoDlListSubscriptions()
+  } catch (err) {
+    console.warn('Failed to load auto-dl subscriptions:', err)
+  }
+}
+
+async function runAutoDlNow(): Promise<void> {
+  if (autoDlRunning.value) return
+  autoDlRunning.value = true
+  try {
+    await window.api.autoDlTrigger()
+    await refreshAutoDlSubscriptions()
+  } finally {
+    autoDlRunning.value = false
+  }
+}
+
+async function unsubscribeAutoDl(animeId: number): Promise<void> {
+  await window.api.autoDlSetSubscription(animeId, false)
+  await refreshAutoDlSubscriptions()
+}
+
+function autoDlLastCheckedLabel(ts: number): string {
+  if (!ts) return 'never'
+  const diff = Date.now() - ts
+  if (diff < 60_000) return 'just now'
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`
+  return `${Math.round(diff / 86_400_000)}d ago`
+}
 watch(enableLocalSkipDetection, (val) => { if (loaded.value) autoSave('enableLocalSkipDetection', val) })
 watch(backgroundQualityProbe, (val) => { if (loaded.value) autoSave('backgroundQualityProbe', val) })
 let suppressVideoCodecSave = false
@@ -993,6 +1047,46 @@ async function testSyncplayConnection(): Promise<void> {
             <option :value="2">2</option>
             <option :value="3">3</option>
           </select>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">Auto-download</label>
+          <p class="setting-hint">
+            Subscribed shows queue newly-aired episodes automatically. Subscribe per show on its detail page.
+            Forward-only — already-aired episodes are never backfilled.
+          </p>
+          <label class="toggle-row">
+            <input v-model="autoDownloadEnabled" type="checkbox" class="toggle-input" />
+            <span class="toggle-slider"></span>
+            <span class="toggle-label">{{ autoDownloadEnabled ? 'Enabled' : 'Disabled' }}</span>
+          </label>
+          <div class="auto-dl-status">
+            <button class="test-token-btn" :disabled="autoDlRunning || !autoDownloadEnabled" @click="runAutoDlNow">
+              {{ autoDlRunning ? 'Running...' : 'Run now' }}
+            </button>
+            <span v-if="autoDlLastResult" class="setting-hint" style="margin: 0 0 0 12px">
+              Last run: {{ autoDlLastResult.enqueued }} enqueued, {{ autoDlLastResult.skipped }} skipped, {{ autoDlLastResult.errors }} errors
+            </span>
+          </div>
+          <div class="auto-dl-subs">
+            <button
+              type="button"
+              class="auto-dl-subs-toggle"
+              @click="autoDlSubscriptionsExpanded = !autoDlSubscriptionsExpanded"
+            >
+              {{ autoDlSubscriptions.length }} show{{ autoDlSubscriptions.length === 1 ? '' : 's' }} subscribed
+              <span class="caret">{{ autoDlSubscriptionsExpanded ? '▾' : '▸' }}</span>
+            </button>
+            <ul v-if="autoDlSubscriptionsExpanded && autoDlSubscriptions.length > 0" class="auto-dl-sub-list">
+              <li v-for="sub in autoDlSubscriptions" :key="sub.animeId">
+                <span class="auto-dl-sub-name">{{ sub.animeName }}</span>
+                <span class="auto-dl-sub-meta">
+                  next: Ep {{ sub.lastEnqueuedEpisodeInt + 1 }} · checked {{ autoDlLastCheckedLabel(sub.lastCheckedAt) }}
+                </span>
+                <button class="auto-dl-unsub-btn" @click="unsubscribeAutoDl(sub.animeId)">Unsubscribe</button>
+              </li>
+            </ul>
+          </div>
         </div>
 
         <div class="setting-group">
@@ -1869,6 +1963,69 @@ async function testSyncplayConnection(): Promise<void> {
 .test-token-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.auto-dl-status {
+  display: flex;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.auto-dl-subs {
+  margin-top: 10px;
+}
+
+.auto-dl-subs-toggle {
+  background: none;
+  border: none;
+  color: #8aa8d0;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 4px 0;
+}
+
+.auto-dl-subs-toggle .caret {
+  margin-left: 4px;
+  font-size: 0.7rem;
+}
+
+.auto-dl-sub-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+}
+
+.auto-dl-sub-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  font-size: 0.85rem;
+}
+
+.auto-dl-sub-name {
+  flex: 1;
+  color: #e0e0f0;
+}
+
+.auto-dl-sub-meta {
+  color: #6a6a8a;
+  font-size: 0.75rem;
+}
+
+.auto-dl-unsub-btn {
+  background: rgba(120, 50, 50, 0.6);
+  color: #e0a0a0;
+  border: none;
+  border-radius: 3px;
+  padding: 3px 8px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.auto-dl-unsub-btn:hover {
+  background: rgba(150, 60, 60, 0.8);
 }
 
 .token-result {


### PR DESCRIPTION
## Summary

Closes #76. Subscribe to airing shows from `AnimeDetailView` and the app queues new episodes automatically — forward-only, no backfill, gated by Shikimori login + valid MAL ID.

## Changes

- **New** `src/main/auto-downloader.ts` — worker with 60s reentrancy lock, `MAX_ENQUEUES_PER_TICK=10`, in-tick dedup
- **Triggers** in `src/main/index.ts`: `+30s` after `whenReady`, `setInterval(15min)`, post-`shikimori:rates-refreshed`, manual via `auto-dl:trigger` IPC
- **Inline detail refresh** — when cached `shikimoriAnimeDetails[malId]` is older than 6h, the tick refetches via `shikimori.getAnimeDetails` so weekly-airing shows don't go stale between the existing pre-fetch worker's 30-day cadence
- **Translation resolver** — prefers most-recent `downloadedEpisodes` entry for the show (`type` + `author`), falls back to global `translationType` default
- **Dedup** vs `downloadedEpisodes` (new + legacy key formats), live `downloadManager.getEpisodeGroups()`, and per-tick set
- **Forward-only stamping** — at subscribe time, `lastEnqueuedEpisodeInt = current episodes_aired`; bumped on successful enqueue or already-downloaded/already-queued; never on `no-translation`
- **IPC** — 7 handlers (`auto-dl:get-subscription`, `auto-dl:set-subscription`, `auto-dl:list-subscriptions`, `auto-dl:trigger`, `auto-dl:get-status`, `auto-dl:get-enabled`, `auto-dl:set-enabled`) and 2 broadcasts (`auto-dl:tick-result`, `auto-dl:enqueued`)
- **Store keys** — `autoDownloadSubscriptions` (per-show map), `autoDownloadEnabled` (master toggle, default on)
- **UI** —
  - `AnimeDetailView.vue` — Auto-download pill next to library star (hidden for finished shows or when not connected to Shikimori)
  - `CalendarView.vue` — ↻ Auto-DL chip on subscribed cards
  - `SettingsView.vue` — General → Auto-download section with master toggle, **Run now**, last-run counters, expandable subscription list with per-show unsubscribe
- **`DESIGN.md`** — IPC table, store schema, and a new Auto-download subsection under Shikimori
- **Version bump** 3.21.0 → 3.22.0

## Behavior notes

- Master toggle defaults to `true`; turning it off makes ticks no-ops without dropping subscriptions
- Manual "Run now" that hits the 60s reentrancy lock returns silently (no broadcast); SettingsView reads `autoDlLastResult` only from broadcasts, so blocked clicks don't overwrite real counters
- `MAX_ENQUEUES_PER_TICK=10` is a hard cap — if a show jumps from 0→50 episodes_aired, only 10 enqueue per run, the rest pick up next tick
- Subscriptions are gated on `myAnimeListId` + Shikimori login (the calendar pipeline depends on Shikimori) + `status !== 'released'`

## Test plan

- [ ] Subscribe to an ongoing show with episodes_aired = N → click Run now → verify nothing enqueues (forward-only stamp)
- [ ] Manually decrement lastEnqueuedEpisodeInt in ~/.config/anime-dl-app/config.json → restart app → click Run now → verify ep N enqueues with the right translation
- [ ] Manually queue an episode ahead → click Run now → verify dedup skips it (already-queued)
- [ ] Stale cache: subscribe to a show whose shikimoriAnimeDetails cache is >6h old → click Run now → verify the tick refetches details inline and queues newly-aired episodes
- [ ] Subscribe to a finished show → verify the pill is hidden
- [ ] Log out of Shikimori → verify the pill is disabled and ticks become no-ops
- [ ] Stamp lastEnqueuedEpisodeInt 50 episodes behind → verify only 10 enqueue per tick
- [ ] Disable master toggle → verify Run now broadcasts enqueued: 0
- [ ] Cross-platform smoke: Windows/macOS/Linux (no platform-specific code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)