### PR TITLE
feat: cleanup prompt when a show is marked Completed on Shikimori

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -253,6 +253,28 @@ File scan cache (session-level, in-memory):
   - file:open verifies existence; if missing, invalidates cache + returns error
 ```
 
+### Completion-triggered cleanup
+
+When `shikimori:update-rate` flips a status to `completed` (and the prior
+status was not `completed`), main resolves the smotret-anime entry from the
+cached rate (`smotretAnime` field), checks `downloadedAnime[animeId]` and
+`autoCleanupSnoozedAnimeIds[animeId]`, and broadcasts `cleanup:prompt` with
+`{ animeId, animeName, malId }`. The same broadcast fires on the offline
+fallback path so the prompt still appears for offline status flips.
+
+`App.vue` listens and shows a toast (auto-dismisses after 30 s) with three
+actions: open `CleanupModal` → calls `cleanup:execute`; "Keep" → dismiss;
+"Don't ask for this show" → `cleanup:set-snoozed`. `cleanup:execute` deletes
+the show folder in every storage dir, drops `downloadedAnime[animeId]` and
+every `downloadedEpisodes` entry whose key starts with `${animeId}:`, and
+prunes the anime/skip caches. `library`, `watchProgress`, and the Shikimori
+rate are left intact. If active downloads exist for the show, the modal
+chains `download:cancel-by-episode` first.
+
+A "Cleanup files…" button in the AnimeDetailView header (visible when
+`library-is-downloaded`) opens the same modal manually. Settings > Storage >
+Cleanup prompts lists snoozed shows with un-snooze + reset-all controls.
+
 ### Library
 
 ```
@@ -287,6 +309,12 @@ LibraryView shows both with indicators:
 | `library-get-status` | invoke | Batch check starred + downloaded status for multiple anime IDs |
 | `downloaded-anime-add` | invoke | Mark anime as having downloads |
 | `downloaded-anime-delete` | invoke | Remove anime + delete folder |
+| `cleanup:get-size` | invoke | Sum bytes + file count for a show across hot+cold dirs (.mkv/.mp4/.ass/.srt) |
+| `cleanup:get-active-downloads` | invoke | Count download groups still in flight for the given anime name |
+| `cleanup:execute` | invoke | Delete the show's folder(s), drop its `downloadedAnime` + `downloadedEpisodes` entries, prune caches; preserves `library`/`watchProgress`/Shikimori rate |
+| `cleanup:get-snoozed` | invoke | Return `Record<animeId, { animeName }>` of shows the user silenced from completion-cleanup prompts |
+| `cleanup:set-snoozed` | invoke | Toggle a show's entry in `autoCleanupSnoozedAnimeIds` |
+| `cleanup:prompt` | send | Broadcast when a Shikimori rate transitions to `completed` for a show with local files (and not snoozed); App.vue surfaces a toast |
 | `downloaded-episodes-get` | invoke | Get translation metadata per episode (array of metas per episode, supports multiple translations) |
 | `get-setting` | invoke | Read setting value |
 | `set-setting` | invoke | Write setting value |
@@ -479,6 +507,7 @@ interface EpisodeMeta {
 | `mp4StreamingStats` | object | `{ totalChecked:0, faststartCount:0, nonFaststartSamples:[] }` | Telemetry from the MP4 faststart probe: total files scanned, count that had `moov` before `mdat`, and up to 10 most-recent non-faststart samples (anime + episode + path + first non-`ftyp` box). Surfaced in Settings > Debug |
 | `autoDownloadSubscriptions` | object | `{}` | Per-show auto-download subscriptions keyed by smotret-anime ID. Each entry: `{ animeId, malId, animeName, subscribedAt, lastEnqueuedEpisodeInt, lastCheckedAt }`. `lastEnqueuedEpisodeInt` is stamped to current `episodes_aired` at subscribe time so newly-subscribed shows never backfill |
 | `autoDownloadEnabled` | boolean | `true` | Master toggle that gates the auto-download worker. When false, all ticks become no-ops; subscriptions are preserved |
+| `autoCleanupSnoozedAnimeIds` | object | `{}` | Map of smotret-anime IDs (as strings) the user silenced from the Shikimori-completion cleanup prompt via "Don't ask for this show". Settings > Storage > Cleanup prompts manages the list |
 
 ## Watch Progress & Resume
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -149,7 +149,8 @@ const store = new Store({
       totalChecked: 0,
       faststartCount: 0,
       nonFaststartSamples: [] as { animeId: number; animeName: string; episodeInt: string; episodeLabel: string; filePath: string; firstNonFtypBox: string; checkedAt: number }[]
-    } as Mp4StreamingStats
+    } as Mp4StreamingStats,
+    autoCleanupSnoozedAnimeIds: {} as Record<string, true>
   }
 })
 
@@ -620,6 +621,74 @@ function isStarredAnime(animeId: number): boolean {
 
 function isCachableAnime(animeId: number): boolean {
   return isDownloadedAnime(animeId) || isStarredAnime(animeId)
+}
+
+function getDisplayName(anime: AnimeSearchResult): string {
+  return anime.titles?.romaji || anime.titles?.ru || anime.title
+}
+
+function isCleanupSnoozed(animeId: number): boolean {
+  const snoozed = store.get('autoCleanupSnoozedAnimeIds') as Record<string, true>
+  return !!snoozed[String(animeId)]
+}
+
+async function resolveSmotretFromMalId(malId: number, fallback: unknown): Promise<AnimeSearchResult | null> {
+  if (fallback && typeof fallback === 'object' && typeof (fallback as { id?: unknown }).id === 'number') {
+    return fallback as AnimeSearchResult
+  }
+  const map = store.get('malIdMap') as Record<string, AnimeSearchResult>
+  const cached = map[String(malId)]
+  if (cached?.id) return cached
+  try {
+    const resolved = await lookupByMalIds([malId])
+    return resolved[malId] ?? null
+  } catch {
+    return null
+  }
+}
+
+async function maybeBroadcastCleanupPrompt(
+  smotretAnime: unknown,
+  malId: number,
+  status: shikimori.ShikiUserRateStatus,
+  prevStatus?: shikimori.ShikiUserRateStatus
+): Promise<void> {
+  if (status !== 'completed' || prevStatus === 'completed') return
+  const sa = await resolveSmotretFromMalId(malId, smotretAnime)
+  if (!sa || typeof sa.id !== 'number') return
+  if (!isDownloadedAnime(sa.id)) return
+  if (isCleanupSnoozed(sa.id)) return
+  broadcastToAll('cleanup:prompt', {
+    animeId: sa.id,
+    animeName: getDisplayName(sa),
+    malId
+  })
+}
+
+function sumShowFiles(animeName: string): { bytes: number; files: number } {
+  const animeDirName = sanitizeFilename(animeName)
+  let bytes = 0
+  let files = 0
+  for (const dir of storageDirsForScan()) {
+    const showDir = path.join(dir, animeDirName)
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(showDir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isFile()) continue
+      const lower = entry.name.toLowerCase()
+      if (!(lower.endsWith('.mkv') || lower.endsWith('.mp4') || lower.endsWith('.ass') || lower.endsWith('.srt'))) continue
+      try {
+        const stat = fs.statSync(path.join(showDir, entry.name))
+        bytes += stat.size
+        files++
+      } catch { /* ignore */ }
+    }
+  }
+  return { bytes, files }
 }
 
 type FileCheckResult = Record<string, { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]>
@@ -2364,6 +2433,68 @@ function registerIpcHandlers(): void {
     dropSkipDetectionsForAnime(animeId)
   })
 
+  ipcMain.handle('cleanup:get-size', (_event, _animeId: number, animeName: string) => {
+    return sumShowFiles(animeName)
+  })
+
+  ipcMain.handle('cleanup:get-active-downloads', (_event, animeName: string) => {
+    const groups = downloadManager.getEpisodeGroups()
+    const active = groups.filter((g) => g.animeName === animeName).length
+    return { active }
+  })
+
+  ipcMain.handle('cleanup:execute', (_event, animeId: number, animeName: string) => {
+    const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+    delete downloaded[String(animeId)]
+    store.set('downloadedAnime', downloaded)
+
+    const dirName = sanitizeFilename(animeName)
+    for (const dir of storageDirsForScan()) {
+      const dirPath = path.join(dir, dirName)
+      try { fs.rmSync(dirPath, { recursive: true }) } catch { /* ignore */ }
+    }
+
+    const episodes = store.get('downloadedEpisodes') as Record<string, { translationType: string; author: string; quality: number; translationId: number }>
+    const prefix = `${animeId}:`
+    let mutated = false
+    for (const key of Object.keys(episodes)) {
+      if (key.startsWith(prefix)) {
+        delete episodes[key]
+        mutated = true
+      }
+    }
+    if (mutated) store.set('downloadedEpisodes', episodes)
+
+    fileCheckCache.delete(animeName)
+    deleteCacheEntry(animeId)
+    pruneSkipCacheForAnime(animeId)
+    dropSkipDetectionsForAnime(animeId)
+  })
+
+  ipcMain.handle('cleanup:get-snoozed', () => {
+    const snoozed = store.get('autoCleanupSnoozedAnimeIds') as Record<string, true>
+    const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
+    const lib = store.get('library') as Record<string, AnimeSearchResult>
+    const recent = store.get('recentAnimeMeta') as Record<string, AnimeSearchResult>
+    const out: Record<string, { animeName: string }> = {}
+    for (const id of Object.keys(snoozed)) {
+      const entry = downloaded[id] || lib[id] || recent[id]
+      out[id] = { animeName: entry ? getDisplayName(entry) : `Anime ${id}` }
+    }
+    return out
+  })
+
+  ipcMain.handle('cleanup:set-snoozed', (_event, animeId: number, snoozed: boolean) => {
+    const map = store.get('autoCleanupSnoozedAnimeIds') as Record<string, true>
+    const key = String(animeId)
+    if (snoozed) {
+      map[key] = true
+    } else {
+      delete map[key]
+    }
+    store.set('autoCleanupSnoozedAnimeIds', map)
+  })
+
   ipcMain.handle('get-setting', (_event, key: string) => {
     if (key === 'downloadDir') return getDownloadDir()
     return store.get(key)
@@ -2968,6 +3099,7 @@ function registerIpcHandlers(): void {
 
       const cached = store.get('shikimoriUserRates') as { rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number }; shikiAnime: unknown; smotretAnime: unknown }[]
       const idx = cached.findIndex((e) => e.rate.target_id === malId)
+      const prevStatus = idx !== -1 ? cached[idx].rate.status : undefined
 
       try {
         const accessToken = await shikimori.ensureFreshToken(store)
@@ -2991,8 +3123,10 @@ function registerIpcHandlers(): void {
           store.set('shikimoriUserRates', cached)
           invalidateCalendarCache()
           broadcastToAll('shikimori:rate-updated', cached[idx])
+          void maybeBroadcastCleanupPrompt(cached[idx].smotretAnime, malId, updatedRate.status, prevStatus)
         } else {
           refreshShikimoriRatesInBackground()
+          void maybeBroadcastCleanupPrompt(null, malId, updatedRate.status, undefined)
         }
 
         void syncShikimoriQueue()
@@ -3028,6 +3162,7 @@ function registerIpcHandlers(): void {
         broadcastToAll('shikimori:rate-updated', cached[idx])
         broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
         startSyncTimer()
+        void maybeBroadcastCleanupPrompt(cached[idx].smotretAnime, malId, status, prevStatus)
 
         return {
           id: rateId ?? -1,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -665,7 +665,7 @@ async function maybeBroadcastCleanupPrompt(
   })
 }
 
-function sumShowFiles(animeName: string): { bytes: number; files: number } {
+async function sumShowFiles(animeName: string): Promise<{ bytes: number; files: number }> {
   const animeDirName = sanitizeFilename(animeName)
   let bytes = 0
   let files = 0
@@ -673,19 +673,29 @@ function sumShowFiles(animeName: string): { bytes: number; files: number } {
     const showDir = path.join(dir, animeDirName)
     let entries: fs.Dirent[]
     try {
-      entries = fs.readdirSync(showDir, { withFileTypes: true })
+      entries = await fs.promises.readdir(showDir, { withFileTypes: true })
     } catch {
       continue
     }
-    for (const entry of entries) {
-      if (!entry.isFile()) continue
+    const targets = entries.filter((entry) => {
+      if (!entry.isFile()) return false
       const lower = entry.name.toLowerCase()
-      if (!(lower.endsWith('.mkv') || lower.endsWith('.mp4') || lower.endsWith('.ass') || lower.endsWith('.srt'))) continue
-      try {
-        const stat = fs.statSync(path.join(showDir, entry.name))
-        bytes += stat.size
-        files++
-      } catch { /* ignore */ }
+      return lower.endsWith('.mkv') || lower.endsWith('.mp4') || lower.endsWith('.ass') || lower.endsWith('.srt')
+    })
+    const sizes = await Promise.all(
+      targets.map(async (entry) => {
+        try {
+          const stat = await fs.promises.stat(path.join(showDir, entry.name))
+          return stat.size
+        } catch {
+          return null
+        }
+      })
+    )
+    for (const size of sizes) {
+      if (size === null) continue
+      bytes += size
+      files++
     }
   }
   return { bytes, files }
@@ -2433,8 +2443,8 @@ function registerIpcHandlers(): void {
     dropSkipDetectionsForAnime(animeId)
   })
 
-  ipcMain.handle('cleanup:get-size', (_event, _animeId: number, animeName: string) => {
-    return sumShowFiles(animeName)
+  ipcMain.handle('cleanup:get-size', async (_event, _animeId: number, animeName: string) => {
+    return await sumShowFiles(animeName)
   })
 
   ipcMain.handle('cleanup:get-active-downloads', (_event, animeName: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -57,6 +57,22 @@ const api = {
   libraryIsDownloaded: (id: number) => ipcRenderer.invoke('library-is-downloaded', id),
   downloadedAnimeAdd: (anime: unknown) => ipcRenderer.invoke('downloaded-anime-add', anime),
   downloadedAnimeDelete: (animeId: number, animeName: string) => ipcRenderer.invoke('downloaded-anime-delete', animeId, animeName),
+  cleanupGetSize: (animeId: number, animeName: string) =>
+    ipcRenderer.invoke('cleanup:get-size', animeId, animeName) as Promise<{ bytes: number; files: number }>,
+  cleanupGetActiveDownloads: (animeName: string) =>
+    ipcRenderer.invoke('cleanup:get-active-downloads', animeName) as Promise<{ active: number }>,
+  cleanupExecute: (animeId: number, animeName: string) =>
+    ipcRenderer.invoke('cleanup:execute', animeId, animeName) as Promise<void>,
+  cleanupGetSnoozed: () =>
+    ipcRenderer.invoke('cleanup:get-snoozed') as Promise<Record<string, { animeName: string }>>,
+  cleanupSetSnoozed: (animeId: number, snoozed: boolean) =>
+    ipcRenderer.invoke('cleanup:set-snoozed', animeId, snoozed) as Promise<void>,
+  onCleanupPrompt: (callback: (data: { animeId: number; animeName: string; malId: number }) => void) => {
+    ipcRenderer.on('cleanup:prompt', (_event, data) => callback(data))
+  },
+  offCleanupPrompt: () => {
+    ipcRenderer.removeAllListeners('cleanup:prompt')
+  },
   getSetting: (key: string) => ipcRenderer.invoke('get-setting', key),
   setSetting: (key: string, value: unknown) => ipcRenderer.invoke('set-setting', key, value),
 

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -35,6 +35,13 @@ interface Api {
   libraryIsDownloaded: (id: number) => Promise<boolean>
   downloadedAnimeAdd: (anime: AnimeSearchResult) => Promise<void>
   downloadedAnimeDelete: (animeId: number, animeName: string) => Promise<void>
+  cleanupGetSize: (animeId: number, animeName: string) => Promise<{ bytes: number; files: number }>
+  cleanupGetActiveDownloads: (animeName: string) => Promise<{ active: number }>
+  cleanupExecute: (animeId: number, animeName: string) => Promise<void>
+  cleanupGetSnoozed: () => Promise<Record<string, { animeName: string }>>
+  cleanupSetSnoozed: (animeId: number, snoozed: boolean) => Promise<void>
+  onCleanupPrompt: (callback: (data: { animeId: number; animeName: string; malId: number }) => void) => void
+  offCleanupPrompt: () => void
   getSetting: (key: string) => Promise<unknown>
   setSetting: (key: string, value: unknown) => Promise<void>
 

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -11,6 +11,8 @@ import FriendsActivityView from './components/FriendsActivityView.vue'
 import CalendarView from './components/CalendarView.vue'
 import HomeView from './components/HomeView.vue'
 import PlayerView from './components/PlayerView.vue'
+import CleanupModal from './components/CleanupModal.vue'
+import { formatBytes } from './utils'
 
 const currentView = ref('home')
 const searchViewRef = ref<InstanceType<typeof SearchView> | null>(null)
@@ -163,6 +165,68 @@ async function loadShortcuts(): Promise<void> {
 const ffmpegDownloading = ref(false)
 const ffmpegProgress = ref(0)
 
+// Cleanup prompt (Shikimori "completed" transition)
+const cleanupToast = ref<{
+  animeId: number
+  animeName: string
+  bytes: number
+  files: number
+  loading: boolean
+} | null>(null)
+const cleanupModal = ref<{ animeId: number; animeName: string } | null>(null)
+let cleanupToastTimer: ReturnType<typeof setTimeout> | null = null
+
+function dismissCleanupToast(): void {
+  if (cleanupToastTimer) {
+    clearTimeout(cleanupToastTimer)
+    cleanupToastTimer = null
+  }
+  cleanupToast.value = null
+}
+
+async function handleCleanupPrompt(data: { animeId: number; animeName: string; malId: number }): Promise<void> {
+  dismissCleanupToast()
+  cleanupToast.value = {
+    animeId: data.animeId,
+    animeName: data.animeName,
+    bytes: 0,
+    files: 0,
+    loading: true
+  }
+  cleanupToastTimer = setTimeout(dismissCleanupToast, 30000)
+  try {
+    const size = await window.api.cleanupGetSize(data.animeId, data.animeName)
+    if (cleanupToast.value && cleanupToast.value.animeId === data.animeId) {
+      cleanupToast.value.bytes = size.bytes
+      cleanupToast.value.files = size.files
+      cleanupToast.value.loading = false
+    }
+  } catch {
+    if (cleanupToast.value && cleanupToast.value.animeId === data.animeId) {
+      cleanupToast.value.loading = false
+    }
+  }
+}
+
+function openCleanupModalFromToast(): void {
+  if (!cleanupToast.value) return
+  cleanupModal.value = { animeId: cleanupToast.value.animeId, animeName: cleanupToast.value.animeName }
+  dismissCleanupToast()
+}
+
+async function snoozeCleanupFromToast(): Promise<void> {
+  if (!cleanupToast.value) return
+  const id = cleanupToast.value.animeId
+  dismissCleanupToast()
+  try {
+    await window.api.cleanupSetSnoozed(id, true)
+  } catch { /* ignore */ }
+}
+
+function closeCleanupModal(): void {
+  cleanupModal.value = null
+}
+
 onMounted(async () => {
   await loadShortcuts()
   const shikiUser = await window.api.shikimoriGetUser()
@@ -176,6 +240,7 @@ onMounted(async () => {
       ffmpegDownloading.value = false
     }
   })
+  window.api.onCleanupPrompt(handleCleanupPrompt)
   // Expose test hook for Playwright screenshot script
   ;(window as any).__openTestPlayer = openPlayer
 })
@@ -183,6 +248,8 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKeydown)
   window.api.offFfmpegDownloadProgress()
+  window.api.offCleanupPrompt()
+  if (cleanupToastTimer) clearTimeout(cleanupToastTimer)
 })
 </script>
 
@@ -199,6 +266,27 @@ onBeforeUnmount(() => {
     <SettingsView v-if="currentView === 'settings'" />
     <DownloadsView v-if="currentView === 'downloads'" />
     <PlayerView v-if="playerState" :file-path="playerState.filePath" :stream-url="playerState.streamUrl" :subtitle-content="playerState.subtitleContent" :anime-name="playerState.animeName" :episode-label="playerState.episodeLabel" :available-streams="playerState.availableStreams" :translation-id="playerState.translationId" :translations="playerState.translations" :downloaded-tr-ids="playerState.downloadedTrIds" :all-episodes="playerState.allEpisodes" :episode-index="playerState.episodeIndex" :anime-id="playerState.animeId" :mal-id="playerState.malId" @close="closePlayer" />
+    <CleanupModal
+      v-if="cleanupModal"
+      :anime-id="cleanupModal.animeId"
+      :anime-name="cleanupModal.animeName"
+      @closed="closeCleanupModal"
+    />
+    <div v-if="cleanupToast" class="cleanup-toast">
+      <div class="cleanup-toast-body">
+        <div class="cleanup-toast-title">✓ You finished «{{ cleanupToast.animeName }}»</div>
+        <div class="cleanup-toast-size">
+          <template v-if="cleanupToast.loading">Calculating size…</template>
+          <template v-else-if="cleanupToast.files === 0">No local files</template>
+          <template v-else>{{ cleanupToast.files }} file{{ cleanupToast.files === 1 ? '' : 's' }} · {{ formatBytes(cleanupToast.bytes) }} on disk</template>
+        </div>
+      </div>
+      <div class="cleanup-toast-actions">
+        <button class="cleanup-toast-btn primary" @click="openCleanupModalFromToast">Cleanup files</button>
+        <button class="cleanup-toast-btn" @click="dismissCleanupToast">Keep</button>
+        <button class="cleanup-toast-btn subtle" @click="snoozeCleanupFromToast">Don't ask for this show</button>
+      </div>
+    </div>
     <div v-if="ffmpegDownloading" class="ffmpeg-overlay">
       <div class="ffmpeg-modal">
         <div class="ffmpeg-spinner"></div>
@@ -311,5 +399,72 @@ body {
   margin-top: 0.5rem;
   font-size: 0.75rem;
   color: #6a6a8a;
+}
+
+.cleanup-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  width: 360px;
+  background: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 16px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  z-index: 8000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cleanup-toast-title {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: #e0e0e0;
+  margin-bottom: 4px;
+}
+
+.cleanup-toast-size {
+  font-size: 0.8rem;
+  color: #a0a0b8;
+}
+
+.cleanup-toast-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.cleanup-toast-btn {
+  padding: 5px 10px;
+  font-size: 0.78rem;
+  border-radius: 5px;
+  border: 1px solid #0f3460;
+  background: transparent;
+  color: #c0c0d0;
+  cursor: pointer;
+}
+
+.cleanup-toast-btn:hover {
+  background: rgba(15, 52, 96, 0.4);
+}
+
+.cleanup-toast-btn.primary {
+  background: #e94560;
+  border-color: #e94560;
+  color: #ffffff;
+}
+
+.cleanup-toast-btn.primary:hover {
+  background: #f25670;
+}
+
+.cleanup-toast-btn.subtle {
+  color: #7a7a98;
+  border-color: transparent;
+}
+
+.cleanup-toast-btn.subtle:hover {
+  color: #c0c0d0;
 }
 </style>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue'
 import { formatBytes, formatSpeed, formatEta, getAnimeName as _getAnimeName, sanitizeFilename } from '../utils'
+import CleanupModal from './CleanupModal.vue'
 
 const props = defineProps<{
   animeId: number
@@ -32,6 +33,8 @@ let disposed = false
 const isStarred = ref(false)
 const autoDlSubscription = ref<AutoDownloadSubscription | null>(null)
 const autoDlSaving = ref(false)
+const isDownloaded = ref(false)
+const cleanupModalOpen = ref(false)
 
 const episodeOverrides = ref<Map<number, number>>(new Map()) // episodeId -> translationId
 const realQuality = ref<Map<number, number>>(new Map()) // translationId -> actual height from embed
@@ -531,6 +534,7 @@ onMounted(async () => {
 
   window.api.libraryHas(props.animeId).then((v) => { isStarred.value = v }).catch(() => {})
   window.api.autoDlGetSubscription(props.animeId).then((s) => { autoDlSubscription.value = s }).catch(() => {})
+  window.api.libraryIsDownloaded(props.animeId).then((v) => { isDownloaded.value = v }).catch(() => {})
 
   const gen = ++loadGeneration
   let renderedFromCache = false
@@ -1059,6 +1063,12 @@ async function toggleAutoDl(): Promise<void> {
   }
 }
 
+async function onCleanupDeleted(): Promise<void> {
+  isDownloaded.value = false
+  episodeMeta.value = {}
+  await checkFileStatus()
+}
+
 const episodeMeta = ref<Record<string, EpisodeMeta[]>>({})
 const downloadGroups = ref<Map<string, EpisodeGroup>>(new Map())
 const downloading = ref(false)
@@ -1407,6 +1417,12 @@ function typeChip(type: string): { short: string; color: string } {
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12c0 4.142-3.358 7.5-7.5 7.5S4.5 16.142 4.5 12 7.858 4.5 12 4.5c1.747 0 3.354.6 4.625 1.604M19.5 4.5v3.75h-3.75" />
             </svg>
             {{ autoDlSubscription ? 'Auto-download on' : 'Auto-download' }}
+          </button>
+          <button v-if="isDownloaded" class="cleanup-btn" @click="cleanupModalOpen = true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="14" height="14">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+            </svg>
+            Cleanup files…
           </button>
         </div>
         <div class="anime-info">
@@ -1874,6 +1890,13 @@ function typeChip(type: string): { short: string; color: string } {
         </div>
       </div>
     </div>
+    <CleanupModal
+      v-if="cleanupModalOpen && anime"
+      :anime-id="props.animeId"
+      :anime-name="getAnimeName()"
+      @closed="cleanupModalOpen = false"
+      @deleted="onCleanupDeleted"
+    />
   </main>
 </template>
 
@@ -1985,6 +2008,30 @@ function typeChip(type: string): { short: string; color: string } {
 .library-btn.active {
   color: #fbbf24;
   border-color: #fbbf24;
+}
+
+.cleanup-btn {
+  width: 200px;
+  padding: 10px 14px;
+  background: transparent;
+  border: 1px solid #2a2a4a;
+  border-radius: 8px;
+  color: #a0a0c0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.cleanup-btn:hover {
+  background: #16213e;
+  border-color: #5a3a4e;
+  color: #f0a070;
 }
 
 .anime-info {

--- a/src/renderer/src/components/CleanupModal.vue
+++ b/src/renderer/src/components/CleanupModal.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { formatBytes } from '../utils'
+
+const props = defineProps<{
+  animeId: number
+  animeName: string
+}>()
+
+const emit = defineEmits<{
+  closed: []
+  deleted: []
+}>()
+
+const sizeLoading = ref(true)
+const bytes = ref(0)
+const fileCount = ref(0)
+const activeDownloads = ref(0)
+const deleting = ref(false)
+const error = ref('')
+
+onMounted(async () => {
+  try {
+    const [size, active] = await Promise.all([
+      window.api.cleanupGetSize(props.animeId, props.animeName),
+      window.api.cleanupGetActiveDownloads(props.animeName)
+    ])
+    bytes.value = size.bytes
+    fileCount.value = size.files
+    activeDownloads.value = active.active
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    sizeLoading.value = false
+  }
+})
+
+async function confirmDelete(): Promise<void> {
+  if (deleting.value) return
+  deleting.value = true
+  error.value = ''
+  try {
+    if (activeDownloads.value > 0) {
+      await window.api.downloadCancelByEpisode(props.animeName)
+    }
+    await window.api.cleanupExecute(props.animeId, props.animeName)
+    emit('deleted')
+    emit('closed')
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+    deleting.value = false
+  }
+}
+
+function cancel(): void {
+  if (deleting.value) return
+  emit('closed')
+}
+</script>
+
+<template>
+  <div class="cleanup-backdrop" @click.self="cancel">
+    <div class="cleanup-modal">
+      <div class="cleanup-title">Clean up «{{ animeName }}»?</div>
+      <p v-if="sizeLoading" class="cleanup-hint">Calculating disk usage…</p>
+      <template v-else>
+        <p v-if="fileCount === 0" class="cleanup-hint">
+          No local files found for this anime.
+        </p>
+        <p v-else class="cleanup-hint">
+          {{ fileCount }} file{{ fileCount === 1 ? '' : 's' }} · {{ formatBytes(bytes) }} on disk.
+        </p>
+      </template>
+      <p class="cleanup-note">Watch progress and your Shikimori rate will be kept.</p>
+      <p v-if="activeDownloads > 0" class="cleanup-warn">
+        ⚠ {{ activeDownloads }} download{{ activeDownloads === 1 ? '' : 's' }} for this show
+        {{ activeDownloads === 1 ? 'is' : 'are' }} still in flight and will be cancelled.
+      </p>
+      <p v-if="error" class="cleanup-error">{{ error }}</p>
+      <div class="cleanup-actions">
+        <button class="btn btn-secondary" :disabled="deleting" @click="cancel">Cancel</button>
+        <button
+          class="btn btn-danger"
+          :disabled="deleting || sizeLoading || fileCount === 0"
+          @click="confirmDelete"
+        >
+          {{ deleting ? 'Deleting…' : (activeDownloads > 0 ? 'Cancel downloads + delete files' : 'Delete files') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.cleanup-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9000;
+}
+
+.cleanup-modal {
+  width: 460px;
+  max-width: calc(100% - 40px);
+  background-color: #1a1a2e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 20px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cleanup-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #e0e0e0;
+  margin-bottom: 4px;
+}
+
+.cleanup-hint {
+  font-size: 0.9rem;
+  color: #c0c0d0;
+}
+
+.cleanup-note {
+  font-size: 0.8rem;
+  color: #8a8aa8;
+}
+
+.cleanup-warn {
+  font-size: 0.82rem;
+  color: #f0b070;
+  background: rgba(240, 176, 112, 0.08);
+  padding: 8px 10px;
+  border-radius: 6px;
+  border: 1px solid rgba(240, 176, 112, 0.3);
+}
+
+.cleanup-error {
+  font-size: 0.82rem;
+  color: #e94560;
+}
+
+.cleanup-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.btn {
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  font-weight: 500;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background-color: transparent;
+  color: #c0c0d0;
+  border-color: #0f3460;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: rgba(15, 52, 96, 0.4);
+}
+
+.btn-danger {
+  background-color: #b8324a;
+  color: #ffffff;
+}
+
+.btn-danger:hover:not(:disabled) {
+  background-color: #d13a55;
+}
+</style>

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -27,6 +27,8 @@ const cleanupRunning = ref(false)
 const cleanupResult = ref<CleanupResult | null>(null)
 const cleanupPending = ref<CleanupCandidate[] | null>(null)
 const cleanupLogExpanded = ref(false)
+const snoozedEntries = ref<{ animeId: number; animeName: string }[]>([])
+const snoozedLoading = ref(false)
 const loaded = ref(false)
 const savedVisible = ref(false)
 let savedTimeout: ReturnType<typeof setTimeout> | null = null
@@ -534,6 +536,30 @@ async function reloadCleanupLog(): Promise<void> {
   cleanupLog.value = log || []
 }
 
+async function reloadSnoozedCleanups(): Promise<void> {
+  snoozedLoading.value = true
+  try {
+    const map = await window.api.cleanupGetSnoozed()
+    snoozedEntries.value = Object.entries(map)
+      .map(([id, v]) => ({ animeId: Number(id), animeName: v.animeName }))
+      .sort((a, b) => a.animeName.localeCompare(b.animeName))
+  } finally {
+    snoozedLoading.value = false
+  }
+}
+
+async function unsnoozeCleanup(animeId: number): Promise<void> {
+  await window.api.cleanupSetSnoozed(animeId, false)
+  await reloadSnoozedCleanups()
+}
+
+async function resetAllCleanupSnoozes(): Promise<void> {
+  for (const entry of snoozedEntries.value) {
+    await window.api.cleanupSetSnoozed(entry.animeId, false)
+  }
+  await reloadSnoozedCleanups()
+}
+
 function onUsageProgress(data: { scanned: number; total: number }): void {
   usageProgress.value = data
 }
@@ -582,6 +608,11 @@ onMounted(async () => {
   skipQueuePollTimer = setInterval(refreshSkipQueueStatus, 4000)
 
   appVersion.value = await window.api.appVersion()
+  await reloadSnoozedCleanups()
+})
+
+watch(activeTab, (tab) => {
+  if (tab === 'storage') reloadSnoozedCleanups()
 })
 
 onUnmounted(() => {
@@ -1331,6 +1362,26 @@ async function testSyncplayConnection(): Promise<void> {
               </div>
             </div>
           </div>
+        </div>
+
+        <div class="setting-group">
+          <label class="setting-label">Cleanup prompts</label>
+          <p class="setting-hint">When a Shikimori rate is flipped to «Completed», a prompt offers to delete the show's local files. Use «Don't ask for this show» on a prompt to silence it; manage silenced shows here.</p>
+          <div v-if="snoozedLoading" class="usage-meta-row">Loading…</div>
+          <template v-else>
+            <div v-if="snoozedEntries.length === 0" class="usage-meta-row">No shows are snoozed.</div>
+            <template v-else>
+              <div class="cleanup-log-list">
+                <div v-for="entry in snoozedEntries" :key="entry.animeId" class="cleanup-log-row">
+                  <span class="cleanup-log-name">{{ entry.animeName }}</span>
+                  <button class="cleanup-log-toggle" @click="unsnoozeCleanup(entry.animeId)">Un-snooze</button>
+                </div>
+              </div>
+              <div class="usage-actions" style="margin-top: 12px">
+                <button class="merge-all-btn" @click="resetAllCleanupSnoozes">Reset all ({{ snoozedEntries.length }})</button>
+              </div>
+            </template>
+          </template>
         </div>
       </template>
 


### PR DESCRIPTION
## Summary

Surfaces a non-blocking toast at the highest-signal moment for recovering disk space — the user just told Shikimori they're done with a show. No automatic deletion: every cleanup goes through an explicit confirmation.

Fixes #77.

## Changes

**Reactive trigger.** `shikimori:update-rate` broadcasts a new `cleanup:prompt` event when the status flips to `completed` and the prior status was not `completed` (including first-time rate creation, which previously had no transition signal). Fires on the offline-fallback path too, so offline status flips still prompt. Gated on `downloadedAnime[animeId]` and the new `autoCleanupSnoozedAnimeIds` map.

**Manual trigger.** New "Cleanup files…" button in the AnimeDetailView header (visible while the show has local files), opens the same modal.

**Shared `CleanupModal.vue`** lists file count + on-disk size, warns about in-flight downloads (chains `download:cancel-by-episode` → `cleanup:execute`), and preserves `library` / `watchProgress` / Shikimori rate when deleting.

**Settings → Storage → Cleanup prompts** manages the per-show "Don't ask for this show" snooze list (un-snooze + reset all).

**New IPC:** `cleanup:get-size`, `cleanup:get-active-downloads`, `cleanup:execute`, `cleanup:get-snoozed`, `cleanup:set-snoozed`, `cleanup:prompt`.

**New store key:** `autoCleanupSnoozedAnimeIds: Record<animeId, true>`.

**`cleanup:execute`** unifies what `downloaded-anime-delete` already did *plus* the per-anime sweep of `downloadedEpisodes` entries that the legacy handler skipped. Caches (`animeCache`, `skipFingerprintCache`, `skipDetections`) and the in-memory `fileCheckCache` are pruned for the show as well.

DESIGN.md: new IPC rows, new store key, and a "Completion-triggered cleanup" subsection under File Management.

## Behavior

- Re-saves of an already-`completed` rate: no prompt (only true transitions trigger).
- Show with no local files: no prompt.
- "Don't ask for this show" persists across restarts and survives re-downloads (intentional).
- Toast auto-dismisses after 30 s if ignored (treated as "Keep").
- Active-download case: modal switches the destructive button to "Cancel downloads + delete files".

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run dev` boots
- [x] Flip a downloaded show to Completed → toast appears with size + file count
- [x] "Cleanup files…" header button on a downloaded show opens the modal and deletes
- [ ] "Don't ask for this show" silences future prompts; Settings → Storage → Cleanup prompts un-snoozes
- [ ] First-time rate creation at Completed (no prior cached entry) also fires the prompt
- [ ] No prompt on re-save of an already-Completed rate
- [ ] No prompt for a never-downloaded show
- [ ] With downloads in flight: modal shows "Cancel downloads + delete files" path
- [ ] Hot + cold storage: cleanup removes from both dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)