### PR TITLE
Phase 1c: wire main + preload to the IPC contract (#84)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, shell, BrowserWindow, ipcMain, dialog, Notification, protocol, net } from 'electron'
+import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
 import Store from 'electron-store'
@@ -949,7 +950,7 @@ async function backgroundRescan(animeName: string): Promise<void> {
   if (newJson !== cachedJson) {
     fileCheckCache.set(animeName, result)
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('file:episodes-changed', animeName, result)
+      win.webContents.send(EVENT_CHANNELS.FILE_EPISODES_CHANGED, animeName, result)
     }
   }
 }
@@ -1083,7 +1084,7 @@ function ensureFfmpeg(win?: BrowserWindow): Promise<string> {
 
   const sendProgress = (status: string, progress?: number): void => {
     if (win && !win.isDestroyed()) {
-      win.webContents.send('ffmpeg:download-progress', { status, progress })
+      win.webContents.send(EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS, { status, progress })
     }
   }
 
@@ -2304,14 +2305,14 @@ function dropSkipDetectionsForEpisode(animeId: number, episodeInt: string): bool
 }
 
 function registerIpcHandlers(): void {
-  ipcMain.handle('app:version', () => app.getVersion())
+  ipcMain.handle(CHANNELS.APP_VERSION, () => app.getVersion())
 
-  ipcMain.handle('update:check', async () => {
+  ipcMain.handle(CHANNELS.UPDATE_CHECK, async () => {
     try {
       const result = await autoUpdater.checkForUpdates()
       if (!result) {
         for (const win of BrowserWindow.getAllWindows()) {
-          win.webContents.send('update:status', {
+          win.webContents.send(EVENT_CHANNELS.UPDATE_STATUS, {
             status: 'error',
             error: 'Update check not available in development mode'
           })
@@ -2319,7 +2320,7 @@ function registerIpcHandlers(): void {
       }
     } catch (err) {
       for (const win of BrowserWindow.getAllWindows()) {
-        win.webContents.send('update:status', {
+        win.webContents.send(EVENT_CHANNELS.UPDATE_STATUS, {
           status: 'error',
           error: err instanceof Error ? err.message : String(err)
         })
@@ -2327,12 +2328,12 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('update:download', async () => {
+  ipcMain.handle(CHANNELS.UPDATE_DOWNLOAD, async () => {
     try {
       await autoUpdater.downloadUpdate()
     } catch (err) {
       for (const win of BrowserWindow.getAllWindows()) {
-        win.webContents.send('update:status', {
+        win.webContents.send(EVENT_CHANNELS.UPDATE_STATUS, {
           status: 'error',
           error: err instanceof Error ? err.message : String(err)
         })
@@ -2340,17 +2341,17 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('update:install', () => {
+  ipcMain.handle(CHANNELS.UPDATE_INSTALL, () => {
     autoUpdater.quitAndInstall()
   })
 
-  ipcMain.handle('validate-token', () => smotretApi.validateToken())
+  ipcMain.handle(CHANNELS.VALIDATE_TOKEN, () => smotretApi.validateToken())
 
-  ipcMain.handle('search-anime', async (_event, query: string) => {
+  ipcMain.handle(CHANNELS.SEARCH_ANIME, async (_event, query: string) => {
     return smotretApi.searchAnime(query)
   })
 
-  ipcMain.handle('get-anime', async (_event, id: number) => {
+  ipcMain.handle(CHANNELS.GET_ANIME, async (_event, id: number) => {
     try {
       const result = await smotretApi.getAnime(id)
       updateAnimeDetailCache(id, result.data)
@@ -2365,32 +2366,38 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('probe-embed-quality', async (_event, translationId: number, animeId?: number) => {
-    try {
-      const embed = await smotretApi.getEmbed(translationId)
-      const streams = embed.stream || []
-      if (streams.length === 0) return null
-      const best = streams.reduce((a, b) => (a.height > b.height ? a : b))
-      if (animeId) updateQualityProbeCache(animeId, translationId, best.height)
-      return best.height
-    } catch {
-      if (animeId) {
-        const cached = getCacheEntry(animeId)
-        return cached?.qualityProbes[translationId] ?? null
+  ipcMain.handle(
+    CHANNELS.PROBE_EMBED_QUALITY,
+    async (_event, translationId: number, animeId?: number) => {
+      try {
+        const embed = await smotretApi.getEmbed(translationId)
+        const streams = embed.stream || []
+        if (streams.length === 0) return null
+        const best = streams.reduce((a, b) => (a.height > b.height ? a : b))
+        if (animeId) updateQualityProbeCache(animeId, translationId, best.height)
+        return best.height
+      } catch {
+        if (animeId) {
+          const cached = getCacheEntry(animeId)
+          return cached?.qualityProbes[translationId] ?? null
+        }
+        return null
       }
-      return null
     }
-  })
+  )
 
-  ipcMain.handle('probe-full-scan-needed', (_event, animeId: number, episodeCount: number) => {
-    const entry = getCacheEntry(animeId)
-    if (!entry?.fullProbeAt) return true
-    if (entry.fullProbeEpisodeCount !== episodeCount) return true
-    const weekMs = 7 * 24 * 60 * 60 * 1000
-    return Date.now() - entry.fullProbeAt > weekMs
-  })
+  ipcMain.handle(
+    CHANNELS.PROBE_FULL_SCAN_NEEDED,
+    (_event, animeId: number, episodeCount: number) => {
+      const entry = getCacheEntry(animeId)
+      if (!entry?.fullProbeAt) return true
+      if (entry.fullProbeEpisodeCount !== episodeCount) return true
+      const weekMs = 7 * 24 * 60 * 60 * 1000
+      return Date.now() - entry.fullProbeAt > weekMs
+    }
+  )
 
-  ipcMain.handle('probe-full-scan-done', (_event, animeId: number, episodeCount: number) => {
+  ipcMain.handle(CHANNELS.PROBE_FULL_SCAN_DONE, (_event, animeId: number, episodeCount: number) => {
     const entry = getCacheEntry(animeId)
     if (!entry) return
     entry.fullProbeAt = Date.now()
@@ -2404,7 +2411,7 @@ function registerIpcHandlers(): void {
   >()
 
   ipcMain.handle(
-    'report-quality-mismatch',
+    CHANNELS.REPORT_QUALITY_MISMATCH,
     (
       _event,
       data: {
@@ -2419,20 +2426,20 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('get-quality-mismatch-count', () => {
+  ipcMain.handle(CHANNELS.GET_QUALITY_MISMATCH_COUNT, () => {
     return qualityMismatches.size
   })
 
-  ipcMain.handle('debug:get-mp4-stats', () => {
+  ipcMain.handle(CHANNELS.DEBUG_GET_MP4_STATS, () => {
     return store.get('mp4StreamingStats') as Mp4StreamingStats
   })
 
-  ipcMain.handle('debug:reset-mp4-stats', () => {
+  ipcMain.handle(CHANNELS.DEBUG_RESET_MP4_STATS, () => {
     store.set('mp4StreamingStats', { totalChecked: 0, faststartCount: 0, nonFaststartSamples: [] })
     mp4FaststartChecked.clear()
   })
 
-  ipcMain.handle('dump-quality-mismatches', () => {
+  ipcMain.handle(CHANNELS.DUMP_QUALITY_MISMATCHES, () => {
     const outPath = path.join(getDownloadDir(), 'quality-mismatches.json')
     const data = [...qualityMismatches.values()]
     fs.mkdirSync(path.dirname(outPath), { recursive: true })
@@ -2441,7 +2448,7 @@ function registerIpcHandlers(): void {
     return { count: data.length, path: outPath }
   })
 
-  ipcMain.handle('get-episode', async (_event, id: number, animeId?: number) => {
+  ipcMain.handle(CHANNELS.GET_EPISODE, async (_event, id: number, animeId?: number) => {
     try {
       const result = await smotretApi.getEpisode(id)
       if (animeId) updateEpisodeCache(animeId, id, result.data)
@@ -2457,7 +2464,7 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('library-get', () => {
+  ipcMain.handle(CHANNELS.LIBRARY_GET, () => {
     const lib = store.get('library') as Record<string, AnimeSearchResult>
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     const merged = new Map<string, AnimeSearchResult>()
@@ -2468,12 +2475,12 @@ function registerIpcHandlers(): void {
     return [...merged.values()]
   })
 
-  ipcMain.handle('library-is-downloaded', (_event, id: number) => {
+  ipcMain.handle(CHANNELS.LIBRARY_IS_DOWNLOADED, (_event, id: number) => {
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     return !!downloaded[String(id)]
   })
 
-  ipcMain.handle('library-toggle', (_event, anime: AnimeSearchResult) => {
+  ipcMain.handle(CHANNELS.LIBRARY_TOGGLE, (_event, anime: AnimeSearchResult) => {
     const lib = store.get('library') as Record<string, AnimeSearchResult>
     const key = String(anime.id)
     if (lib[key]) {
@@ -2488,25 +2495,25 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('get-anime-cache', (_event, id: number) => {
+  ipcMain.handle(CHANNELS.GET_ANIME_CACHE, (_event, id: number) => {
     const entry = getCacheEntry(id)
     if (!entry?.animeDetail || !entry.cachedAt) return null
     if (Date.now() - entry.cachedAt > ANIME_DETAIL_CACHE_TTL_MS) return null
     return { data: entry.animeDetail, cachedAt: entry.cachedAt }
   })
 
-  ipcMain.handle('set-anime-cache', (_event, id: number, data: AnimeDetail) => {
+  ipcMain.handle(CHANNELS.SET_ANIME_CACHE, (_event, id: number, data: AnimeDetail) => {
     if (!isCachableAnime(id)) return false
     updateAnimeDetailCache(id, data)
     return true
   })
 
-  ipcMain.handle('library-has', (_event, id: number) => {
+  ipcMain.handle(CHANNELS.LIBRARY_HAS, (_event, id: number) => {
     const lib = store.get('library') as Record<string, AnimeSearchResult>
     return !!lib[String(id)]
   })
 
-  ipcMain.handle('library-get-status', (_event, ids: number[]) => {
+  ipcMain.handle(CHANNELS.LIBRARY_GET_STATUS, (_event, ids: number[]) => {
     const lib = store.get('library') as Record<string, AnimeSearchResult>
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     const result: Record<number, { starred: boolean; downloaded: boolean }> = {}
@@ -2517,7 +2524,7 @@ function registerIpcHandlers(): void {
     return result
   })
 
-  ipcMain.handle('home:get-continue-watching', async () => {
+  ipcMain.handle(CHANNELS.HOME_GET_CONTINUE_WATCHING, async () => {
     const lib = store.get('library') as Record<string, AnimeSearchResult>
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     const malMap = store.get('malIdMap') as Record<string, AnimeSearchResult>
@@ -2806,13 +2813,13 @@ function registerIpcHandlers(): void {
     return out.slice(0, 24)
   })
 
-  ipcMain.handle('downloaded-anime-add', (_event, anime: AnimeSearchResult) => {
+  ipcMain.handle(CHANNELS.DOWNLOADED_ANIME_ADD, (_event, anime: AnimeSearchResult) => {
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     downloaded[String(anime.id)] = anime
     store.set('downloadedAnime', downloaded)
   })
 
-  ipcMain.handle('downloaded-anime-delete', (_event, animeId: number, animeName: string) => {
+  ipcMain.handle(CHANNELS.DOWNLOADED_ANIME_DELETE, (_event, animeId: number, animeName: string) => {
     // Remove from store
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     delete downloaded[String(animeId)]
@@ -2838,17 +2845,17 @@ function registerIpcHandlers(): void {
     dropSkipDetectionsForAnime(animeId)
   })
 
-  ipcMain.handle('cleanup:get-size', async (_event, _animeId: number, animeName: string) => {
+  ipcMain.handle(CHANNELS.CLEANUP_GET_SIZE, async (_event, _animeId: number, animeName: string) => {
     return await sumShowFiles(animeName)
   })
 
-  ipcMain.handle('cleanup:get-active-downloads', (_event, animeName: string) => {
+  ipcMain.handle(CHANNELS.CLEANUP_GET_ACTIVE_DOWNLOADS, (_event, animeName: string) => {
     const groups = downloadManager.getEpisodeGroups()
     const active = groups.filter((g) => g.animeName === animeName).length
     return { active }
   })
 
-  ipcMain.handle('cleanup:execute', (_event, animeId: number, animeName: string) => {
+  ipcMain.handle(CHANNELS.CLEANUP_EXECUTE, (_event, animeId: number, animeName: string) => {
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     delete downloaded[String(animeId)]
     store.set('downloadedAnime', downloaded)
@@ -2883,7 +2890,7 @@ function registerIpcHandlers(): void {
     dropSkipDetectionsForAnime(animeId)
   })
 
-  ipcMain.handle('cleanup:get-snoozed', () => {
+  ipcMain.handle(CHANNELS.CLEANUP_GET_SNOOZED, () => {
     const snoozed = store.get('autoCleanupSnoozedAnimeIds') as Record<string, true>
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     const lib = store.get('library') as Record<string, AnimeSearchResult>
@@ -2896,7 +2903,7 @@ function registerIpcHandlers(): void {
     return out
   })
 
-  ipcMain.handle('cleanup:set-snoozed', (_event, animeId: number, snoozed: boolean) => {
+  ipcMain.handle(CHANNELS.CLEANUP_SET_SNOOZED, (_event, animeId: number, snoozed: boolean) => {
     const map = store.get('autoCleanupSnoozedAnimeIds') as Record<string, true>
     const key = String(animeId)
     if (snoozed) {
@@ -2907,18 +2914,18 @@ function registerIpcHandlers(): void {
     store.set('autoCleanupSnoozedAnimeIds', map)
   })
 
-  ipcMain.handle('get-setting', (_event, key: string) => {
+  ipcMain.handle(CHANNELS.GET_SETTING, (_event, key: string) => {
     if (key === 'downloadDir') return getDownloadDir()
     return store.get(key)
   })
 
-  ipcMain.handle('set-setting', (_event, key: string, value: unknown) => {
+  ipcMain.handle(CHANNELS.SET_SETTING, (_event, key: string, value: unknown) => {
     store.set(key, value)
   })
 
   // Watch progress tracking
   ipcMain.handle(
-    'watch-progress:save',
+    CHANNELS.WATCH_PROGRESS_SAVE,
     (
       _event,
       animeId: number,
@@ -2955,7 +2962,7 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('watch-progress:get', (_event, animeId: number, episodeInt: string) => {
+  ipcMain.handle(CHANNELS.WATCH_PROGRESS_GET, (_event, animeId: number, episodeInt: string) => {
     const all = store.get('watchProgress') as Record<
       string,
       {
@@ -2970,7 +2977,7 @@ function registerIpcHandlers(): void {
     return all[`${animeId}:${episodeInt}`] || null
   })
 
-  ipcMain.handle('watch-progress:get-all', (_event, animeId: number) => {
+  ipcMain.handle(CHANNELS.WATCH_PROGRESS_GET_ALL, (_event, animeId: number) => {
     const all = store.get('watchProgress') as Record<
       string,
       {
@@ -3003,38 +3010,38 @@ function registerIpcHandlers(): void {
   })
 
   // Download handlers
-  ipcMain.handle('download:enqueue', async (_event, requests: DownloadRequest[]) => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_ENQUEUE, async (_event, requests: DownloadRequest[]) => {
     await downloadManager.enqueue(requests)
     // Metadata in `downloadedEpisodes` is written by the onEpisodeComplete callback
     // once the video is actually on disk — premature writes here caused stale ⬇ icons
     // to survive cancelled or never-finished downloads.
   })
 
-  ipcMain.handle('download:pause', (_event, id: string) => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_PAUSE, (_event, id: string) => {
     downloadManager.pause(id)
   })
 
-  ipcMain.handle('download:resume', (_event, id: string) => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_RESUME, (_event, id: string) => {
     downloadManager.resume(id)
   })
 
-  ipcMain.handle('download:restart', async (_event, id: string) => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_RESTART, async (_event, id: string) => {
     await downloadManager.restart(id)
   })
 
-  ipcMain.handle('download:restart-all-failed', async () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_RESTART_ALL_FAILED, async () => {
     await downloadManager.restartAllFailed()
   })
 
-  ipcMain.handle('download:pause-all', () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_PAUSE_ALL, () => {
     downloadManager.pauseAll()
   })
 
-  ipcMain.handle('download:resume-all', () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_RESUME_ALL, () => {
     downloadManager.resumeAll()
   })
 
-  ipcMain.handle('download:cancel', (_event, id: string) => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_CANCEL, (_event, id: string) => {
     const item = downloadManager.getItem(id)
     downloadManager.cancel(id)
     if (item && item.animeId > 0 && item.episodeInt) {
@@ -3048,12 +3055,12 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('download:get-queue', () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_GET_QUEUE, () => {
     return downloadManager.getEpisodeGroups()
   })
 
   ipcMain.handle(
-    'download:cancel-by-episode',
+    CHANNELS.DOWNLOAD_CANCEL_BY_EPISODE,
     (_event, animeName: string, episodeLabel?: string) => {
       // Snapshot items before cancellation so we can prune metadata for any translation
       // whose file never landed on disk.
@@ -3106,7 +3113,7 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('downloaded-episodes-get', (_event, animeId: number) => {
+  ipcMain.handle(CHANNELS.DOWNLOADED_EPISODES_GET, (_event, animeId: number) => {
     const episodes = store.get('downloadedEpisodes') as Record<
       string,
       { translationType: string; author: string; quality: number; translationId: number }
@@ -3158,23 +3165,23 @@ function registerIpcHandlers(): void {
     return result
   })
 
-  ipcMain.handle('download:cancel-merge', () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_CANCEL_MERGE, () => {
     downloadManager.cancelMerge()
   })
 
-  ipcMain.handle('download:clear-completed', () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_CLEAR_COMPLETED, () => {
     downloadManager.clearCompleted()
   })
 
-  ipcMain.handle('download:merge', async () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_MERGE, async () => {
     if (!ffmpegPath) throw new Error('ffmpeg binary not found')
     const codec = (store.get('videoCodec') as string) || 'copy'
     await downloadManager.mergeCompleted(ffmpegPath, ffprobePath, codec)
   })
 
-  ipcMain.handle('ffmpeg:check', () => checkFfmpeg())
+  ipcMain.handle(CHANNELS.FFMPEG_CHECK, () => checkFfmpeg())
 
-  ipcMain.handle('ffmpeg:delete', () => {
+  ipcMain.handle(CHANNELS.FFMPEG_DELETE, () => {
     const dest = getFfmpegDir()
     const ext = process.platform === 'win32' ? '.exe' : ''
     const ffmpegBin = path.join(dest, `ffmpeg${ext}`)
@@ -3202,7 +3209,7 @@ function registerIpcHandlers(): void {
     ffprobePath = ''
   })
 
-  ipcMain.handle('download:scan-merge', async () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_SCAN_MERGE, async () => {
     if (!ffmpegPath) throw new Error('ffmpeg binary not found')
     const codec = (store.get('videoCodec') as string) || 'copy'
     const extraDirs = isAdvancedStorage() && getColdStorageDir() ? [getColdStorageDir()] : undefined
@@ -3213,7 +3220,12 @@ function registerIpcHandlers(): void {
       (current, total, file, percent) => {
         const windows = BrowserWindow.getAllWindows()
         for (const win of windows) {
-          win.webContents.send('scan-merge:progress', { current, total, file, percent })
+          win.webContents.send(EVENT_CHANNELS.SCAN_MERGE_PROGRESS, {
+            current,
+            total,
+            file,
+            percent
+          })
         }
       },
       extraDirs
@@ -3221,7 +3233,7 @@ function registerIpcHandlers(): void {
     return result
   })
 
-  ipcMain.handle('download:fix-metadata', async () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_FIX_METADATA, async () => {
     if (!ffmpegPath || !ffprobePath) throw new Error('ffmpeg/ffprobe not found')
 
     Ffmpeg.setFfmpegPath(ffmpegPath)
@@ -3304,7 +3316,7 @@ function registerIpcHandlers(): void {
       // Broadcast progress
       const windows = BrowserWindow.getAllWindows()
       for (const win of windows) {
-        win.webContents.send('fix-metadata:progress', {
+        win.webContents.send(EVENT_CHANNELS.FIX_METADATA_PROGRESS, {
           current: i + 1,
           total: toFix.length,
           file: item.label
@@ -3345,7 +3357,7 @@ function registerIpcHandlers(): void {
     return result
   })
 
-  ipcMain.handle('cache-get-poster', (_event, animeId: number) => {
+  ipcMain.handle(CHANNELS.CACHE_GET_POSTER, (_event, animeId: number) => {
     const posterPath = getPosterCachePath(animeId)
     if (fs.existsSync(posterPath)) return `file://${posterPath}`
     return null
@@ -3354,34 +3366,34 @@ function registerIpcHandlers(): void {
   // Skip detection (Chromaprint local fingerprinting). Orchestration lives at
   // module scope so the auto-trigger from download/merge hooks shares the same
   // single-flight state as these handlers.
-  ipcMain.handle('skip-detector:get-detections', (_event, animeId: number) => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_GET_DETECTIONS, (_event, animeId: number) => {
     const all = store.get('skipDetections') as Record<string, ShowSkipDetections>
     return normalizeSkipDetections(all[String(animeId)] ?? null)
   })
 
-  ipcMain.handle('skip-detector:get-status', () => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_GET_STATUS, () => {
     if (!currentSkipAnalysis) return null
     return { animeId: currentSkipAnalysis.animeId, lastProgress: currentSkipAnalysis.lastProgress }
   })
 
-  ipcMain.handle('skip-detector:cancel', () => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_CANCEL, () => {
     if (currentSkipAnalysis) currentSkipAnalysis.controller.abort()
   })
 
-  ipcMain.handle('skip-detector:cache-stats', () => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_CACHE_STATS, () => {
     const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
     return { fingerprintCount: Object.keys(cache).length }
   })
 
   ipcMain.handle(
-    'skip-detector:analyze-show',
+    CHANNELS.SKIP_DETECTOR_ANALYZE_SHOW,
     (_event, animeId: number, episodes: EpisodeInput[]) => {
       return runSkipAnalysisInternal(animeId, episodes)
     }
   )
 
   ipcMain.handle(
-    'skip-detector:detect-stream',
+    CHANNELS.SKIP_DETECTOR_DETECT_STREAM,
     async (
       event,
       animeId: number,
@@ -3402,14 +3414,14 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('skip-detector:cancel-stream-detect', (event) => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_CANCEL_STREAM_DETECT, (event) => {
     cancelStreamSkipDetection(event.sender.id)
   })
 
   // One-shot backfill for shows downloaded before Phase 3 was wired in.
   // Honors the dedupe in `enqueueAutoSkipAnalysis` so a manual click doesn't
   // double-queue a show that's already running or pending.
-  ipcMain.handle('skip-detector:backfill-all', () => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_BACKFILL_ALL, () => {
     const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
     const detections = store.get('skipDetections') as Record<string, ShowSkipDetections>
     let queued = 0
@@ -3435,7 +3447,7 @@ function registerIpcHandlers(): void {
     return { queued, alreadyAnalyzed, skippedFewEpisodes, total }
   })
 
-  ipcMain.handle('skip-detector:queue-status', () => {
+  ipcMain.handle(CHANNELS.SKIP_DETECTOR_QUEUE_STATUS, () => {
     return {
       currentAnimeId: currentSkipAnalysis?.animeId ?? null,
       queueLength: autoSkipQueue.length
@@ -3443,7 +3455,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(
-    'download:inject-chapters',
+    CHANNELS.DOWNLOAD_INJECT_CHAPTERS,
     async (_event, animeId: number, allInputs: EpisodeInput[]) => {
       if (!Number.isFinite(animeId) || animeId <= 0) throw new Error('invalid animeId')
       if (!ffmpegPath || !ffprobePath) throw new Error('ffmpeg/ffprobe not available')
@@ -3561,19 +3573,22 @@ function registerIpcHandlers(): void {
   )
 
   // File management handlers
-  ipcMain.handle('file:check-episodes', (_event, animeName: string, episodeInts: string[]) => {
-    const cached = fileCheckCache.get(animeName)
-    if (cached) {
-      backgroundRescan(animeName).catch((err) => console.error('Background rescan failed:', err))
-      return filterScanResult(cached, animeName, episodeInts)
+  ipcMain.handle(
+    CHANNELS.FILE_CHECK_EPISODES,
+    (_event, animeName: string, episodeInts: string[]) => {
+      const cached = fileCheckCache.get(animeName)
+      if (cached) {
+        backgroundRescan(animeName).catch((err) => console.error('Background rescan failed:', err))
+        return filterScanResult(cached, animeName, episodeInts)
+      }
+
+      const fullResult = scanEpisodeFiles(animeName)
+      fileCheckCache.set(animeName, fullResult)
+      return filterScanResult(fullResult, animeName, episodeInts)
     }
+  )
 
-    const fullResult = scanEpisodeFiles(animeName)
-    fileCheckCache.set(animeName, fullResult)
-    return filterScanResult(fullResult, animeName, episodeInts)
-  })
-
-  ipcMain.handle('file:open', async (_event, filePath: string) => {
+  ipcMain.handle(CHANNELS.FILE_OPEN, async (_event, filePath: string) => {
     if (!fs.existsSync(filePath)) {
       const animeDirName = path.basename(path.dirname(filePath))
       for (const [key] of fileCheckCache) {
@@ -3587,12 +3602,12 @@ function registerIpcHandlers(): void {
     return shell.openPath(filePath)
   })
 
-  ipcMain.handle('file:show-in-folder', (_event, filePath: string) => {
+  ipcMain.handle(CHANNELS.FILE_SHOW_IN_FOLDER, (_event, filePath: string) => {
     shell.showItemInFolder(filePath)
   })
 
   ipcMain.handle(
-    'file:delete-episode',
+    CHANNELS.FILE_DELETE_EPISODE,
     (_event, animeName: string, episodeInt: string, animeId?: number, translationId?: number) => {
       deleteEpisodeFiles(animeName, episodeInt, animeId, translationId)
       if (animeId && animeId > 0) {
@@ -3602,7 +3617,7 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('download:pick-dir', async () => {
+  ipcMain.handle(CHANNELS.DOWNLOAD_PICK_DIR, async () => {
     const win = BrowserWindow.getFocusedWindow()
     if (!win) return null
     const result = await dialog.showOpenDialog(win, {
@@ -3616,7 +3631,7 @@ function registerIpcHandlers(): void {
     return dir
   })
 
-  ipcMain.handle('storage:pick-hot-dir', async () => {
+  ipcMain.handle(CHANNELS.STORAGE_PICK_HOT_DIR, async () => {
     const win = BrowserWindow.getFocusedWindow()
     if (!win) return null
     const result = await dialog.showOpenDialog(win, {
@@ -3630,7 +3645,7 @@ function registerIpcHandlers(): void {
     return dir
   })
 
-  ipcMain.handle('storage:pick-cold-dir', async () => {
+  ipcMain.handle(CHANNELS.STORAGE_PICK_COLD_DIR, async () => {
     const win = BrowserWindow.getFocusedWindow()
     if (!win) return null
     const result = await dialog.showOpenDialog(win, {
@@ -3643,30 +3658,30 @@ function registerIpcHandlers(): void {
     return dir
   })
 
-  ipcMain.handle('storage:move-to-cold', async () => {
+  ipcMain.handle(CHANNELS.STORAGE_MOVE_TO_COLD, async () => {
     fileCheckCache.clear()
     const result = await moveAllFilesToColdStorage((current, total, file) => {
       for (const win of BrowserWindow.getAllWindows()) {
-        win.webContents.send('storage:move-to-cold-progress', { current, total, file })
+        win.webContents.send(EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS, { current, total, file })
       }
     })
     return result
   })
 
-  ipcMain.handle('storage:get-usage', async () => {
+  ipcMain.handle(CHANNELS.STORAGE_GET_USAGE, async () => {
     return scanStorageUsage()
   })
 
-  ipcMain.handle('storage:run-cleanup', async (_event, opts?: { force?: boolean }) => {
+  ipcMain.handle(CHANNELS.STORAGE_RUN_CLEANUP, async (_event, opts?: { force?: boolean }) => {
     return runWatchedCleanup(!!opts?.force)
   })
 
   // Shikimori integration
-  ipcMain.handle('shikimori:get-auth-url', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_AUTH_URL, () => {
     return shikimori.getAuthUrl()
   })
 
-  ipcMain.handle('shikimori:exchange-code', async (_event, code: string) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_EXCHANGE_CODE, async (_event, code: string) => {
     const creds = await shikimori.exchangeCode(code)
     store.set('shikimoriCredentials', creds)
     const user = await shikimori.getUser(creds.access_token)
@@ -3674,7 +3689,7 @@ function registerIpcHandlers(): void {
     return user
   })
 
-  ipcMain.handle('shikimori:logout', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_LOGOUT, () => {
     store.set('shikimoriCredentials', null)
     store.set('shikimoriUser', null)
     store.set('shikimoriUserRates', [])
@@ -3687,11 +3702,11 @@ function registerIpcHandlers(): void {
     broadcastSyncStatus()
   })
 
-  ipcMain.handle('shikimori:get-user', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_USER, () => {
     return store.get('shikimoriUser') as shikimori.ShikiUser | null
   })
 
-  ipcMain.handle('shikimori:get-rate', async (_event, malId: number) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_RATE, async (_event, malId: number) => {
     const accessToken = await shikimori.ensureFreshToken(store)
     const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
     if (!user) throw new Error('Not logged in to Shikimori')
@@ -3699,7 +3714,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(
-    'shikimori:update-rate',
+    CHANNELS.SHIKIMORI_UPDATE_RATE,
     async (
       _event,
       malId: number,
@@ -3825,7 +3840,7 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('shikimori:get-friends-rates', async (_event, malId: number) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_FRIENDS_RATES, async (_event, malId: number) => {
     const accessToken = await shikimori.ensureFreshToken(store)
     const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
     if (!user) throw new Error('Not logged in to Shikimori')
@@ -3876,7 +3891,7 @@ function registerIpcHandlers(): void {
       .catch((err) => console.warn('[shikimori] background refresh failed:', err))
   }
 
-  ipcMain.handle('shikimori:get-anime-rates', async (_event, status?: string) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_ANIME_RATES, async (_event, status?: string) => {
     if (!status) {
       const cached = store.get('shikimoriUserRates') as unknown[]
       if (cached.length > 0) {
@@ -3889,7 +3904,7 @@ function registerIpcHandlers(): void {
     return entries
   })
 
-  ipcMain.handle('shikimori:get-anime-details', (_event, malId: number) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_ANIME_DETAILS, (_event, malId: number) => {
     const cache = store.get('shikimoriAnimeDetails') as Record<
       string,
       { details: shikimori.ShikiAnimeDetails; fetchedAt: number }
@@ -3903,21 +3918,21 @@ function registerIpcHandlers(): void {
     return entry.details
   })
 
-  ipcMain.handle('shikimori:trigger-detail-prefetch', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_TRIGGER_DETAIL_PREFETCH, () => {
     void prefetchShikimoriDetails()
   })
 
-  ipcMain.handle('shikimori:get-offline-queue-length', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_OFFLINE_QUEUE_LENGTH, () => {
     return (store.get('shikimoriUpdateQueue') as unknown[]).length
   })
 
-  ipcMain.handle('shikimori:get-sync-status', () => getSyncStatus())
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_SYNC_STATUS, () => getSyncStatus())
 
-  ipcMain.handle('shikimori:trigger-sync', () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_TRIGGER_SYNC, () => {
     void syncShikimoriQueue()
   })
 
-  ipcMain.handle('shikimori:get-friends-activity', async () => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_FRIENDS_ACTIVITY, async () => {
     const accessToken = await shikimori.ensureFreshToken(store)
     const user = store.get('shikimoriUser') as shikimori.ShikiUser | null
     if (!user) throw new Error('Not logged in to Shikimori')
@@ -3932,7 +3947,7 @@ function registerIpcHandlers(): void {
     }))
   })
 
-  ipcMain.handle('shikimori:get-calendar', async (_event, force = false) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_CALENDAR, async (_event, force = false) => {
     if (!force && calendarCache && Date.now() - calendarCache.fetchedAt < CALENDAR_CACHE_TTL_MS) {
       return calendarCache.data
     }
@@ -4010,7 +4025,7 @@ function registerIpcHandlers(): void {
     return entries
   })
 
-  ipcMain.handle('shikimori:get-related', async (_event, malId: number) => {
+  ipcMain.handle(CHANNELS.SHIKIMORI_GET_RELATED, async (_event, malId: number) => {
     const franchise = await shikimori.getFranchise(malId)
 
     const CANONICAL_RELATIONS = new Set([
@@ -4127,7 +4142,7 @@ function registerIpcHandlers(): void {
       .filter((e) => e.isCurrent || !(e.shikiAnime.kind && EXCLUDED_KINDS.has(e.shikiAnime.kind)))
   })
 
-  ipcMain.handle('shell:open-external', async (_event, url: string) => {
+  ipcMain.handle(CHANNELS.SHELL_OPEN_EXTERNAL, async (_event, url: string) => {
     try {
       await shell.openExternal(url)
       return true
@@ -4136,7 +4151,7 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('shell:open-external-file', async (_event, filePath: string) => {
+  ipcMain.handle(CHANNELS.SHELL_OPEN_EXTERNAL_FILE, async (_event, filePath: string) => {
     try {
       const err = await shell.openPath(filePath)
       return { ok: err === '', error: err || undefined }
@@ -4146,7 +4161,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(
-    'player:get-stream-url',
+    CHANNELS.PLAYER_GET_STREAM_URL,
     async (_event, translationId: number, maxHeight: number) => {
       try {
         const embed = await smotretApi.getEmbed(translationId)
@@ -4175,7 +4190,7 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('player:get-local-subtitles', async (_event, filePath: string) => {
+  ipcMain.handle(CHANNELS.PLAYER_GET_LOCAL_SUBTITLES, async (_event, filePath: string) => {
     const assPath = filePath.replace(/\.(mp4|mkv)$/i, '.ass')
     try {
       if (fs.existsSync(assPath)) {
@@ -4188,7 +4203,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(
-    'player:find-local-file',
+    CHANNELS.PLAYER_FIND_LOCAL_FILE,
     async (
       _event,
       animeName: string,
@@ -4283,7 +4298,7 @@ function registerIpcHandlers(): void {
   // Remux MKV to fragmented MP4 (stream copy) for progressive HTML5 playback.
   // See protocol.handle('anime-video', …) below for the streaming reader.
   ipcMain.handle(
-    'player:remux-mkv',
+    CHANNELS.PLAYER_REMUX_MKV,
     async (
       _event,
       mkvPath: string
@@ -4333,7 +4348,7 @@ function registerIpcHandlers(): void {
   // renderer can set MediaSource.duration and addSourceBuffer(mimeType) upfront.
   // Video bytes are pushed to the renderer via 'player:stream-chunk' events.
   ipcMain.handle(
-    'player:remux-mkv-stream',
+    CHANNELS.PLAYER_REMUX_MKV_STREAM,
     async (
       event,
       mkvPath: string,
@@ -4400,7 +4415,7 @@ function registerIpcHandlers(): void {
             if (!content) return
             const sender = event.sender
             if (sender && !sender.isDestroyed()) {
-              sender.send('player:stream-subtitles', { sessionId, content })
+              sender.send(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES, { sessionId, content })
             }
           })
           .catch(() => {
@@ -4424,7 +4439,7 @@ function registerIpcHandlers(): void {
   // on Linux without VA-API). Audio is copied when AAC, otherwise transcoded
   // to AAC so MSE can play it.
   ipcMain.handle(
-    'player:remux-mkv-stream-transcode',
+    CHANNELS.PLAYER_REMUX_MKV_STREAM_TRANSCODE,
     async (
       event,
       mkvPath: string,
@@ -4500,7 +4515,7 @@ function registerIpcHandlers(): void {
             if (!content) return
             const sender = event.sender
             if (sender && !sender.isDestroyed()) {
-              sender.send('player:stream-subtitles', { sessionId, content })
+              sender.send(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES, { sessionId, content })
             }
           })
           .catch(() => {
@@ -4524,42 +4539,45 @@ function registerIpcHandlers(): void {
   // already set sourceBuffer.timestampOffset to place fragments on the correct
   // MSE timeline position. Stale chunks from the old proc are filtered out by
   // the generation counter captured in spawnFfmpegForSession.
-  ipcMain.handle('player:stream-seek', async (event, sessionId: string, seekSeconds: number) => {
-    const session = mseSessions.get(sessionId)
-    if (!session) return { error: 'session not found' }
-    const requestedSeek = Math.max(0, seekSeconds)
-    const keyframeTime =
-      requestedSeek > 0 ? await findKeyframeBefore(session.mkvPath, requestedSeek) : 0
-    session.generation++
-    try {
-      session.proc.kill('SIGKILL')
-    } catch {
-      /* ignore */
-    }
-    session.pendingBytes = 0
-    session.prelude = []
-    session.done = false
-    session.error = null
-    // Hold new chunks in the prelude until the renderer has set its
-    // SourceBuffer.timestampOffset and called player:stream-start again.
-    // Otherwise first frames of the new run race ahead of the offset change
-    // and get placed on the wrong MSE timeline.
-    session.ready = false
-    if (session.proc.stdout && session.proc.stdout.isPaused()) {
+  ipcMain.handle(
+    CHANNELS.PLAYER_STREAM_SEEK,
+    async (event, sessionId: string, seekSeconds: number) => {
+      const session = mseSessions.get(sessionId)
+      if (!session) return { error: 'session not found' }
+      const requestedSeek = Math.max(0, seekSeconds)
+      const keyframeTime =
+        requestedSeek > 0 ? await findKeyframeBefore(session.mkvPath, requestedSeek) : 0
+      session.generation++
       try {
-        session.proc.stdout.resume()
+        session.proc.kill('SIGKILL')
       } catch {
         /* ignore */
       }
+      session.pendingBytes = 0
+      session.prelude = []
+      session.done = false
+      session.error = null
+      // Hold new chunks in the prelude until the renderer has set its
+      // SourceBuffer.timestampOffset and called player:stream-start again.
+      // Otherwise first frames of the new run race ahead of the offset change
+      // and get placed on the wrong MSE timeline.
+      session.ready = false
+      if (session.proc.stdout && session.proc.stdout.isPaused()) {
+        try {
+          session.proc.stdout.resume()
+        } catch {
+          /* ignore */
+        }
+      }
+      session.proc = spawnFfmpegForSession(session, event, sessionId, keyframeTime)
+      return { ok: true, generation: session.generation, keyframeTime }
     }
-    session.proc = spawnFfmpegForSession(session, event, sessionId, keyframeTime)
-    return { ok: true, generation: session.generation, keyframeTime }
-  })
+  )
 
   // Handshake: renderer's MediaSource + SourceBuffer are ready to receive chunks.
   // Flush any buffered prelude (the MP4 moov header lives in here) and switch to
   // forwarding subsequent chunks directly.
-  ipcMain.handle('player:stream-start', (event, sessionId: string) => {
+  ipcMain.handle(CHANNELS.PLAYER_STREAM_START, (event, sessionId: string) => {
     const session = mseSessions.get(sessionId)
     if (!session) return
     if (session.ready) return
@@ -4568,7 +4586,7 @@ function registerIpcHandlers(): void {
     if (sender && !sender.isDestroyed()) {
       const gen = session.generation
       for (const chunk of session.prelude) {
-        sender.send('player:stream-chunk', { sessionId, gen, data: chunk })
+        sender.send(EVENT_CHANNELS.PLAYER_STREAM_CHUNK, { sessionId, gen, data: chunk })
       }
     }
     session.prelude = []
@@ -4576,7 +4594,7 @@ function registerIpcHandlers(): void {
 
   // Backpressure ack: renderer reports bytes it has appended into its SourceBuffer.
   // When enough data has been consumed we resume the ffmpeg stdout pipe.
-  ipcMain.handle('player:stream-ack', (_event, sessionId: string, bytesConsumed: number) => {
+  ipcMain.handle(CHANNELS.PLAYER_STREAM_ACK, (_event, sessionId: string, bytesConsumed: number) => {
     const session = mseSessions.get(sessionId)
     if (!session) return
     session.pendingBytes = Math.max(0, session.pendingBytes - bytesConsumed)
@@ -4588,7 +4606,7 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('player:cleanup-remux', async () => {
+  ipcMain.handle(CHANNELS.PLAYER_CLEANUP_REMUX, async () => {
     for (const sessionId of Array.from(mseSessions.keys())) {
       cleanupMseSession(sessionId)
     }
@@ -4613,7 +4631,7 @@ function registerIpcHandlers(): void {
     }
   })
 
-  ipcMain.handle('syncplay:connect', (_event, cfg: SyncplayConfig) => {
+  ipcMain.handle(CHANNELS.SYNCPLAY_CONNECT, (_event, cfg: SyncplayConfig) => {
     const persisted = store.get('syncplay')
     store.set('syncplay', {
       ...persisted,
@@ -4626,41 +4644,41 @@ function registerIpcHandlers(): void {
     syncplay.connect(cfg)
   })
 
-  ipcMain.handle('syncplay:disconnect', () => {
+  ipcMain.handle(CHANNELS.SYNCPLAY_DISCONNECT, () => {
     syncplay.disconnect()
   })
 
-  ipcMain.handle('syncplay:set-file', (_event, file: SyncplayFileInfo) => {
+  ipcMain.handle(CHANNELS.SYNCPLAY_SET_FILE, (_event, file: SyncplayFileInfo) => {
     syncplay.setFile(file)
   })
 
   ipcMain.handle(
-    'syncplay:local-state',
+    CHANNELS.SYNCPLAY_LOCAL_STATE,
     (_event, payload: { paused: boolean; position: number; cause: 'play' | 'pause' | 'seek' }) => {
       syncplay.sendLocalState(payload)
     }
   )
 
   ipcMain.handle(
-    'syncplay:local-snapshot',
+    CHANNELS.SYNCPLAY_LOCAL_SNAPSHOT,
     (_event, snap: { position: number; paused: boolean }) => {
       syncplay.updateSnapshot(snap)
     }
   )
 
-  ipcMain.handle('syncplay:set-ready', (_event, isReady: boolean) => {
+  ipcMain.handle(CHANNELS.SYNCPLAY_SET_READY, (_event, isReady: boolean) => {
     syncplay.setReady(isReady)
   })
 
-  ipcMain.handle('syncplay:get-status', () => syncplay.getStatus())
+  ipcMain.handle(CHANNELS.SYNCPLAY_GET_STATUS, () => syncplay.getStatus())
 
   // Auto-downloader
-  ipcMain.handle('auto-dl:get-subscription', (_event, animeId: number) => {
+  ipcMain.handle(CHANNELS.AUTO_DL_GET_SUBSCRIPTION, (_event, animeId: number) => {
     return autoDlGetSubscription(animeId)
   })
 
   ipcMain.handle(
-    'auto-dl:set-subscription',
+    CHANNELS.AUTO_DL_SET_SUBSCRIPTION,
     async (
       _event,
       animeId: number,
@@ -4679,17 +4697,17 @@ function registerIpcHandlers(): void {
     }
   )
 
-  ipcMain.handle('auto-dl:list-subscriptions', () => autoDlListSubscriptions())
+  ipcMain.handle(CHANNELS.AUTO_DL_LIST_SUBSCRIPTIONS, () => autoDlListSubscriptions())
 
-  ipcMain.handle('auto-dl:trigger', async () => {
+  ipcMain.handle(CHANNELS.AUTO_DL_TRIGGER, async () => {
     return runAutoDownloadTick('manual')
   })
 
-  ipcMain.handle('auto-dl:get-status', () => getAutoDownloaderStatus())
+  ipcMain.handle(CHANNELS.AUTO_DL_GET_STATUS, () => getAutoDownloaderStatus())
 
-  ipcMain.handle('auto-dl:get-enabled', () => Boolean(store.get('autoDownloadEnabled')))
+  ipcMain.handle(CHANNELS.AUTO_DL_GET_ENABLED, () => Boolean(store.get('autoDownloadEnabled')))
 
-  ipcMain.handle('auto-dl:set-enabled', (_event, enabled: boolean) => {
+  ipcMain.handle(CHANNELS.AUTO_DL_SET_ENABLED, (_event, enabled: boolean) => {
     store.set('autoDownloadEnabled', Boolean(enabled))
     return Boolean(enabled)
   })
@@ -4799,7 +4817,7 @@ function spawnFfmpegForSession(
         parseInt(timeMatch[2], 10) * 60 +
         parseFloat(timeMatch[3])
       : null
-    sender.send('player:stream-progress', { sessionId, gen: procGen, speed, time })
+    sender.send(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS, { sessionId, gen: procGen, speed, time })
   })
 
   // Coalesce small ffmpeg stdout chunks into ~256 KB IPC messages. ffmpeg
@@ -4817,7 +4835,7 @@ function spawnFfmpegForSession(
     if (session.ready) {
       const sender = event.sender
       if (sender && !sender.isDestroyed()) {
-        sender.send('player:stream-chunk', { sessionId, gen: procGen, data: out })
+        sender.send(EVENT_CHANNELS.PLAYER_STREAM_CHUNK, { sessionId, gen: procGen, data: out })
       }
     } else {
       session.prelude.push(out)
@@ -4843,7 +4861,7 @@ function spawnFfmpegForSession(
     session.done = true
     const sender = event.sender
     if (sender && !sender.isDestroyed()) {
-      sender.send('player:stream-end', { sessionId })
+      sender.send(EVENT_CHANNELS.PLAYER_STREAM_END, { sessionId })
     }
   })
 
@@ -4855,7 +4873,7 @@ function spawnFfmpegForSession(
     console.error('[remux-stream] spawn error:', err.message)
     const sender = event.sender
     if (sender && !sender.isDestroyed()) {
-      sender.send('player:stream-error', { sessionId, error: err.message })
+      sender.send(EVENT_CHANNELS.PLAYER_STREAM_ERROR, { sessionId, error: err.message })
     }
   })
 
@@ -4869,7 +4887,7 @@ function spawnFfmpegForSession(
       console.error('[remux-stream]', msg)
       const sender = event.sender
       if (sender && !sender.isDestroyed()) {
-        sender.send('player:stream-error', { sessionId, error: msg })
+        sender.send(EVENT_CHANNELS.PLAYER_STREAM_ERROR, { sessionId, error: msg })
       }
     }
   })
@@ -5550,7 +5568,7 @@ app.whenReady().then(async () => {
 
   const broadcastUpdateStatus = (data: Record<string, unknown>): void => {
     for (const win of BrowserWindow.getAllWindows()) {
-      win.webContents.send('update:status', data)
+      win.webContents.send(EVENT_CHANNELS.UPDATE_STATUS, data)
     }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -368,7 +368,7 @@ function getSyncStatus(): ShikiSyncStatus {
 }
 
 function broadcastSyncStatus(): void {
-  broadcastToAll('shikimori:sync-status', getSyncStatus())
+  broadcastToAll(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS, getSyncStatus())
 }
 
 function startSyncTimer(): void {
@@ -414,7 +414,7 @@ function dropConsumedEntries(malId: number, consumedQueuedAts: number[]): number
     (q) => !(q.malId === malId && consumed.has(q.queuedAt))
   )
   store.set('shikimoriUpdateQueue', queue)
-  broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+  broadcastToAll(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED, { length: queue.length })
   return queue.length
 }
 
@@ -451,7 +451,7 @@ function reconcileCacheFromRate(malId: number, rate: shikimori.ShikiUserRate): v
   }
   store.set('shikimoriUserRates', cached)
   invalidateCalendarCache()
-  broadcastToAll('shikimori:rate-updated', cached[idx])
+  broadcastToAll(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED, cached[idx])
 }
 
 function shouldApplyOnDrift(
@@ -618,7 +618,7 @@ async function refreshShikimoriDetailsForMalId(
     >
     cache[String(malId)] = { details, fetchedAt: Date.now() }
     store.set('shikimoriAnimeDetails', cache)
-    broadcastToAll('shikimori:anime-details-updated', { malId, details })
+    broadcastToAll(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED, { malId, details })
     return details
   } catch (err) {
     if (!isNetworkError(err)) {
@@ -662,7 +662,7 @@ async function prefetchShikimoriDetails(): Promise<void> {
         >
         cache[String(malId)] = { details, fetchedAt: Date.now() }
         store.set('shikimoriAnimeDetails', cache)
-        broadcastToAll('shikimori:anime-details-updated', { malId, details })
+        broadcastToAll(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED, { malId, details })
       } catch (err) {
         if (isNetworkError(err)) {
           console.warn('[shikimori prefetch] network error, aborting loop:', err)
@@ -747,7 +747,7 @@ async function maybeBroadcastCleanupPrompt(
   if (!sa || typeof sa.id !== 'number') return
   if (!isDownloadedAnime(sa.id)) return
   if (isCleanupSnoozed(sa.id)) return
-  broadcastToAll('cleanup:prompt', {
+  broadcastToAll(EVENT_CHANNELS.CLEANUP_PROMPT, {
     animeId: sa.id,
     animeName: getDisplayName(sa),
     malId
@@ -1680,7 +1680,7 @@ async function scanStorageUsage(): Promise<StorageUsage> {
     const animeId = dirNameToId.get(folder)
     if (!animeId) {
       scanned++
-      if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+      if (reportProgress) broadcastToAll(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS, { scanned, total })
       continue
     }
     const animeRec = downloaded[animeId]
@@ -1704,7 +1704,7 @@ async function scanStorageUsage(): Promise<StorageUsage> {
       files = await fsPromises.readdir(animeDir)
     } catch {
       scanned++
-      if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+      if (reportProgress) broadcastToAll(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS, { scanned, total })
       continue
     }
 
@@ -1741,7 +1741,7 @@ async function scanStorageUsage(): Promise<StorageUsage> {
     }
 
     scanned++
-    if (reportProgress) broadcastToAll('storage:usage-progress', { scanned, total })
+    if (reportProgress) broadcastToAll(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS, { scanned, total })
   }
 
   let totalBytes = 0
@@ -1874,7 +1874,7 @@ async function runWatchedCleanup(force = false): Promise<{
 
     const requireConfirm = store.get('autoCleanupConfirm') as boolean
     if (requireConfirm && !force) {
-      broadcastToAll('storage:cleanup-pending', { candidates })
+      broadcastToAll(EVENT_CHANNELS.STORAGE_CLEANUP_PENDING, { candidates })
       return { ranAt, deletedCount: 0, freedBytes: 0, items: [] }
     }
 
@@ -1916,12 +1916,12 @@ async function runWatchedCleanup(force = false): Promise<{
     for (const animeName of affectedAnime) {
       try {
         const data = scanEpisodeFiles(animeName)
-        broadcastToAll('file:episodes-changed', animeName, data)
+        broadcastToAll(EVENT_CHANNELS.FILE_EPISODES_CHANGED, animeName, data)
       } catch {
         /* ignore */
       }
     }
-    broadcastToAll('storage:cleanup-finished', result)
+    broadcastToAll(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED, result)
     return result
   } finally {
     cleanupRunning = false
@@ -1973,7 +1973,7 @@ function broadcastSkipProgress(animeId: number, p: AnalyzeProgress): void {
   if (currentSkipAnalysis && currentSkipAnalysis.animeId === animeId) {
     currentSkipAnalysis.lastProgress = p
   }
-  broadcastToAll('skip-detector:analyze-progress', { animeId, ...p })
+  broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS, { animeId, ...p })
 }
 
 function normalizeSkipDetections(detections: ShowSkipDetections | null): ShowSkipDetections | null {
@@ -2034,7 +2034,10 @@ function runSkipAnalysisInternal(
     const all = store.get('skipDetections') as Record<string, ShowSkipDetections>
     all[String(animeId)] = result
     store.set('skipDetections', all)
-    broadcastToAll('skip-detector:signature-updated', { animeId, perEpisode: result.perEpisode })
+    broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, {
+      animeId,
+      perEpisode: result.perEpisode
+    })
     return result
   })()
 
@@ -2283,7 +2286,7 @@ function dropSkipDetectionsForAnime(animeId: number): boolean {
   if (!(key in detections)) return false
   delete detections[key]
   store.set('skipDetections', detections)
-  broadcastToAll('skip-detector:signature-updated', { animeId, perEpisode: {} })
+  broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, { animeId, perEpisode: {} })
   return true
 }
 
@@ -2297,7 +2300,7 @@ function dropSkipDetectionsForEpisode(animeId: number, episodeInt: string): bool
     delete detections[key]
   }
   store.set('skipDetections', detections)
-  broadcastToAll('skip-detector:signature-updated', {
+  broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, {
     animeId,
     perEpisode: detections[key]?.perEpisode ?? {}
   })
@@ -3470,7 +3473,7 @@ function registerIpcHandlers(): void {
       let detections =
         (store.get('skipDetections') as Record<string, ShowSkipDetections>)[String(animeId)] ?? null
       if (!detections) {
-        broadcastToAll('chapter-inject:progress', {
+        broadcastToAll(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS, {
           animeId,
           phase: 'analyzing',
           current: 0,
@@ -3486,7 +3489,7 @@ function registerIpcHandlers(): void {
 
       for (let i = 0; i < episodes.length; i++) {
         const ep = episodes[i]
-        broadcastToAll('chapter-inject:progress', {
+        broadcastToAll(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS, {
           animeId,
           phase: 'writing',
           current: i,
@@ -3562,7 +3565,7 @@ function registerIpcHandlers(): void {
         }
       }
 
-      broadcastToAll('chapter-inject:progress', {
+      broadcastToAll(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS, {
         animeId,
         phase: 'done',
         current: episodes.length,
@@ -3698,7 +3701,7 @@ function registerIpcHandlers(): void {
     prefetchAbort = true
     invalidateCalendarCache()
     stopSyncTimer()
-    broadcastToAll('shikimori:offline-queue-changed', { length: 0 })
+    broadcastToAll(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED, { length: 0 })
     broadcastSyncStatus()
   })
 
@@ -3778,7 +3781,7 @@ function registerIpcHandlers(): void {
           }
           store.set('shikimoriUserRates', cached)
           invalidateCalendarCache()
-          broadcastToAll('shikimori:rate-updated', cached[idx])
+          broadcastToAll(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED, cached[idx])
           void maybeBroadcastCleanupPrompt(
             cached[idx].smotretAnime,
             malId,
@@ -3822,8 +3825,8 @@ function registerIpcHandlers(): void {
         }
         store.set('shikimoriUserRates', cached)
         invalidateCalendarCache()
-        broadcastToAll('shikimori:rate-updated', cached[idx])
-        broadcastToAll('shikimori:offline-queue-changed', { length: queue.length })
+        broadcastToAll(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED, cached[idx])
+        broadcastToAll(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED, { length: queue.length })
         startSyncTimer()
         void maybeBroadcastCleanupPrompt(cached[idx].smotretAnime, malId, status, prevStatus)
 
@@ -3881,7 +3884,7 @@ function registerIpcHandlers(): void {
     fetchAndCacheShikimoriRates()
       .then((entries) => {
         invalidateCalendarCache()
-        broadcastToAll('shikimori:rates-refreshed', entries)
+        broadcastToAll(EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED, entries)
         void syncShikimoriQueue()
         void prefetchShikimoriDetails()
         void runAutoDownloadTick('rates-refreshed').catch((err) =>
@@ -5539,22 +5542,22 @@ app.whenReady().then(async () => {
   }, 30_000)
 
   syncplay.on('connection-status', (status: SyncplayStatus) => {
-    broadcastToAll('syncplay:connection-status', status)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS, status)
   })
   syncplay.on('remote-state', (state: SyncplayRemoteState) => {
-    broadcastToAll('syncplay:remote-state', state)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE, state)
   })
   syncplay.on('room-users', (users: SyncplayRoomUser[]) => {
-    broadcastToAll('syncplay:room-users', users)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS, users)
   })
   syncplay.on('room-event', (ev: SyncplayRoomEvent) => {
-    broadcastToAll('syncplay:room-event', ev)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT, ev)
   })
   syncplay.on('remote-episode-change', (ep: SyncplayRemoteEpisode) => {
-    broadcastToAll('syncplay:remote-episode-change', ep)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE, ep)
   })
   syncplay.on('trace', (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => {
-    broadcastToAll('syncplay:trace', entry)
+    broadcastToAll(EVENT_CHANNELS.SYNCPLAY_TRACE, entry)
   })
 
   if (getQueueLength() > 0) {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -565,30 +565,30 @@ const api = {
   syncplayGetStatus: () =>
     ipcRenderer.invoke(CHANNELS.SYNCPLAY_GET_STATUS) as Promise<SyncplayStatus>,
   onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
-    syncplayOn('syncplay:connection-status', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS, callback),
   offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
-    syncplayOff('syncplay:connection-status', callback),
+    syncplayOff(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS, callback),
   onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
-    syncplayOn('syncplay:remote-state', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE, callback),
   offSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
-    syncplayOff('syncplay:remote-state', callback),
+    syncplayOff(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE, callback),
   onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
-    syncplayOn('syncplay:room-users', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS, callback),
   offSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
-    syncplayOff('syncplay:room-users', callback),
+    syncplayOff(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS, callback),
   onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
-    syncplayOn('syncplay:room-event', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT, callback),
   offSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
-    syncplayOff('syncplay:room-event', callback),
+    syncplayOff(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT, callback),
   onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
-    syncplayOn('syncplay:remote-episode-change', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE, callback),
   offSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
-    syncplayOff('syncplay:remote-episode-change', callback),
+    syncplayOff(EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE, callback),
   onSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) =>
-    syncplayOn('syncplay:trace', callback),
+    syncplayOn(EVENT_CHANNELS.SYNCPLAY_TRACE, callback),
   offSyncplayTrace: (
     callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void
-  ) => syncplayOff('syncplay:trace', callback),
+  ) => syncplayOff(EVENT_CHANNELS.SYNCPLAY_TRACE, callback),
 
   // Auto-downloader
   autoDlGetSubscription: (animeId: number) =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
+import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'
 
 // Per-channel map of {original-callback → wrapped-handler} so the matching
 // off* helper can call ipcRenderer.removeListener with the actual wrapped
@@ -30,75 +31,86 @@ function syncplayOff<T>(channel: string, cb: SyncplayHandler<T>): void {
 }
 
 const api = {
-  validateToken: () => ipcRenderer.invoke('validate-token'),
-  searchAnime: (query: string) => ipcRenderer.invoke('search-anime', query),
-  getAnime: (id: number) => ipcRenderer.invoke('get-anime', id),
+  validateToken: () => ipcRenderer.invoke(CHANNELS.VALIDATE_TOKEN),
+  searchAnime: (query: string) => ipcRenderer.invoke(CHANNELS.SEARCH_ANIME, query),
+  getAnime: (id: number) => ipcRenderer.invoke(CHANNELS.GET_ANIME, id),
   getAnimeCache: (id: number) =>
-    ipcRenderer.invoke('get-anime-cache', id) as Promise<{
+    ipcRenderer.invoke(CHANNELS.GET_ANIME_CACHE, id) as Promise<{
       data: AnimeDetail
       cachedAt: number
     } | null>,
   setAnimeCache: (id: number, data: AnimeDetail) =>
-    ipcRenderer.invoke('set-anime-cache', id, data) as Promise<boolean>,
-  getEpisode: (id: number, animeId?: number) => ipcRenderer.invoke('get-episode', id, animeId),
+    ipcRenderer.invoke(CHANNELS.SET_ANIME_CACHE, id, data) as Promise<boolean>,
+  getEpisode: (id: number, animeId?: number) =>
+    ipcRenderer.invoke(CHANNELS.GET_EPISODE, id, animeId),
   probeEmbedQuality: (translationId: number, animeId?: number) =>
-    ipcRenderer.invoke('probe-embed-quality', translationId, animeId) as Promise<number | null>,
+    ipcRenderer.invoke(CHANNELS.PROBE_EMBED_QUALITY, translationId, animeId) as Promise<
+      number | null
+    >,
   probeFullScanNeeded: (animeId: number, episodeCount: number) =>
-    ipcRenderer.invoke('probe-full-scan-needed', animeId, episodeCount) as Promise<boolean>,
+    ipcRenderer.invoke(CHANNELS.PROBE_FULL_SCAN_NEEDED, animeId, episodeCount) as Promise<boolean>,
   probeFullScanDone: (animeId: number, episodeCount: number) =>
-    ipcRenderer.invoke('probe-full-scan-done', animeId, episodeCount) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.PROBE_FULL_SCAN_DONE, animeId, episodeCount) as Promise<void>,
   reportQualityMismatch: (data: {
     translationId: number
     author: string
     type: string
     reported: number
     actual: number
-  }) => ipcRenderer.invoke('report-quality-mismatch', data),
+  }) => ipcRenderer.invoke(CHANNELS.REPORT_QUALITY_MISMATCH, data),
   getQualityMismatchCount: () =>
-    ipcRenderer.invoke('get-quality-mismatch-count') as Promise<number>,
+    ipcRenderer.invoke(CHANNELS.GET_QUALITY_MISMATCH_COUNT) as Promise<number>,
   dumpQualityMismatches: () =>
-    ipcRenderer.invoke('dump-quality-mismatches') as Promise<{ count: number; path: string }>,
-  debugGetMp4Stats: () => ipcRenderer.invoke('debug:get-mp4-stats') as Promise<Mp4StreamingStats>,
-  debugResetMp4Stats: () => ipcRenderer.invoke('debug:reset-mp4-stats') as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.DUMP_QUALITY_MISMATCHES) as Promise<{
+      count: number
+      path: string
+    }>,
+  debugGetMp4Stats: () =>
+    ipcRenderer.invoke(CHANNELS.DEBUG_GET_MP4_STATS) as Promise<Mp4StreamingStats>,
+  debugResetMp4Stats: () => ipcRenderer.invoke(CHANNELS.DEBUG_RESET_MP4_STATS) as Promise<void>,
   getCachedPoster: (animeId: number) =>
-    ipcRenderer.invoke('cache-get-poster', animeId) as Promise<string | null>,
-  libraryGet: () => ipcRenderer.invoke('library-get'),
-  libraryToggle: (anime: unknown) => ipcRenderer.invoke('library-toggle', anime),
-  libraryHas: (id: number) => ipcRenderer.invoke('library-has', id),
+    ipcRenderer.invoke(CHANNELS.CACHE_GET_POSTER, animeId) as Promise<string | null>,
+  libraryGet: () => ipcRenderer.invoke(CHANNELS.LIBRARY_GET),
+  libraryToggle: (anime: unknown) => ipcRenderer.invoke(CHANNELS.LIBRARY_TOGGLE, anime),
+  libraryHas: (id: number) => ipcRenderer.invoke(CHANNELS.LIBRARY_HAS, id),
   libraryGetStatus: (ids: number[]) =>
-    ipcRenderer.invoke('library-get-status', ids) as Promise<
+    ipcRenderer.invoke(CHANNELS.LIBRARY_GET_STATUS, ids) as Promise<
       Record<number, { starred: boolean; downloaded: boolean }>
     >,
-  libraryIsDownloaded: (id: number) => ipcRenderer.invoke('library-is-downloaded', id),
-  downloadedAnimeAdd: (anime: unknown) => ipcRenderer.invoke('downloaded-anime-add', anime),
+  libraryIsDownloaded: (id: number) => ipcRenderer.invoke(CHANNELS.LIBRARY_IS_DOWNLOADED, id),
+  downloadedAnimeAdd: (anime: unknown) => ipcRenderer.invoke(CHANNELS.DOWNLOADED_ANIME_ADD, anime),
   downloadedAnimeDelete: (animeId: number, animeName: string) =>
-    ipcRenderer.invoke('downloaded-anime-delete', animeId, animeName),
+    ipcRenderer.invoke(CHANNELS.DOWNLOADED_ANIME_DELETE, animeId, animeName),
   cleanupGetSize: (animeId: number, animeName: string) =>
-    ipcRenderer.invoke('cleanup:get-size', animeId, animeName) as Promise<{
+    ipcRenderer.invoke(CHANNELS.CLEANUP_GET_SIZE, animeId, animeName) as Promise<{
       bytes: number
       files: number
     }>,
   cleanupGetActiveDownloads: (animeName: string) =>
-    ipcRenderer.invoke('cleanup:get-active-downloads', animeName) as Promise<{ active: number }>,
+    ipcRenderer.invoke(CHANNELS.CLEANUP_GET_ACTIVE_DOWNLOADS, animeName) as Promise<{
+      active: number
+    }>,
   cleanupExecute: (animeId: number, animeName: string) =>
-    ipcRenderer.invoke('cleanup:execute', animeId, animeName) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.CLEANUP_EXECUTE, animeId, animeName) as Promise<void>,
   cleanupGetSnoozed: () =>
-    ipcRenderer.invoke('cleanup:get-snoozed') as Promise<Record<string, { animeName: string }>>,
+    ipcRenderer.invoke(CHANNELS.CLEANUP_GET_SNOOZED) as Promise<
+      Record<string, { animeName: string }>
+    >,
   cleanupSetSnoozed: (animeId: number, snoozed: boolean) =>
-    ipcRenderer.invoke('cleanup:set-snoozed', animeId, snoozed) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.CLEANUP_SET_SNOOZED, animeId, snoozed) as Promise<void>,
   onCleanupPrompt: (
     callback: (data: { animeId: number; animeName: string; malId: number }) => void
   ) => {
-    ipcRenderer.on('cleanup:prompt', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.CLEANUP_PROMPT, (_event, data) => callback(data))
   },
   offCleanupPrompt: () => {
-    ipcRenderer.removeAllListeners('cleanup:prompt')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.CLEANUP_PROMPT)
   },
-  getSetting: (key: string) => ipcRenderer.invoke('get-setting', key),
-  setSetting: (key: string, value: unknown) => ipcRenderer.invoke('set-setting', key, value),
+  getSetting: (key: string) => ipcRenderer.invoke(CHANNELS.GET_SETTING, key),
+  setSetting: (key: string, value: unknown) => ipcRenderer.invoke(CHANNELS.SET_SETTING, key, value),
 
   homeGetContinueWatching: () =>
-    ipcRenderer.invoke('home:get-continue-watching') as Promise<ContinueWatchingEntry[]>,
+    ipcRenderer.invoke(CHANNELS.HOME_GET_CONTINUE_WATCHING) as Promise<ContinueWatchingEntry[]>,
 
   // Watch progress
   watchProgressSave: (
@@ -110,7 +122,7 @@ const api = {
     translationId?: number
   ) =>
     ipcRenderer.invoke(
-      'watch-progress:save',
+      CHANNELS.WATCH_PROGRESS_SAVE,
       animeId,
       episodeInt,
       position,
@@ -119,7 +131,7 @@ const api = {
       translationId
     ),
   watchProgressGet: (animeId: number, episodeInt: string) =>
-    ipcRenderer.invoke('watch-progress:get', animeId, episodeInt) as Promise<{
+    ipcRenderer.invoke(CHANNELS.WATCH_PROGRESS_GET, animeId, episodeInt) as Promise<{
       position: number
       duration: number
       updatedAt: number
@@ -127,7 +139,7 @@ const api = {
       translationId?: number
     } | null>,
   watchProgressGetAll: (animeId: number) =>
-    ipcRenderer.invoke('watch-progress:get-all', animeId) as Promise<
+    ipcRenderer.invoke(CHANNELS.WATCH_PROGRESS_GET_ALL, animeId) as Promise<
       Record<
         string,
         {
@@ -141,36 +153,38 @@ const api = {
     >,
 
   // Downloads
-  downloadEnqueue: (requests: unknown[]) => ipcRenderer.invoke('download:enqueue', requests),
-  downloadPause: (id: string) => ipcRenderer.invoke('download:pause', id),
-  downloadResume: (id: string) => ipcRenderer.invoke('download:resume', id),
-  downloadRestart: (id: string) => ipcRenderer.invoke('download:restart', id),
-  downloadRestartAllFailed: () => ipcRenderer.invoke('download:restart-all-failed'),
-  downloadPauseAll: () => ipcRenderer.invoke('download:pause-all'),
-  downloadResumeAll: () => ipcRenderer.invoke('download:resume-all'),
-  downloadCancel: (id: string) => ipcRenderer.invoke('download:cancel', id),
-  downloadGetQueue: () => ipcRenderer.invoke('download:get-queue'),
+  downloadEnqueue: (requests: unknown[]) => ipcRenderer.invoke(CHANNELS.DOWNLOAD_ENQUEUE, requests),
+  downloadPause: (id: string) => ipcRenderer.invoke(CHANNELS.DOWNLOAD_PAUSE, id),
+  downloadResume: (id: string) => ipcRenderer.invoke(CHANNELS.DOWNLOAD_RESUME, id),
+  downloadRestart: (id: string) => ipcRenderer.invoke(CHANNELS.DOWNLOAD_RESTART, id),
+  downloadRestartAllFailed: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_RESTART_ALL_FAILED),
+  downloadPauseAll: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_PAUSE_ALL),
+  downloadResumeAll: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_RESUME_ALL),
+  downloadCancel: (id: string) => ipcRenderer.invoke(CHANNELS.DOWNLOAD_CANCEL, id),
+  downloadGetQueue: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_GET_QUEUE),
   downloadCancelByEpisode: (animeName: string, episodeLabel?: string) =>
-    ipcRenderer.invoke('download:cancel-by-episode', animeName, episodeLabel),
+    ipcRenderer.invoke(CHANNELS.DOWNLOAD_CANCEL_BY_EPISODE, animeName, episodeLabel),
   downloadedEpisodesGet: (animeId: number) =>
-    ipcRenderer.invoke('downloaded-episodes-get', animeId),
-  downloadClearCompleted: () => ipcRenderer.invoke('download:clear-completed'),
-  downloadCancelMerge: () => ipcRenderer.invoke('download:cancel-merge'),
-  downloadMerge: () => ipcRenderer.invoke('download:merge'),
-  ffmpegCheck: () => ipcRenderer.invoke('ffmpeg:check'),
-  ffmpegDelete: () => ipcRenderer.invoke('ffmpeg:delete'),
-  downloadPickDir: () => ipcRenderer.invoke('download:pick-dir'),
+    ipcRenderer.invoke(CHANNELS.DOWNLOADED_EPISODES_GET, animeId),
+  downloadClearCompleted: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_CLEAR_COMPLETED),
+  downloadCancelMerge: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_CANCEL_MERGE),
+  downloadMerge: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_MERGE),
+  ffmpegCheck: () => ipcRenderer.invoke(CHANNELS.FFMPEG_CHECK),
+  ffmpegDelete: () => ipcRenderer.invoke(CHANNELS.FFMPEG_DELETE),
+  downloadPickDir: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_PICK_DIR),
   // File management
   fileCheckEpisodes: (animeName: string, episodeInts: string[]) =>
-    ipcRenderer.invoke('file:check-episodes', animeName, episodeInts),
-  fileOpen: (filePath: string) => ipcRenderer.invoke('file:open', filePath),
-  fileShowInFolder: (filePath: string) => ipcRenderer.invoke('file:show-in-folder', filePath),
+    ipcRenderer.invoke(CHANNELS.FILE_CHECK_EPISODES, animeName, episodeInts),
+  fileOpen: (filePath: string) => ipcRenderer.invoke(CHANNELS.FILE_OPEN, filePath),
+  fileShowInFolder: (filePath: string) =>
+    ipcRenderer.invoke(CHANNELS.FILE_SHOW_IN_FOLDER, filePath),
   fileDeleteEpisode: (
     animeName: string,
     episodeInt: string,
     animeId?: number,
     translationId?: number
-  ) => ipcRenderer.invoke('file:delete-episode', animeName, episodeInt, animeId, translationId),
+  ) =>
+    ipcRenderer.invoke(CHANNELS.FILE_DELETE_EPISODE, animeName, episodeInt, animeId, translationId),
   onFileEpisodesChanged: (
     callback: (
       animeName: string,
@@ -180,78 +194,80 @@ const api = {
       >
     ) => void
   ) => {
-    ipcRenderer.on('file:episodes-changed', (_event, animeName, data) => callback(animeName, data))
+    ipcRenderer.on(EVENT_CHANNELS.FILE_EPISODES_CHANGED, (_event, animeName, data) =>
+      callback(animeName, data)
+    )
   },
   offFileEpisodesChanged: () => {
-    ipcRenderer.removeAllListeners('file:episodes-changed')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FILE_EPISODES_CHANGED)
   },
 
   // Storage
-  storagePickHotDir: () => ipcRenderer.invoke('storage:pick-hot-dir'),
-  storagePickColdDir: () => ipcRenderer.invoke('storage:pick-cold-dir'),
-  storageMoveToCold: () => ipcRenderer.invoke('storage:move-to-cold'),
+  storagePickHotDir: () => ipcRenderer.invoke(CHANNELS.STORAGE_PICK_HOT_DIR),
+  storagePickColdDir: () => ipcRenderer.invoke(CHANNELS.STORAGE_PICK_COLD_DIR),
+  storageMoveToCold: () => ipcRenderer.invoke(CHANNELS.STORAGE_MOVE_TO_COLD),
   onStorageMoveToColdProgress: (
     callback: (data: { current: number; total: number; file: string }) => void
   ) => {
-    ipcRenderer.on('storage:move-to-cold-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS, (_event, data) => callback(data))
   },
   offStorageMoveToColdProgress: () => {
-    ipcRenderer.removeAllListeners('storage:move-to-cold-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS)
   },
-  storageGetUsage: () => ipcRenderer.invoke('storage:get-usage') as Promise<StorageUsage>,
+  storageGetUsage: () => ipcRenderer.invoke(CHANNELS.STORAGE_GET_USAGE) as Promise<StorageUsage>,
   storageRunCleanup: (opts?: { force?: boolean }) =>
-    ipcRenderer.invoke('storage:run-cleanup', opts) as Promise<CleanupResult>,
+    ipcRenderer.invoke(CHANNELS.STORAGE_RUN_CLEANUP, opts) as Promise<CleanupResult>,
   onStorageUsageProgress: (callback: (data: { scanned: number; total: number }) => void) => {
-    ipcRenderer.on('storage:usage-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS, (_event, data) => callback(data))
   },
   offStorageUsageProgress: () => {
-    ipcRenderer.removeAllListeners('storage:usage-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS)
   },
   onStorageCleanupPending: (callback: (data: { candidates: CleanupCandidate[] }) => void) => {
-    ipcRenderer.on('storage:cleanup-pending', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.STORAGE_CLEANUP_PENDING, (_event, data) => callback(data))
   },
   offStorageCleanupPending: () => {
-    ipcRenderer.removeAllListeners('storage:cleanup-pending')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_CLEANUP_PENDING)
   },
   onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => {
-    ipcRenderer.on('storage:cleanup-finished', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED, (_event, data) => callback(data))
   },
   offStorageCleanupFinished: () => {
-    ipcRenderer.removeAllListeners('storage:cleanup-finished')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED)
   },
 
-  downloadScanMerge: () => ipcRenderer.invoke('download:scan-merge'),
-  downloadFixMetadata: () => ipcRenderer.invoke('download:fix-metadata'),
+  downloadScanMerge: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_SCAN_MERGE),
+  downloadFixMetadata: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_FIX_METADATA),
   onFixMetadataProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on('fix-metadata:progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.FIX_METADATA_PROGRESS, (_event, data) => callback(data))
   },
   offFixMetadataProgress: () => {
-    ipcRenderer.removeAllListeners('fix-metadata:progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FIX_METADATA_PROGRESS)
   },
 
   onDownloadProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on('download:progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.DOWNLOAD_PROGRESS, (_event, data) => callback(data))
   },
   offDownloadProgress: () => {
-    ipcRenderer.removeAllListeners('download:progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.DOWNLOAD_PROGRESS)
   },
   onScanMergeProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on('scan-merge:progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SCAN_MERGE_PROGRESS, (_event, data) => callback(data))
   },
   offScanMergeProgress: () => {
-    ipcRenderer.removeAllListeners('scan-merge:progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SCAN_MERGE_PROGRESS)
   },
   onFfmpegDownloadProgress: (callback: (data: { status: string; progress?: number }) => void) => {
-    ipcRenderer.on('ffmpeg:download-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS, (_event, data) => callback(data))
   },
   offFfmpegDownloadProgress: () => {
-    ipcRenderer.removeAllListeners('ffmpeg:download-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS)
   },
   onFpcalcDownloadProgress: (callback: (data: { status: string; progress?: number }) => void) => {
-    ipcRenderer.on('fpcalc:download-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS, (_event, data) => callback(data))
   },
   offFpcalcDownloadProgress: () => {
-    ipcRenderer.removeAllListeners('fpcalc:download-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS)
   },
 
   // Skip detection (Phase 1: debug panel only)
@@ -260,84 +276,84 @@ const api = {
     episodes: { episodeInt: string; episodeLabel: string; filePath: string }[]
   ) =>
     ipcRenderer.invoke(
-      'skip-detector:analyze-show',
+      CHANNELS.SKIP_DETECTOR_ANALYZE_SHOW,
       animeId,
       episodes
     ) as Promise<ShowSkipDetections>,
   skipDetectorGetDetections: (animeId: number) =>
     ipcRenderer.invoke(
-      'skip-detector:get-detections',
+      CHANNELS.SKIP_DETECTOR_GET_DETECTIONS,
       animeId
     ) as Promise<ShowSkipDetections | null>,
   skipDetectorDetectStream: (animeId: number, episodeInt: string, streamUrl: string) =>
     ipcRenderer.invoke(
-      'skip-detector:detect-stream',
+      CHANNELS.SKIP_DETECTOR_DETECT_STREAM,
       animeId,
       episodeInt,
       streamUrl
     ) as Promise<EpisodeSkipDetection | null>,
   skipDetectorCancelStreamDetect: () =>
-    ipcRenderer.invoke('skip-detector:cancel-stream-detect') as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_CANCEL_STREAM_DETECT) as Promise<void>,
   skipDetectorGetStatus: () =>
-    ipcRenderer.invoke('skip-detector:get-status') as Promise<{
+    ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_GET_STATUS) as Promise<{
       animeId: number
       lastProgress: SkipDetectorProgress | null
     } | null>,
-  skipDetectorCancel: () => ipcRenderer.invoke('skip-detector:cancel') as Promise<void>,
+  skipDetectorCancel: () => ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_CANCEL) as Promise<void>,
   skipDetectorCacheStats: () =>
-    ipcRenderer.invoke('skip-detector:cache-stats') as Promise<{ fingerprintCount: number }>,
+    ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_CACHE_STATS) as Promise<{ fingerprintCount: number }>,
   skipDetectorBackfillAll: () =>
-    ipcRenderer.invoke('skip-detector:backfill-all') as Promise<{
+    ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_BACKFILL_ALL) as Promise<{
       queued: number
       alreadyAnalyzed: number
       skippedFewEpisodes: number
       total: number
     }>,
   skipDetectorQueueStatus: () =>
-    ipcRenderer.invoke('skip-detector:queue-status') as Promise<{
+    ipcRenderer.invoke(CHANNELS.SKIP_DETECTOR_QUEUE_STATUS) as Promise<{
       currentAnimeId: number | null
       queueLength: number
     }>,
   onSkipDetectorProgress: (callback: (data: SkipDetectorProgress) => void) => {
-    ipcRenderer.on('skip-detector:analyze-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS, (_event, data) => callback(data))
   },
   offSkipDetectorProgress: () => {
-    ipcRenderer.removeAllListeners('skip-detector:analyze-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS)
   },
   onSkipDetectorSignatureUpdated: (
     callback: (data: { animeId: number; perEpisode: Record<string, EpisodeSkipDetection> }) => void
   ) => {
-    ipcRenderer.on('skip-detector:signature-updated', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, (_event, data) => callback(data))
   },
   offSkipDetectorSignatureUpdated: () => {
-    ipcRenderer.removeAllListeners('skip-detector:signature-updated')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED)
   },
 
   injectChapters: (
     animeId: number,
     episodes: { episodeInt: string; episodeLabel: string; filePath: string }[]
   ) =>
-    ipcRenderer.invoke('download:inject-chapters', animeId, episodes) as Promise<{
+    ipcRenderer.invoke(CHANNELS.DOWNLOAD_INJECT_CHAPTERS, animeId, episodes) as Promise<{
       written: number
       skipped: number
       failed: number
       total: number
     }>,
   onChapterInjectProgress: (callback: (data: ChapterInjectProgress) => void) => {
-    ipcRenderer.on('chapter-inject:progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS, (_event, data) => callback(data))
   },
   offChapterInjectProgress: () => {
-    ipcRenderer.removeAllListeners('chapter-inject:progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS)
   },
 
   shellOpenExternal: (url: string) =>
-    ipcRenderer.invoke('shell:open-external', url) as Promise<boolean>,
+    ipcRenderer.invoke(CHANNELS.SHELL_OPEN_EXTERNAL, url) as Promise<boolean>,
 
   // Player
   playerGetStreamUrl: (translationId: number, maxHeight: number) =>
-    ipcRenderer.invoke('player:get-stream-url', translationId, maxHeight),
+    ipcRenderer.invoke(CHANNELS.PLAYER_GET_STREAM_URL, translationId, maxHeight),
   playerGetLocalSubtitles: (filePath: string) =>
-    ipcRenderer.invoke('player:get-local-subtitles', filePath) as Promise<string | null>,
+    ipcRenderer.invoke(CHANNELS.PLAYER_GET_LOCAL_SUBTITLES, filePath) as Promise<string | null>,
   playerFindLocalFile: (
     animeName: string,
     episodeInt: string,
@@ -345,18 +361,18 @@ const api = {
     episodeLabel: string
   ) =>
     ipcRenderer.invoke(
-      'player:find-local-file',
+      CHANNELS.PLAYER_FIND_LOCAL_FILE,
       animeName,
       episodeInt,
       translationId,
       episodeLabel
     ) as Promise<{ filePath: string; subtitleContent: string | null } | null>,
   playerRemuxMkv: (mkvPath: string) =>
-    ipcRenderer.invoke('player:remux-mkv', mkvPath) as Promise<
+    ipcRenderer.invoke(CHANNELS.PLAYER_REMUX_MKV, mkvPath) as Promise<
       { mp4Path: string; subtitleContent?: string } | { error: string }
     >,
   playerRemuxMkvStream: (mkvPath: string, initialSeek?: number) =>
-    ipcRenderer.invoke('player:remux-mkv-stream', mkvPath, initialSeek) as Promise<
+    ipcRenderer.invoke(CHANNELS.PLAYER_REMUX_MKV_STREAM, mkvPath, initialSeek) as Promise<
       | {
           sessionId: string
           generation: number
@@ -368,7 +384,7 @@ const api = {
       | { error: string }
     >,
   playerRemuxMkvStreamTranscode: (mkvPath: string, initialSeek?: number) =>
-    ipcRenderer.invoke('player:remux-mkv-stream-transcode', mkvPath, initialSeek) as Promise<
+    ipcRenderer.invoke(CHANNELS.PLAYER_REMUX_MKV_STREAM_TRANSCODE, mkvPath, initialSeek) as Promise<
       | {
           sessionId: string
           generation: number
@@ -380,44 +396,44 @@ const api = {
       | { error: string }
     >,
   shellOpenExternalFile: (filePath: string) =>
-    ipcRenderer.invoke('shell:open-external-file', filePath) as Promise<{
+    ipcRenderer.invoke(CHANNELS.SHELL_OPEN_EXTERNAL_FILE, filePath) as Promise<{
       ok: boolean
       error?: string
     }>,
   playerStreamStart: (sessionId: string) =>
-    ipcRenderer.invoke('player:stream-start', sessionId) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.PLAYER_STREAM_START, sessionId) as Promise<void>,
   playerStreamAck: (sessionId: string, bytes: number) =>
-    ipcRenderer.invoke('player:stream-ack', sessionId, bytes) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.PLAYER_STREAM_ACK, sessionId, bytes) as Promise<void>,
   playerStreamSeek: (sessionId: string, seekSeconds: number) =>
-    ipcRenderer.invoke('player:stream-seek', sessionId, seekSeconds) as Promise<
+    ipcRenderer.invoke(CHANNELS.PLAYER_STREAM_SEEK, sessionId, seekSeconds) as Promise<
       { ok: true; generation: number; keyframeTime: number } | { error: string }
     >,
-  playerCleanupRemux: () => ipcRenderer.invoke('player:cleanup-remux') as Promise<void>,
+  playerCleanupRemux: () => ipcRenderer.invoke(CHANNELS.PLAYER_CLEANUP_REMUX) as Promise<void>,
   onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => {
-    ipcRenderer.on('player:stream-subtitles', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES, (_event, data) => callback(data))
   },
   offPlayerStreamSubtitles: () => {
-    ipcRenderer.removeAllListeners('player:stream-subtitles')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES)
   },
   onPlayerStreamChunk: (
     callback: (data: { sessionId: string; gen: number; data: Uint8Array }) => void
   ) => {
-    ipcRenderer.on('player:stream-chunk', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_CHUNK, (_event, data) => callback(data))
   },
   offPlayerStreamChunk: () => {
-    ipcRenderer.removeAllListeners('player:stream-chunk')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_CHUNK)
   },
   onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => {
-    ipcRenderer.on('player:stream-end', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_END, (_event, data) => callback(data))
   },
   offPlayerStreamEnd: () => {
-    ipcRenderer.removeAllListeners('player:stream-end')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_END)
   },
   onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => {
-    ipcRenderer.on('player:stream-error', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_ERROR, (_event, data) => callback(data))
   },
   offPlayerStreamError: () => {
-    ipcRenderer.removeAllListeners('player:stream-error')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_ERROR)
   },
   onPlayerStreamProgress: (
     callback: (data: {
@@ -427,63 +443,69 @@ const api = {
       time: number | null
     }) => void
   ) => {
-    ipcRenderer.on('player:stream-progress', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS, (_event, data) => callback(data))
   },
   offPlayerStreamProgress: () => {
-    ipcRenderer.removeAllListeners('player:stream-progress')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS)
   },
 
   // Shikimori
-  shikimoriGetAuthUrl: () => ipcRenderer.invoke('shikimori:get-auth-url') as Promise<string>,
-  shikimoriExchangeCode: (code: string) => ipcRenderer.invoke('shikimori:exchange-code', code),
-  shikimoriLogout: () => ipcRenderer.invoke('shikimori:logout'),
-  shikimoriGetUser: () => ipcRenderer.invoke('shikimori:get-user'),
-  shikimoriGetRate: (malId: number) => ipcRenderer.invoke('shikimori:get-rate', malId),
+  shikimoriGetAuthUrl: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_AUTH_URL) as Promise<string>,
+  shikimoriExchangeCode: (code: string) =>
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_EXCHANGE_CODE, code),
+  shikimoriLogout: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_LOGOUT),
+  shikimoriGetUser: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_USER),
+  shikimoriGetRate: (malId: number) => ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_RATE, malId),
   shikimoriUpdateRate: (
     malId: number,
     episodes: number,
     status: string,
     score: number,
     rewatches: number
-  ) => ipcRenderer.invoke('shikimori:update-rate', malId, episodes, status, score, rewatches),
+  ) =>
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_UPDATE_RATE, malId, episodes, status, score, rewatches),
   shikimoriGetFriendsRates: (malId: number) =>
-    ipcRenderer.invoke('shikimori:get-friends-rates', malId) as Promise<ShikiFriendRate[]>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_FRIENDS_RATES, malId) as Promise<ShikiFriendRate[]>,
   shikimoriGetAnimeRates: (status?: string) =>
-    ipcRenderer.invoke('shikimori:get-anime-rates', status) as Promise<ShikiAnimeRateEntry[]>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_ANIME_RATES, status) as Promise<
+      ShikiAnimeRateEntry[]
+    >,
   shikimoriGetFriendsActivity: () =>
-    ipcRenderer.invoke('shikimori:get-friends-activity') as Promise<ShikiFriendActivityEntry[]>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_FRIENDS_ACTIVITY) as Promise<
+      ShikiFriendActivityEntry[]
+    >,
   shikimoriGetCalendar: (force = false) =>
-    ipcRenderer.invoke('shikimori:get-calendar', force) as Promise<CalendarEntry[]>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_CALENDAR, force) as Promise<CalendarEntry[]>,
   shikimoriGetRelated: (malId: number) =>
-    ipcRenderer.invoke('shikimori:get-related', malId) as Promise<ShikiRelatedEntry[]>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_RELATED, malId) as Promise<ShikiRelatedEntry[]>,
   onShikimoriRateUpdated: (callback: (entry: ShikiAnimeRateEntry) => void) => {
-    ipcRenderer.on('shikimori:rate-updated', (_event, entry) => callback(entry))
+    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED, (_event, entry) => callback(entry))
   },
   offShikimoriRateUpdated: () => {
-    ipcRenderer.removeAllListeners('shikimori:rate-updated')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED)
   },
   onShikimoriRatesRefreshed: (callback: (entries: ShikiAnimeRateEntry[]) => void) => {
-    ipcRenderer.on('shikimori:rates-refreshed', (_event, entries) => callback(entries))
+    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED, (_event, entries) => callback(entries))
   },
   offShikimoriRatesRefreshed: () => {
-    ipcRenderer.removeAllListeners('shikimori:rates-refreshed')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED)
   },
   shikimoriGetOfflineQueueLength: () =>
-    ipcRenderer.invoke('shikimori:get-offline-queue-length') as Promise<number>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_OFFLINE_QUEUE_LENGTH) as Promise<number>,
   onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => {
-    ipcRenderer.on('shikimori:offline-queue-changed', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED, (_event, data) => callback(data))
   },
   offShikimoriOfflineQueueChanged: () => {
-    ipcRenderer.removeAllListeners('shikimori:offline-queue-changed')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED)
   },
   shikimoriGetSyncStatus: () =>
-    ipcRenderer.invoke('shikimori:get-sync-status') as Promise<{
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_SYNC_STATUS) as Promise<{
       state: 'idle' | 'syncing'
       queueLength: number
       lastSyncAt: number
       lastSyncError: string | null
     }>,
-  shikimoriTriggerSync: () => ipcRenderer.invoke('shikimori:trigger-sync') as Promise<void>,
+  shikimoriTriggerSync: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_TRIGGER_SYNC) as Promise<void>,
   onShikimoriSyncStatus: (
     callback: (data: {
       state: 'idle' | 'syncing'
@@ -492,22 +514,25 @@ const api = {
       lastSyncError: string | null
     }) => void
   ) => {
-    ipcRenderer.on('shikimori:sync-status', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS, (_event, data) => callback(data))
   },
   offShikimoriSyncStatus: () => {
-    ipcRenderer.removeAllListeners('shikimori:sync-status')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS)
   },
   shikimoriGetAnimeDetails: (malId: number) =>
-    ipcRenderer.invoke('shikimori:get-anime-details', malId) as Promise<ShikiAnimeDetails | null>,
+    ipcRenderer.invoke(
+      CHANNELS.SHIKIMORI_GET_ANIME_DETAILS,
+      malId
+    ) as Promise<ShikiAnimeDetails | null>,
   shikimoriTriggerDetailPrefetch: () =>
-    ipcRenderer.invoke('shikimori:trigger-detail-prefetch') as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.SHIKIMORI_TRIGGER_DETAIL_PREFETCH) as Promise<void>,
   onShikimoriAnimeDetailsUpdated: (
     callback: (data: { malId: number; details: ShikiAnimeDetails }) => void
   ) => {
-    ipcRenderer.on('shikimori:anime-details-updated', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED, (_event, data) => callback(data))
   },
   offShikimoriAnimeDetailsUpdated: () => {
-    ipcRenderer.removeAllListeners('shikimori:anime-details-updated')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED)
   },
 
   // Syncplay (Watch Together)
@@ -518,8 +543,8 @@ const api = {
     username: string
     password?: string
     autoReconnect: boolean
-  }) => ipcRenderer.invoke('syncplay:connect', cfg) as Promise<void>,
-  syncplayDisconnect: () => ipcRenderer.invoke('syncplay:disconnect') as Promise<void>,
+  }) => ipcRenderer.invoke(CHANNELS.SYNCPLAY_CONNECT, cfg) as Promise<void>,
+  syncplayDisconnect: () => ipcRenderer.invoke(CHANNELS.SYNCPLAY_DISCONNECT) as Promise<void>,
   syncplaySetFile: (file: {
     animeId: number
     malId: number | null
@@ -527,17 +552,18 @@ const api = {
     translationId: number | null
     canonicalName: string
     duration: number
-  }) => ipcRenderer.invoke('syncplay:set-file', file) as Promise<void>,
+  }) => ipcRenderer.invoke(CHANNELS.SYNCPLAY_SET_FILE, file) as Promise<void>,
   syncplaySendLocalState: (payload: {
     paused: boolean
     position: number
     cause: 'play' | 'pause' | 'seek'
-  }) => ipcRenderer.invoke('syncplay:local-state', payload) as Promise<void>,
+  }) => ipcRenderer.invoke(CHANNELS.SYNCPLAY_LOCAL_STATE, payload) as Promise<void>,
   syncplaySendLocalSnapshot: (snap: { position: number; paused: boolean }) =>
-    ipcRenderer.invoke('syncplay:local-snapshot', snap) as Promise<void>,
+    ipcRenderer.invoke(CHANNELS.SYNCPLAY_LOCAL_SNAPSHOT, snap) as Promise<void>,
   syncplaySetReady: (isReady: boolean) =>
-    ipcRenderer.invoke('syncplay:set-ready', isReady) as Promise<void>,
-  syncplayGetStatus: () => ipcRenderer.invoke('syncplay:get-status') as Promise<SyncplayStatus>,
+    ipcRenderer.invoke(CHANNELS.SYNCPLAY_SET_READY, isReady) as Promise<void>,
+  syncplayGetStatus: () =>
+    ipcRenderer.invoke(CHANNELS.SYNCPLAY_GET_STATUS) as Promise<SyncplayStatus>,
   onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
     syncplayOn('syncplay:connection-status', callback),
   offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
@@ -567,7 +593,7 @@ const api = {
   // Auto-downloader
   autoDlGetSubscription: (animeId: number) =>
     ipcRenderer.invoke(
-      'auto-dl:get-subscription',
+      CHANNELS.AUTO_DL_GET_SUBSCRIPTION,
       animeId
     ) as Promise<AutoDownloadSubscription | null>,
   autoDlSetSubscription: (
@@ -576,48 +602,48 @@ const api = {
     meta?: { malId: number; animeName: string }
   ) =>
     ipcRenderer.invoke(
-      'auto-dl:set-subscription',
+      CHANNELS.AUTO_DL_SET_SUBSCRIPTION,
       animeId,
       enabled,
       meta
     ) as Promise<AutoDownloadSubscription | null>,
   autoDlListSubscriptions: () =>
-    ipcRenderer.invoke('auto-dl:list-subscriptions') as Promise<AutoDownloadSubscription[]>,
-  autoDlTrigger: () => ipcRenderer.invoke('auto-dl:trigger') as Promise<AutoDlTickResult>,
+    ipcRenderer.invoke(CHANNELS.AUTO_DL_LIST_SUBSCRIPTIONS) as Promise<AutoDownloadSubscription[]>,
+  autoDlTrigger: () => ipcRenderer.invoke(CHANNELS.AUTO_DL_TRIGGER) as Promise<AutoDlTickResult>,
   autoDlGetStatus: () =>
-    ipcRenderer.invoke('auto-dl:get-status') as Promise<{
+    ipcRenderer.invoke(CHANNELS.AUTO_DL_GET_STATUS) as Promise<{
       lastResult: AutoDlTickResult | null
       locked: boolean
       enabled: boolean
     }>,
-  autoDlGetEnabled: () => ipcRenderer.invoke('auto-dl:get-enabled') as Promise<boolean>,
+  autoDlGetEnabled: () => ipcRenderer.invoke(CHANNELS.AUTO_DL_GET_ENABLED) as Promise<boolean>,
   autoDlSetEnabled: (enabled: boolean) =>
-    ipcRenderer.invoke('auto-dl:set-enabled', enabled) as Promise<boolean>,
+    ipcRenderer.invoke(CHANNELS.AUTO_DL_SET_ENABLED, enabled) as Promise<boolean>,
   onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => {
-    ipcRenderer.on('auto-dl:tick-result', (_event, result) => callback(result))
+    ipcRenderer.on(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, (_event, result) => callback(result))
   },
   offAutoDlTickResult: () => {
-    ipcRenderer.removeAllListeners('auto-dl:tick-result')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.AUTO_DL_TICK_RESULT)
   },
   onAutoDlEnqueued: (
     callback: (data: { animeId: number; episodeInt: string; animeName: string }) => void
   ) => {
-    ipcRenderer.on('auto-dl:enqueued', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.AUTO_DL_ENQUEUED, (_event, data) => callback(data))
   },
   offAutoDlEnqueued: () => {
-    ipcRenderer.removeAllListeners('auto-dl:enqueued')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.AUTO_DL_ENQUEUED)
   },
 
   // Updates
-  appVersion: () => ipcRenderer.invoke('app:version'),
-  updateCheck: () => ipcRenderer.invoke('update:check'),
-  updateDownload: () => ipcRenderer.invoke('update:download'),
-  updateInstall: () => ipcRenderer.invoke('update:install'),
+  appVersion: () => ipcRenderer.invoke(CHANNELS.APP_VERSION),
+  updateCheck: () => ipcRenderer.invoke(CHANNELS.UPDATE_CHECK),
+  updateDownload: () => ipcRenderer.invoke(CHANNELS.UPDATE_DOWNLOAD),
+  updateInstall: () => ipcRenderer.invoke(CHANNELS.UPDATE_INSTALL),
   onUpdateStatus: (callback: (data: unknown) => void) => {
-    ipcRenderer.on('update:status', (_event, data) => callback(data))
+    ipcRenderer.on(EVENT_CHANNELS.UPDATE_STATUS, (_event, data) => callback(data))
   },
   offUpdateStatus: () => {
-    ipcRenderer.removeAllListeners('update:status')
+    ipcRenderer.removeAllListeners(EVENT_CHANNELS.UPDATE_STATUS)
   }
 }
 

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -226,7 +226,15 @@ export const EVENT_CHANNELS = {
   STORAGE_CLEANUP_FINISHED: 'storage:cleanup-finished',
   STORAGE_CLEANUP_PENDING: 'storage:cleanup-pending',
   STORAGE_MOVE_TO_COLD_PROGRESS: 'storage:move-to-cold-progress',
-  STORAGE_USAGE_PROGRESS: 'storage:usage-progress'
+  STORAGE_USAGE_PROGRESS: 'storage:usage-progress',
+
+  // Syncplay
+  SYNCPLAY_CONNECTION_STATUS: 'syncplay:connection-status',
+  SYNCPLAY_REMOTE_EPISODE_CHANGE: 'syncplay:remote-episode-change',
+  SYNCPLAY_REMOTE_STATE: 'syncplay:remote-state',
+  SYNCPLAY_ROOM_EVENT: 'syncplay:room-event',
+  SYNCPLAY_ROOM_USERS: 'syncplay:room-users',
+  SYNCPLAY_TRACE: 'syncplay:trace'
 } as const
 
 export type RequestChannel = (typeof CHANNELS)[keyof typeof CHANNELS]

--- a/test/ipc-channels.test.ts
+++ b/test/ipc-channels.test.ts
@@ -12,7 +12,7 @@ const SOURCES = MAIN + '\n' + PRELOAD
 // EVENT_CHANNELS. reference — a bare string literal here means an un-migrated
 // channel bypassing the single source of truth.
 const IPC_CALL =
-  /(?:ipcMain\.(?:handle|on)|ipcRenderer\.(?:invoke|send|on|removeListener|removeAllListeners)|[\w.]+\.webContents\.send|sender\.send)\(\s*(['"`])([a-z][\w:-]+)\1/g
+  /(?:ipcMain\.(?:handle|on)|ipcRenderer\.(?:invoke|send|on|removeListener|removeAllListeners)|[\w.]+\.webContents\.send|sender\.send|broadcastToAll)\(\s*(['"`])([a-z][\w:-]+)\1/g
 
 describe('IPC channel contract', () => {
   const requestValues = Object.values(CHANNELS)

--- a/test/ipc-channels.test.ts
+++ b/test/ipc-channels.test.ts
@@ -3,27 +3,16 @@ import { readFileSync } from 'fs'
 import { resolve } from 'path'
 import { CHANNELS, EVENT_CHANNELS } from '../src/shared/ipc/channels'
 
-// Re-derive the channel literals straight from the production source so the
-// contract can't silently drift: if someone adds/renames an ipc channel in
-// main or preload without updating channels.ts, this fails.
-function scan() {
-  const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
-  const sources = read('src/main/index.ts') + '\n' + read('src/preload/index.ts')
+const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
+const MAIN = read('src/main/index.ts')
+const PRELOAD = read('src/preload/index.ts')
+const SOURCES = MAIN + '\n' + PRELOAD
 
-  const reqRe =
-    /(?:ipcMain\.(?:handle|on)|ipcRenderer\.(?:invoke|send))\(\s*[`'"]([a-z][\w:-]+)[`'"]/g
-  const evtRe =
-    /(?:webContents\.send|ipcRenderer\.(?:on|removeListener|removeAllListeners))\(\s*[`'"]([a-z][\w:-]+)[`'"]/g
-
-  const request = new Set<string>()
-  const event = new Set<string>()
-  let m: RegExpExecArray | null
-  while ((m = reqRe.exec(sources))) request.add(m[1])
-  while ((m = evtRe.exec(sources))) event.add(m[1])
-  // A channel that is broadcast is an event, not a request.
-  for (const c of event) request.delete(c)
-  return { request, event }
-}
+// First arg of every IPC-ish call. Post-1c every one must be a CHANNELS./
+// EVENT_CHANNELS. reference — a bare string literal here means an un-migrated
+// channel bypassing the single source of truth.
+const IPC_CALL =
+  /(?:ipcMain\.(?:handle|on)|ipcRenderer\.(?:invoke|send|on|removeListener|removeAllListeners)|[\w.]+\.webContents\.send|sender\.send)\(\s*(['"`])([a-z][\w:-]+)\1/g
 
 describe('IPC channel contract', () => {
   const requestValues = Object.values(CHANNELS)
@@ -48,9 +37,21 @@ describe('IPC channel contract', () => {
     }
   })
 
-  it('exhaustively mirrors the channels used in main + preload', () => {
-    const { request, event } = scan()
-    expect([...request].sort()).toEqual([...requestValues].sort())
-    expect([...event].sort()).toEqual([...eventValues].sort())
+  it('leaves no raw IPC channel string literals in main or preload (1c migration complete)', () => {
+    const leftovers = new Set<string>()
+    let m: RegExpExecArray | null
+    IPC_CALL.lastIndex = 0
+    while ((m = IPC_CALL.exec(SOURCES))) leftovers.add(m[2])
+    expect([...leftovers]).toEqual([])
+  })
+
+  it('has no dead contract constants — every channel is referenced by symbol', () => {
+    const unreferenced = [...Object.keys(CHANNELS), ...Object.keys(EVENT_CHANNELS)].filter(
+      (key) => {
+        const sym = (key in CHANNELS ? 'CHANNELS.' : 'EVENT_CHANNELS.') + key
+        return !SOURCES.includes(sym)
+      }
+    )
+    expect(unreferenced).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

Final slice of **Phase 1** (#84). **Behavior byte-identical.** Every IPC channel string literal in `main` and `preload` now dereferences its `CHANNELS` / `EVENT_CHANNELS` constant from `@shared/ipc/channels` — the single source of truth introduced in 1b becomes load-bearing.

> ⚠️ **Stacked on #87 → #86.** Base is `phase-1b-ipc-contract`. I'll rebase down onto `main` and retarget as #86/#87 merge.

## Changes

- `src/main/index.ts` — **128** distinct channel literals → constants (`ipcMain.handle/on`, `webContents.send`, `sender.send`).
- `src/preload/index.ts` — **144** distinct channel literals → constants (`ipcRenderer.invoke/send/on/removeListener/removeAllListeners`).
- Added `import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'` to both.
- `test/ipc-channels.test.ts` reworked for the post-migration invariant: **no raw IPC channel literal may remain** (single source of truth enforced) and **no contract constant is dead** (each referenced by symbol), keeping the uniqueness / disjoint / key-derivation checks.

## Why this is behavior-identical

The constant values are the exact original strings — guaranteed by the 1b test that every key is `value.replace(/[:-]/g,'_').toUpperCase()`. The codemod only substitutes the first argument of IPC calls; no handler logic, no `on*/off*` set, and **no `window.api` / `Api` shape** changes. The renderer is untouched.

## Explicitly deferred (not a regression)

The `on*/off*` → `subscribe`-returns-disposer rewrite and the `removeAllListeners` footgun fix are **out of scope here**: they change `window.api`'s shape and every renderer subscription call site, which Phase 1 forbids ("no renderer changes yet"). The epic assigns that to **Phase 4** (renderer state layer). 1b already ships the `Unsubscribe`/`EventSubscriber` contract those will implement.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run build` — succeeds (`@shared` resolves in main+preload bundles)
- [x] `npm run test` — 8 tests green (incl. "no literals remain" + "no dead constants")
- [ ] CI `quality` job — verify on this PR
- [ ] Manual smoke (post-merge): app launches, a few IPC round-trips (search, library toggle, download enqueue, a broadcast like download progress) behave identically

Part of #84 (Phase 1, slice 1c — completes Phase 1's main/preload wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)