### PR TITLE
feat: re-watching support and rewatches counter via Shikimori (#82)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -59,7 +59,7 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 
 `HomeView` is the default landing view. It calls `home:get-continue-watching`, which merges two local sources (no network) into a single, time-sorted list capped at 24 entries:
 
-- **Resume rows** — entries in `watchProgress` where `watched !== true`, `position > 5`, `duration > 0`, and `position / duration < 0.95`. Collapsed to a single entry per anime: the most-recently-updated unfinished episode wins.
+- **Resume rows** — entries in `watchProgress` where `watched !== true`, `position > 5`, `duration > 0`, and `position / duration < 0.95`. Collapsed to a single entry per anime: the most-recently-updated unfinished episode wins. Rows whose Shikimori rate status is `completed` are dropped — lingering local progress shouldn't drag a finished show back into Continue Watching.
 - **Next-up rows** — entries in `shikimoriUserRates` with `status ∈ {watching, rewatching}` and `episodes_aired === 0 || rate.episodes + 1 <= episodes_aired`.
 
 Dedup rule: if a `(animeId, _)` resume row exists, no Next-up row is emitted for that anime — Resume already represents the user's most recent intent on the show.
@@ -372,7 +372,7 @@ LibraryView shows both with indicators:
 | `shikimori:logout` | invoke | Clear Shikimori credentials and user |
 | `shikimori:get-user` | invoke | Get cached Shikimori user profile |
 | `shikimori:get-rate` | invoke | Fetch user's anime rate from Shikimori by MAL ID |
-| `shikimori:update-rate` | invoke | Create or update user rate (episodes, status, score); updates cached rates and broadcasts change |
+| `shikimori:update-rate` | invoke | Create or update user rate (episodes, status, score, rewatches); updates cached rates and broadcasts change |
 | `shikimori:get-anime-rates` | invoke | Returns cached anime rates instantly (if available), triggers background API refresh; first call fetches from API |
 | `shikimori:rate-updated` | send | Single rate entry changed (after update-rate); renderer views surgically update their local state |
 | `shikimori:rates-refreshed` | send | Full rate list refreshed from API in background; renderer views replace their entries |
@@ -517,7 +517,9 @@ The built-in player auto-saves playback position to `watchProgress` (electron-st
 
 "Watched" detection counts real playback time via `timeupdate` deltas (clamped `< 2s` to ignore seek jumps). An episode is marked `watched: true` when `position / duration >= 0.8` AND cumulative playback `>= 180s`. The flag is set once per episode per session.
 
-When an episode is marked watched and `malId > 0`, the player fetches the current Shikimori rate and, if `epNum > rate.episodes`, calls `shikimoriUpdateRate` with `'watching'` (or `'rewatching'` if current status was `'completed'`).
+When an episode is marked watched and `malId > 0`, the player fetches the current Shikimori rate and:
+- If `rate.status === 'completed'`: flips to `'rewatching'`, resets `episodes` to the just-watched episode number, and increments `rewatches` by 1 (starts a fresh rewatch cycle from whichever episode the user opened — typically ep 1). The status check itself prevents double-bumping: after the flip the status is `'rewatching'`, so the branch no longer fires.
+- Otherwise, if `epNum > rate.episodes`: calls `shikimoriUpdateRate` with `'watching'`, preserving the existing `rewatches` count.
 
 `AnimeDetailView` loads all watch-progress entries for the anime on mount via `watchProgressGetAll` and renders a small ✓ badge (watched) or mini progress bar (partial) on each episode row. The view listens on a `watch-progress-updated` window event — dispatched by `PlayerView` after each save — to refresh indicators live.
 
@@ -681,9 +683,11 @@ Shown when user is logged in AND anime has `myAnimeListId`. Displays:
 - Status dropdown (planned/watching/rewatching/completed/on_hold/dropped)
 - Episode count input
 - Score dropdown (1–10)
+- Rewatches numeric input (`rate.rewatches`, edited manually here; auto-incremented by PlayerView when transitioning from `completed` → `rewatching`)
 - Save button to push changes
 - Link to anime on Shikimori
 - Auto-status: episodes > 0 → watching (from planned) / rewatching (from completed); episodes = max → completed
+- When `rate.status === 'completed'`, every episode in the list is shown with the ✓ watched badge (regardless of local `watchProgress`), and "Continue" jumps to episode 1 so the user can start a rewatch.
 
 ### Series Chronology
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -239,8 +239,8 @@ async function recordMp4FaststartCheck(
 interface QueuedShikimoriUpdate {
   malId: number
   rateId: number | null
-  before: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
-  after: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+  before: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number; rewatches: number }
+  after: { episodes: number; status: shikimori.ShikiUserRateStatus; score: number; rewatches: number }
   queuedAt: number
 }
 
@@ -352,7 +352,7 @@ function sleep(ms: number): Promise<void> {
 
 function reconcileCacheFromRate(malId: number, rate: shikimori.ShikiUserRate): void {
   const cached = store.get('shikimoriUserRates') as {
-    rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number }
+    rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number; rewatches?: number }
     shikiAnime: unknown
     smotretAnime: unknown
   }[]
@@ -366,6 +366,7 @@ function reconcileCacheFromRate(malId: number, rate: shikimori.ShikiUserRate): v
       episodes: rate.episodes,
       status: rate.status,
       score: rate.score,
+      rewatches: rate.rewatches ?? 0,
       updated_at: new Date().toISOString()
     }
   }
@@ -429,7 +430,8 @@ async function syncShikimoriQueue(): Promise<void> {
           item.malId,
           item.after.episodes,
           item.after.status,
-          item.after.score
+          item.after.score,
+          item.after.rewatches
         )
         reconcileCacheFromRate(item.malId, created)
       } else {
@@ -444,7 +446,8 @@ async function syncShikimoriQueue(): Promise<void> {
             current.id,
             item.after.episodes,
             item.after.status,
-            item.after.score
+            item.after.score,
+            item.after.rewatches
           )
           reconcileCacheFromRate(item.malId, updated)
         } else if (shouldApplyOnDrift(current, item.after)) {
@@ -453,7 +456,8 @@ async function syncShikimoriQueue(): Promise<void> {
             current.id,
             item.after.episodes,
             item.after.status,
-            item.after.score
+            item.after.score,
+            item.after.rewatches
           )
           reconcileCacheFromRate(item.malId, updated)
         } else {
@@ -2355,9 +2359,12 @@ function registerIpcHandlers(): void {
     // Resume rows' sort key with the Shikimori clock so the Home view orders
     // entries the same way as the Shikimori "To Watch" tab.
     const rateUpdatedByAnimeId = new Map<number, number>()
+    const statusByAnimeId = new Map<number, string>()
     for (const r of rates) {
       const animeId = r.smotretAnime?.id ?? (r.rate.target_id ? malMap[String(r.rate.target_id)]?.id : undefined)
-      if (!animeId || !r.rate.updated_at) continue
+      if (!animeId) continue
+      statusByAnimeId.set(animeId, r.rate.status)
+      if (!r.rate.updated_at) continue
       const ms = Date.parse(r.rate.updated_at)
       if (Number.isFinite(ms)) rateUpdatedByAnimeId.set(animeId, ms)
     }
@@ -2365,6 +2372,18 @@ function registerIpcHandlers(): void {
       if (r.kind !== 'resume') continue
       const ms = rateUpdatedByAnimeId.get(r.animeId)
       if (ms) r.updatedAt = ms
+    }
+
+    // Hide stale "Resume" rows when Shikimori says the show is completed —
+    // their watch is done, lingering local progress shouldn't drag them back
+    // into Continue Watching.
+    for (let i = raw.length - 1; i >= 0; i--) {
+      const r = raw[i]
+      if (r.kind !== 'resume') continue
+      if (statusByAnimeId.get(r.animeId) === 'completed') {
+        raw.splice(i, 1)
+        resumeKeys.delete(String(r.animeId))
+      }
     }
 
     for (const entry of rates) {
@@ -3185,11 +3204,11 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     'shikimori:update-rate',
-    async (_event, malId: number, episodes: number, status: shikimori.ShikiUserRateStatus, score: number) => {
+    async (_event, malId: number, episodes: number, status: shikimori.ShikiUserRateStatus, score: number, rewatches: number) => {
       const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
       if (!user) throw new Error('Not logged in to Shikimori')
 
-      const cached = store.get('shikimoriUserRates') as { rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number }; shikiAnime: unknown; smotretAnime: unknown }[]
+      const cached = store.get('shikimoriUserRates') as { rate: Record<string, unknown> & { id?: number; target_id: number; episodes: number; status: shikimori.ShikiUserRateStatus; score: number; rewatches?: number }; shikiAnime: unknown; smotretAnime: unknown }[]
       const idx = cached.findIndex((e) => e.rate.target_id === malId)
       const prevStatus = idx !== -1 ? cached[idx].rate.status : undefined
 
@@ -3197,8 +3216,8 @@ function registerIpcHandlers(): void {
         const accessToken = await shikimori.ensureFreshToken(store)
         const existing = await shikimori.getUserRate(accessToken, user.id, malId)
         const updatedRate = existing
-          ? await shikimori.updateUserRate(accessToken, existing.id, episodes, status, score)
-          : await shikimori.createUserRate(accessToken, user.id, malId, episodes, status, score)
+          ? await shikimori.updateUserRate(accessToken, existing.id, episodes, status, score, rewatches)
+          : await shikimori.createUserRate(accessToken, user.id, malId, episodes, status, score, rewatches)
 
         if (idx !== -1) {
           cached[idx] = {
@@ -3208,6 +3227,7 @@ function registerIpcHandlers(): void {
               score: updatedRate.score,
               status: updatedRate.status,
               episodes: updatedRate.episodes,
+              rewatches: updatedRate.rewatches ?? 0,
               updated_at: new Date().toISOString(),
               target_id: updatedRate.target_id
             }
@@ -3231,9 +3251,10 @@ function registerIpcHandlers(): void {
         const before = {
           episodes: cachedEntry.rate.episodes,
           status: cachedEntry.rate.status,
-          score: cachedEntry.rate.score
+          score: cachedEntry.rate.score,
+          rewatches: cachedEntry.rate.rewatches ?? 0
         }
-        const after = { episodes, status, score }
+        const after = { episodes, status, score, rewatches }
 
         const queue = store.get('shikimoriUpdateQueue') as QueuedShikimoriUpdate[]
         queue.push({ malId, rateId, before, after, queuedAt: Date.now() })
@@ -3246,6 +3267,7 @@ function registerIpcHandlers(): void {
             episodes,
             status,
             score,
+            rewatches,
             updated_at: new Date().toISOString()
           }
         }
@@ -3261,6 +3283,7 @@ function registerIpcHandlers(): void {
           score,
           status,
           episodes,
+          rewatches,
           target_id: malId,
           target_type: 'Anime'
         } satisfies shikimori.ShikiUserRate
@@ -3292,6 +3315,7 @@ function registerIpcHandlers(): void {
         score: rate.score,
         status: rate.status,
         episodes: rate.episodes,
+        rewatches: rate.rewatches ?? 0,
         updated_at: rate.updated_at,
         target_id: rate.target_id
       },

--- a/src/main/shikimori.ts
+++ b/src/main/shikimori.ts
@@ -26,6 +26,7 @@ export interface ShikiUserRate {
   score: number
   status: ShikiUserRateStatus
   episodes: number
+  rewatches: number
   target_id: number
   target_type: string
 }
@@ -35,6 +36,7 @@ export interface ShikiAnimeRateEntry {
   score: number
   status: ShikiUserRateStatus
   episodes: number
+  rewatches: number
   updated_at: string
   target_id: number
   target_type: string
@@ -170,7 +172,8 @@ export async function createUserRate(
   malId: number,
   episodes: number,
   status: ShikiUserRateStatus,
-  score: number
+  score: number,
+  rewatches: number
 ): Promise<ShikiUserRate> {
   const response = await shikiFetch('/api/v2/user_rates', {
     method: 'POST',
@@ -182,7 +185,8 @@ export async function createUserRate(
         target_type: 'Anime',
         episodes,
         status,
-        score
+        score,
+        rewatches
       }
     })
   })
@@ -194,13 +198,14 @@ export async function updateUserRate(
   rateId: number,
   episodes: number,
   status: ShikiUserRateStatus,
-  score: number
+  score: number,
+  rewatches: number
 ): Promise<ShikiUserRate> {
   const response = await shikiFetch(`/api/v2/user_rates/${rateId}`, {
     method: 'PATCH',
     headers: authHeaders(accessToken),
     body: JSON.stringify({
-      user_rate: { episodes, status, score }
+      user_rate: { episodes, status, score, rewatches }
     })
   })
   return response.json() as Promise<ShikiUserRate>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -294,8 +294,8 @@ const api = {
   shikimoriLogout: () => ipcRenderer.invoke('shikimori:logout'),
   shikimoriGetUser: () => ipcRenderer.invoke('shikimori:get-user'),
   shikimoriGetRate: (malId: number) => ipcRenderer.invoke('shikimori:get-rate', malId),
-  shikimoriUpdateRate: (malId: number, episodes: number, status: string, score: number) =>
-    ipcRenderer.invoke('shikimori:update-rate', malId, episodes, status, score),
+  shikimoriUpdateRate: (malId: number, episodes: number, status: string, score: number, rewatches: number) =>
+    ipcRenderer.invoke('shikimori:update-rate', malId, episodes, status, score, rewatches),
   shikimoriGetFriendsRates: (malId: number) =>
     ipcRenderer.invoke('shikimori:get-friends-rates', malId) as Promise<ShikiFriendRate[]>,
   shikimoriGetAnimeRates: (status?: string) =>

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -168,7 +168,7 @@ interface Api {
   shikimoriLogout: () => Promise<void>
   shikimoriGetUser: () => Promise<ShikiUser | null>
   shikimoriGetRate: (malId: number) => Promise<ShikiUserRate | null>
-  shikimoriUpdateRate: (malId: number, episodes: number, status: ShikiUserRateStatus, score: number) => Promise<ShikiUserRate>
+  shikimoriUpdateRate: (malId: number, episodes: number, status: ShikiUserRateStatus, score: number, rewatches: number) => Promise<ShikiUserRate>
   shikimoriGetFriendsRates: (malId: number) => Promise<ShikiFriendRate[]>
   shikimoriGetAnimeRates: (status?: string) => Promise<ShikiAnimeRateEntry[]>
   shikimoriGetFriendsActivity: () => Promise<ShikiFriendActivityEntry[]>
@@ -616,6 +616,7 @@ interface ShikiUserRate {
   score: number
   status: ShikiUserRateStatus
   episodes: number
+  rewatches: number
   target_id: number
   target_type: string
 }
@@ -638,6 +639,7 @@ interface ShikiAnimeRateEntry {
     score: number
     status: ShikiUserRateStatus
     episodes: number
+    rewatches: number
     updated_at: string
     target_id: number
   }

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -45,6 +45,7 @@ const shikiRate = ref<ShikiUserRate | null>(null)
 const shikiStatus = ref<ShikiUserRateStatus>('planned')
 const shikiEpisodes = ref(0)
 const shikiScore = ref(0)
+const shikiRewatches = ref(0)
 const shikiLoading = ref(false)
 const shikiSaving = ref(false)
 const shikiError = ref('')
@@ -372,6 +373,7 @@ async function loadShikimoriData(): Promise<void> {
         shikiStatus.value = rate.status
         shikiEpisodes.value = rate.episodes
         shikiScore.value = rate.score
+        shikiRewatches.value = rate.rewatches ?? 0
       }
     })
     .catch(err => console.error('Failed to load Shikimori rate:', err))
@@ -612,12 +614,14 @@ onMounted(async () => {
         score: entry.rate.score,
         status: entry.rate.status,
         episodes: entry.rate.episodes,
+        rewatches: entry.rate.rewatches ?? 0,
         target_id: entry.rate.target_id,
         target_type: 'Anime'
       }
       shikiStatus.value = entry.rate.status
       shikiEpisodes.value = entry.rate.episodes
       shikiScore.value = entry.rate.score
+      shikiRewatches.value = entry.rate.rewatches ?? 0
     }
   })
 
@@ -636,12 +640,14 @@ onMounted(async () => {
         score: match.rate.score,
         status: match.rate.status,
         episodes: match.rate.episodes,
+        rewatches: match.rate.rewatches ?? 0,
         target_id: match.rate.target_id,
         target_type: 'Anime'
       }
       shikiStatus.value = match.rate.status
       shikiEpisodes.value = match.rate.episodes
       shikiScore.value = match.rate.score
+      shikiRewatches.value = match.rate.rewatches ?? 0
     }
   })
 
@@ -731,9 +737,11 @@ async function shikiSave(): Promise<void> {
       anime.value.myAnimeListId,
       shikiEpisodes.value,
       shikiStatus.value,
-      shikiScore.value
+      shikiScore.value,
+      shikiRewatches.value
     )
     shikiRate.value = rate
+    shikiRewatches.value = rate.rewatches ?? shikiRewatches.value
   } catch (err) {
     shikiError.value = String(err)
   } finally {
@@ -920,12 +928,19 @@ function episodeProgressPercent(episodeInt: string): number {
 }
 
 function isEpisodeWatched(episodeInt: string): boolean {
+  if (shikiRate.value?.status === 'completed') return true
   return !!watchProgress.value[episodeInt]?.watched
 }
 
 const continueTarget = computed((): EpisodeSummary | null => {
   const eps = filteredEpisodes.value
   if (eps.length === 0) return null
+
+  // Completed → "Continue" means "start rewatching from ep 1". Without this the
+  // shikiEpisodes >= eps.length branch below would land on the last episode.
+  if (shikiRate.value?.status === 'completed') {
+    return eps[0]
+  }
 
   // 1) If Shikimori reports N completed episodes, jump to episode N+1.
   // Shikimori is authoritative — ignore local saved positions for earlier episodes.
@@ -1472,6 +1487,15 @@ function typeChip(type: string): { short: string; color: string } {
                 <option :value="0">—</option>
                 <option v-for="n in 10" :key="n" :value="n">{{ n }}</option>
               </select>
+            </div>
+            <div class="shiki-episodes" title="Number of times you've rewatched this anime">
+              <span>Rewatches:</span>
+              <input
+                v-model.number="shikiRewatches"
+                type="number"
+                min="0"
+                class="shiki-ep-input"
+              />
             </div>
             <button class="shiki-save-btn" :disabled="shikiSaving" @click="shikiSave">
               {{ shikiSaving ? 'Saving...' : 'Save' }}

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -581,9 +581,16 @@ async function markEpisodeWatched(episodeInt: string): Promise<void> {
   try {
     const rate = await window.api.shikimoriGetRate(props.malId)
     const currentEps = rate?.episodes ?? 0
-    if (epNum > currentEps) {
-      const nextStatus = rate?.status === 'completed' ? 'rewatching' : 'watching'
-      await window.api.shikimoriUpdateRate(props.malId, epNum, nextStatus, rate?.score ?? 0)
+    const score = rate?.score ?? 0
+    const rewatches = rate?.rewatches ?? 0
+    // Rewatching a completed show: flip status, reset episode count to the one
+    // just finished, bump the rewatch counter. Guarded once-per-watched event by
+    // the status check itself — after the flip, rate.status is 'rewatching' and
+    // this branch no longer fires.
+    if (rate?.status === 'completed') {
+      await window.api.shikimoriUpdateRate(props.malId, epNum, 'rewatching', score, rewatches + 1)
+    } else if (epNum > currentEps) {
+      await window.api.shikimoriUpdateRate(props.malId, epNum, 'watching', score, rewatches)
     }
   } catch (err) {
     console.warn('[player] failed to update Shikimori episode count:', err)
@@ -607,9 +614,12 @@ async function maybeMarkWatched(): Promise<void> {
   try {
     const rate = await window.api.shikimoriGetRate(props.malId)
     const currentEps = rate?.episodes ?? 0
-    if (epNum > currentEps) {
-      const nextStatus = rate?.status === 'completed' ? 'rewatching' : 'watching'
-      await window.api.shikimoriUpdateRate(props.malId, epNum, nextStatus, rate?.score ?? 0)
+    const score = rate?.score ?? 0
+    const rewatches = rate?.rewatches ?? 0
+    if (rate?.status === 'completed') {
+      await window.api.shikimoriUpdateRate(props.malId, epNum, 'rewatching', score, rewatches + 1)
+    } else if (epNum > currentEps) {
+      await window.api.shikimoriUpdateRate(props.malId, epNum, 'watching', score, rewatches)
     }
   } catch (err) {
     console.warn('[player] failed to update Shikimori episode count:', err)


### PR DESCRIPTION
## Summary

Adds first-class support for **re-watching** anime via Shikimori, exposes the **`rewatches`** counter throughout the app, and stops marked-completed shows from clogging the Home "Continue Watching" feed.

Fixes #82.

## Changes

**Shikimori API (`src/main/shikimori.ts`)**
- `ShikiUserRate` / `ShikiAnimeRateEntry` gain a `rewatches: number` field.
- `createUserRate` / `updateUserRate` accept and forward `rewatches` on the v2 `user_rates` POST/PATCH bodies.

**Main process (`src/main/index.ts`)**
- `shikimori:update-rate` IPC accepts a 5th `rewatches` argument; threaded through the cached entry, offline queue (`QueuedShikimoriUpdate.before/after`), `reconcileCacheFromRate`, the consolidating sync worker, and `fetchAndCacheShikimoriRates` so the field round-trips end-to-end.
- `home:get-continue-watching` builds a `statusByAnimeId` map from cached Shikimori rates and drops "Resume" rows whose status is `completed` — finished shows with lingering partial-watch progress no longer surface on Home.

**Preload (`src/preload/{index,types.d}.ts`)**
- `shikimoriUpdateRate` signature gains `rewatches: number`.
- Shared `ShikiUserRate` / `ShikiAnimeRateEntry.rate` types include `rewatches`.

**AnimeDetailView (`src/renderer/src/components/AnimeDetailView.vue`)**
- New numeric **Rewatches** input alongside Episodes / Score, bound to `shikiRewatches`; hydrated from rate on initial load, `shikimori:rate-updated`, and `shikimori:rates-refreshed`.
- `isEpisodeWatched` returns `true` for every episode whenever `rate.status === 'completed'` (regardless of local `watchProgress`).
- `continueTarget` jumps to episode 1 for completed shows so "Continue" becomes "start rewatching" instead of landing on the final episode.
- `shikiSave` forwards `shikiRewatches.value` and reconciles back from the server response.

**PlayerView (`src/renderer/src/components/PlayerView.vue`)**
- `maybeMarkWatched` and `markEpisodeWatched`: when the current rate is `completed`, the player flips the status to `rewatching`, resets `episodes` to the just-watched episode, and increments `rewatches` by 1. Otherwise the existing `epNum > currentEps` guard still applies and `rewatches` is preserved. The status check itself prevents double-bumps within and across sessions — after the flip, the show is no longer `completed`, so the branch doesn't fire again.

**Docs (`DESIGN.md`)**
- Documents the new `rewatches` field, the AnimeDetailView panel changes, the PlayerView completed→rewatching transition, and the Home filter rule.

## Test plan

- [x] `npm run typecheck` — clean
- [x] Manual: Home "Continue Watching" drops Resume rows for completed shows
- [x] Manual: AnimeDetailView shows ✓ on every episode of a completed show; "Continue" lands on ep 1
- [x] Manual: starting ep 1 of a completed show flips status to `rewatching` and bumps `rewatches`
- [x] Manual: editing the Rewatches input + Save persists to Shikimori
- [ ] Offline path: \`Working offline\` chip queues a rewatches edit; sync worker drains it on reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)