### PR TITLE
Phase 1b: shared IPC channel contract (#84)

### DIFF
--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -1,0 +1,250 @@
+// Single source of truth for IPC channel names (epic #84, decision 1).
+//
+// Channel names live here once, as an `as const` object, and are dereferenced
+// by symbol on both sides of the boundary — `main` registers handlers against
+// these constants and `preload` builds `window.api` from them (wired in the
+// Phase 1c slice). A rename becomes a compile error instead of a silent miss,
+// retiring the error-prone "update the same string literal in 4 files" rule.
+//
+// This module is intentionally additive: nothing imports it yet, so Phase 1b
+// is behavior-identical. The literals below are the exhaustive set extracted
+// from the existing `src/main/index.ts` + `src/preload/index.ts` (verified by
+// test/ipc-channels.test.ts).
+
+/**
+ * Request/response channels — renderer `ipcRenderer.invoke` (or fire-and-forget
+ * `send`) handled by a single `ipcMain.handle`/`ipcMain.on` in main.
+ */
+export const CHANNELS = {
+  // App
+  APP_VERSION: 'app:version',
+
+  // Updates
+  UPDATE_CHECK: 'update:check',
+  UPDATE_DOWNLOAD: 'update:download',
+  UPDATE_INSTALL: 'update:install',
+
+  // Auto-downloader
+  AUTO_DL_GET_ENABLED: 'auto-dl:get-enabled',
+  AUTO_DL_GET_STATUS: 'auto-dl:get-status',
+  AUTO_DL_GET_SUBSCRIPTION: 'auto-dl:get-subscription',
+  AUTO_DL_LIST_SUBSCRIPTIONS: 'auto-dl:list-subscriptions',
+  AUTO_DL_SET_ENABLED: 'auto-dl:set-enabled',
+  AUTO_DL_SET_SUBSCRIPTION: 'auto-dl:set-subscription',
+  AUTO_DL_TRIGGER: 'auto-dl:trigger',
+
+  // Cleanup
+  CLEANUP_EXECUTE: 'cleanup:execute',
+  CLEANUP_GET_ACTIVE_DOWNLOADS: 'cleanup:get-active-downloads',
+  CLEANUP_GET_SIZE: 'cleanup:get-size',
+  CLEANUP_GET_SNOOZED: 'cleanup:get-snoozed',
+  CLEANUP_SET_SNOOZED: 'cleanup:set-snoozed',
+
+  // Debug
+  DEBUG_GET_MP4_STATS: 'debug:get-mp4-stats',
+  DEBUG_RESET_MP4_STATS: 'debug:reset-mp4-stats',
+
+  // Downloads
+  DOWNLOAD_CANCEL: 'download:cancel',
+  DOWNLOAD_CANCEL_BY_EPISODE: 'download:cancel-by-episode',
+  DOWNLOAD_CANCEL_MERGE: 'download:cancel-merge',
+  DOWNLOAD_CLEAR_COMPLETED: 'download:clear-completed',
+  DOWNLOAD_ENQUEUE: 'download:enqueue',
+  DOWNLOAD_FIX_METADATA: 'download:fix-metadata',
+  DOWNLOAD_GET_QUEUE: 'download:get-queue',
+  DOWNLOAD_INJECT_CHAPTERS: 'download:inject-chapters',
+  DOWNLOAD_MERGE: 'download:merge',
+  DOWNLOAD_PAUSE: 'download:pause',
+  DOWNLOAD_PAUSE_ALL: 'download:pause-all',
+  DOWNLOAD_PICK_DIR: 'download:pick-dir',
+  DOWNLOAD_RESTART: 'download:restart',
+  DOWNLOAD_RESTART_ALL_FAILED: 'download:restart-all-failed',
+  DOWNLOAD_RESUME: 'download:resume',
+  DOWNLOAD_RESUME_ALL: 'download:resume-all',
+  DOWNLOAD_SCAN_MERGE: 'download:scan-merge',
+
+  // ffmpeg
+  FFMPEG_CHECK: 'ffmpeg:check',
+  FFMPEG_DELETE: 'ffmpeg:delete',
+
+  // File management
+  FILE_CHECK_EPISODES: 'file:check-episodes',
+  FILE_DELETE_EPISODE: 'file:delete-episode',
+  FILE_OPEN: 'file:open',
+  FILE_SHOW_IN_FOLDER: 'file:show-in-folder',
+
+  // Home
+  HOME_GET_CONTINUE_WATCHING: 'home:get-continue-watching',
+
+  // Player
+  PLAYER_CLEANUP_REMUX: 'player:cleanup-remux',
+  PLAYER_FIND_LOCAL_FILE: 'player:find-local-file',
+  PLAYER_GET_LOCAL_SUBTITLES: 'player:get-local-subtitles',
+  PLAYER_GET_STREAM_URL: 'player:get-stream-url',
+  PLAYER_REMUX_MKV: 'player:remux-mkv',
+  PLAYER_REMUX_MKV_STREAM: 'player:remux-mkv-stream',
+  PLAYER_REMUX_MKV_STREAM_TRANSCODE: 'player:remux-mkv-stream-transcode',
+  PLAYER_STREAM_ACK: 'player:stream-ack',
+  PLAYER_STREAM_SEEK: 'player:stream-seek',
+  PLAYER_STREAM_START: 'player:stream-start',
+
+  // Shell
+  SHELL_OPEN_EXTERNAL: 'shell:open-external',
+  SHELL_OPEN_EXTERNAL_FILE: 'shell:open-external-file',
+
+  // Shikimori
+  SHIKIMORI_EXCHANGE_CODE: 'shikimori:exchange-code',
+  SHIKIMORI_GET_ANIME_DETAILS: 'shikimori:get-anime-details',
+  SHIKIMORI_GET_ANIME_RATES: 'shikimori:get-anime-rates',
+  SHIKIMORI_GET_AUTH_URL: 'shikimori:get-auth-url',
+  SHIKIMORI_GET_CALENDAR: 'shikimori:get-calendar',
+  SHIKIMORI_GET_FRIENDS_ACTIVITY: 'shikimori:get-friends-activity',
+  SHIKIMORI_GET_FRIENDS_RATES: 'shikimori:get-friends-rates',
+  SHIKIMORI_GET_OFFLINE_QUEUE_LENGTH: 'shikimori:get-offline-queue-length',
+  SHIKIMORI_GET_RATE: 'shikimori:get-rate',
+  SHIKIMORI_GET_RELATED: 'shikimori:get-related',
+  SHIKIMORI_GET_SYNC_STATUS: 'shikimori:get-sync-status',
+  SHIKIMORI_GET_USER: 'shikimori:get-user',
+  SHIKIMORI_LOGOUT: 'shikimori:logout',
+  SHIKIMORI_TRIGGER_DETAIL_PREFETCH: 'shikimori:trigger-detail-prefetch',
+  SHIKIMORI_TRIGGER_SYNC: 'shikimori:trigger-sync',
+  SHIKIMORI_UPDATE_RATE: 'shikimori:update-rate',
+
+  // Skip detection
+  SKIP_DETECTOR_ANALYZE_SHOW: 'skip-detector:analyze-show',
+  SKIP_DETECTOR_BACKFILL_ALL: 'skip-detector:backfill-all',
+  SKIP_DETECTOR_CACHE_STATS: 'skip-detector:cache-stats',
+  SKIP_DETECTOR_CANCEL: 'skip-detector:cancel',
+  SKIP_DETECTOR_CANCEL_STREAM_DETECT: 'skip-detector:cancel-stream-detect',
+  SKIP_DETECTOR_DETECT_STREAM: 'skip-detector:detect-stream',
+  SKIP_DETECTOR_GET_DETECTIONS: 'skip-detector:get-detections',
+  SKIP_DETECTOR_GET_STATUS: 'skip-detector:get-status',
+  SKIP_DETECTOR_QUEUE_STATUS: 'skip-detector:queue-status',
+
+  // Storage
+  STORAGE_GET_USAGE: 'storage:get-usage',
+  STORAGE_MOVE_TO_COLD: 'storage:move-to-cold',
+  STORAGE_PICK_COLD_DIR: 'storage:pick-cold-dir',
+  STORAGE_PICK_HOT_DIR: 'storage:pick-hot-dir',
+  STORAGE_RUN_CLEANUP: 'storage:run-cleanup',
+
+  // Syncplay
+  SYNCPLAY_CONNECT: 'syncplay:connect',
+  SYNCPLAY_DISCONNECT: 'syncplay:disconnect',
+  SYNCPLAY_GET_STATUS: 'syncplay:get-status',
+  SYNCPLAY_LOCAL_SNAPSHOT: 'syncplay:local-snapshot',
+  SYNCPLAY_LOCAL_STATE: 'syncplay:local-state',
+  SYNCPLAY_SET_FILE: 'syncplay:set-file',
+  SYNCPLAY_SET_READY: 'syncplay:set-ready',
+
+  // Watch progress
+  WATCH_PROGRESS_GET: 'watch-progress:get',
+  WATCH_PROGRESS_GET_ALL: 'watch-progress:get-all',
+  WATCH_PROGRESS_SAVE: 'watch-progress:save',
+
+  // Core / legacy un-namespaced
+  CACHE_GET_POSTER: 'cache-get-poster',
+  DOWNLOADED_ANIME_ADD: 'downloaded-anime-add',
+  DOWNLOADED_ANIME_DELETE: 'downloaded-anime-delete',
+  DOWNLOADED_EPISODES_GET: 'downloaded-episodes-get',
+  DUMP_QUALITY_MISMATCHES: 'dump-quality-mismatches',
+  GET_ANIME: 'get-anime',
+  GET_ANIME_CACHE: 'get-anime-cache',
+  GET_EPISODE: 'get-episode',
+  GET_QUALITY_MISMATCH_COUNT: 'get-quality-mismatch-count',
+  GET_SETTING: 'get-setting',
+  LIBRARY_GET: 'library-get',
+  LIBRARY_GET_STATUS: 'library-get-status',
+  LIBRARY_HAS: 'library-has',
+  LIBRARY_IS_DOWNLOADED: 'library-is-downloaded',
+  LIBRARY_TOGGLE: 'library-toggle',
+  PROBE_EMBED_QUALITY: 'probe-embed-quality',
+  PROBE_FULL_SCAN_DONE: 'probe-full-scan-done',
+  PROBE_FULL_SCAN_NEEDED: 'probe-full-scan-needed',
+  REPORT_QUALITY_MISMATCH: 'report-quality-mismatch',
+  SEARCH_ANIME: 'search-anime',
+  SET_ANIME_CACHE: 'set-anime-cache',
+  SET_SETTING: 'set-setting',
+  VALIDATE_TOKEN: 'validate-token'
+} as const
+
+/**
+ * Broadcast channels — main `webContents.send`, observed by the renderer.
+ * Their subscriptions must follow {@link EventSubscriber} (epic #84, decision 2).
+ */
+export const EVENT_CHANNELS = {
+  // Updates
+  UPDATE_STATUS: 'update:status',
+
+  // Auto-downloader
+  AUTO_DL_ENQUEUED: 'auto-dl:enqueued',
+  AUTO_DL_TICK_RESULT: 'auto-dl:tick-result',
+
+  // Cleanup
+  CLEANUP_PROMPT: 'cleanup:prompt',
+
+  // Downloads
+  DOWNLOAD_PROGRESS: 'download:progress',
+
+  // ffmpeg
+  FFMPEG_DOWNLOAD_PROGRESS: 'ffmpeg:download-progress',
+
+  // fpcalc
+  FPCALC_DOWNLOAD_PROGRESS: 'fpcalc:download-progress',
+
+  // Fix metadata
+  FIX_METADATA_PROGRESS: 'fix-metadata:progress',
+
+  // Scan-merge
+  SCAN_MERGE_PROGRESS: 'scan-merge:progress',
+
+  // Chapter injection
+  CHAPTER_INJECT_PROGRESS: 'chapter-inject:progress',
+
+  // File management
+  FILE_EPISODES_CHANGED: 'file:episodes-changed',
+
+  // Player
+  PLAYER_STREAM_CHUNK: 'player:stream-chunk',
+  PLAYER_STREAM_END: 'player:stream-end',
+  PLAYER_STREAM_ERROR: 'player:stream-error',
+  PLAYER_STREAM_PROGRESS: 'player:stream-progress',
+  PLAYER_STREAM_SUBTITLES: 'player:stream-subtitles',
+
+  // Shikimori
+  SHIKIMORI_ANIME_DETAILS_UPDATED: 'shikimori:anime-details-updated',
+  SHIKIMORI_OFFLINE_QUEUE_CHANGED: 'shikimori:offline-queue-changed',
+  SHIKIMORI_RATE_UPDATED: 'shikimori:rate-updated',
+  SHIKIMORI_RATES_REFRESHED: 'shikimori:rates-refreshed',
+  SHIKIMORI_SYNC_STATUS: 'shikimori:sync-status',
+
+  // Skip detection
+  SKIP_DETECTOR_ANALYZE_PROGRESS: 'skip-detector:analyze-progress',
+  SKIP_DETECTOR_SIGNATURE_UPDATED: 'skip-detector:signature-updated',
+
+  // Storage
+  STORAGE_CLEANUP_FINISHED: 'storage:cleanup-finished',
+  STORAGE_CLEANUP_PENDING: 'storage:cleanup-pending',
+  STORAGE_MOVE_TO_COLD_PROGRESS: 'storage:move-to-cold-progress',
+  STORAGE_USAGE_PROGRESS: 'storage:usage-progress'
+} as const
+
+export type RequestChannel = (typeof CHANNELS)[keyof typeof CHANNELS]
+export type EventChannel = (typeof EVENT_CHANNELS)[keyof typeof EVENT_CHANNELS]
+
+/**
+ * Handle returned by every broadcast subscription. Calling it removes **only
+ * the listener it was created for** — never `removeAllListeners` (epic #84,
+ * decision 2), so independent subscribers on the same channel don't clobber
+ * each other and nothing leaks if a caller forgets to unsubscribe before the
+ * next subscribe.
+ */
+export type Unsubscribe = () => void
+
+/**
+ * Contract for a broadcast-channel subscription on `window.api`. Phase 1c
+ * replaces the ad-hoc `on*`/`off*` pairs with functions of this shape;
+ * renderer owners bind the returned {@link Unsubscribe} to `onUnmounted`
+ * or a Pinia store's disposal (Phase 4).
+ */
+export type EventSubscriber<T> = (listener: (payload: T) => void) => Unsubscribe

--- a/test/ipc-channels.test.ts
+++ b/test/ipc-channels.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { CHANNELS, EVENT_CHANNELS } from '../src/shared/ipc/channels'
+
+// Re-derive the channel literals straight from the production source so the
+// contract can't silently drift: if someone adds/renames an ipc channel in
+// main or preload without updating channels.ts, this fails.
+function scan() {
+  const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+  const sources = read('src/main/index.ts') + '\n' + read('src/preload/index.ts')
+
+  const reqRe =
+    /(?:ipcMain\.(?:handle|on)|ipcRenderer\.(?:invoke|send))\(\s*[`'"]([a-z][\w:-]+)[`'"]/g
+  const evtRe =
+    /(?:webContents\.send|ipcRenderer\.(?:on|removeListener|removeAllListeners))\(\s*[`'"]([a-z][\w:-]+)[`'"]/g
+
+  const request = new Set<string>()
+  const event = new Set<string>()
+  let m: RegExpExecArray | null
+  while ((m = reqRe.exec(sources))) request.add(m[1])
+  while ((m = evtRe.exec(sources))) event.add(m[1])
+  // A channel that is broadcast is an event, not a request.
+  for (const c of event) request.delete(c)
+  return { request, event }
+}
+
+describe('IPC channel contract', () => {
+  const requestValues = Object.values(CHANNELS)
+  const eventValues = Object.values(EVENT_CHANNELS)
+
+  it('has no duplicate literals', () => {
+    const all = [...requestValues, ...eventValues]
+    expect(new Set(all).size).toBe(all.length)
+  })
+
+  it('keeps request and event channels disjoint', () => {
+    const ev = new Set<string>(eventValues)
+    expect(requestValues.filter((c) => ev.has(c))).toEqual([])
+  })
+
+  it('uses a SCREAMING_SNAKE key derived from each channel name', () => {
+    for (const [key, value] of Object.entries(CHANNELS)) {
+      expect(key).toBe(value.replace(/[:-]/g, '_').toUpperCase())
+    }
+    for (const [key, value] of Object.entries(EVENT_CHANNELS)) {
+      expect(key).toBe(value.replace(/[:-]/g, '_').toUpperCase())
+    }
+  })
+
+  it('exhaustively mirrors the channels used in main + preload', () => {
+    const { request, event } = scan()
+    expect([...request].sort()).toEqual([...requestValues].sort())
+    expect([...event].sort()).toEqual([...eventValues].sort())
+  })
+})


### PR DESCRIPTION
## Summary

Second slice of **Phase 1** (#84). **Purely additive — nothing imports the new module yet, so behavior is byte-identical.** Introduces the single source of truth for IPC channel names (epic decision 1) and the disposable-subscription contract (epic decision 2).

> ⚠️ **Stacked on #86 (Phase 1a).** Base is `phase-1a-shared-types` so the diff is clean. I'll rebase onto `main` and retarget to `main` once #86 merges.

## Changes

- **New `src/shared/ipc/channels.ts`:**
  - `CHANNELS` (`as const`) — all **117** request/response channel names, domain-grouped, with `SCREAMING_SNAKE` keys deterministically derived from each literal.
  - `EVENT_CHANNELS` (`as const`) — all **27** broadcast channel names.
  - `RequestChannel` / `EventChannel` union types.
  - `Unsubscribe` + `EventSubscriber<T>` — the subscription contract slice 1c implements (returns a disposer that removes **only its own** listener; never `removeAllListeners`).
- **New `test/ipc-channels.test.ts`** — re-derives the channel set directly from `src/main/index.ts` + `src/preload/index.ts` and asserts the contract mirrors it **exactly** (drift guard), literals are unique, request/event are disjoint, and every key matches the derivation rule.

## Why this is behavior-identical

`channels.ts` is a new module imported by nothing in `main`/`preload`/`renderer`, so it's absent from the build graph and changes no runtime path. It only adds type-checked surface. Wiring `main` to register against `CHANNELS` and regenerating `preload` from it is the deliberately-separate, higher-risk **slice 1c**.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds (module not in graph)
- [x] `npm run test` — 7 tests green (incl. the exhaustive-mirror check: contract == channels actually used in main+preload)
- [ ] CI `quality` job — verify on this PR

Part of #84 (Phase 1, slice 1b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)