### PR TITLE
refactor: Phase 2 PR2 — StorageService injected persistence boundary (#89)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,6 +40,10 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/main/lib/shikimori-queue.ts` | `QueuedShikimoriUpdate`/`ConsolidatedWorkItem` types + pure `consolidateQueue` (per-malId offline-queue collapse) |
 | `src/main/lib/filename.ts` | Pure `parseEpisodeFromFilename` (episodeInt + ext from sanitized download filename) |
 | `src/main/streaming/codec-strings.ts` | Pure ffprobe→codec-string mappers: `avcCodecString`, `hevcCodecString`, `aacCodecString` (MSE-compatible RFC 6381 strings) |
+| `src/main/store/types.ts` | Injected `StorageService<S>` persistence interface (schema-typed get/set/has/delete); decouples services from `electron-store` |
+| `src/main/store/index.ts` | `createStorageService(defaults)` electron-store binding + `MainStorageService.migrateWatchProgressV2()` |
+| `src/main/store/keys.ts` | `PERSISTED_STORE_KEYS` frozen tuple — rename guard, compile-time-asserted against `keyof STORE_DEFAULTS` in `index.ts` |
+| `src/main/store/migrate.ts` | Pure `migrateWatchProgressV2(store)` (one-shot `watchedAt` backfill) |
 | `src/preload/index.ts` | contextBridge API exposure to renderer |
 | `src/preload/index.d.ts` | Shared TypeScript interfaces for IPC communication |
 | `src/renderer/src/main.ts` | Vue app entry point |

--- a/src/main/auto-downloader.ts
+++ b/src/main/auto-downloader.ts
@@ -1,4 +1,4 @@
-import type Store from 'electron-store'
+import type { StorageService } from './store/types'
 import type { SmotretApi, EpisodeDetail, Translation } from './smotret-api'
 import type { DownloadManager, DownloadRequest } from './download-manager'
 import type { AutoDownloadSubscription } from './index'
@@ -45,7 +45,7 @@ interface ShikiAnimeDetailsCacheEntry {
 }
 
 interface AutoDownloaderDeps {
-  store: Store<Record<string, unknown>>
+  store: StorageService
   smotretApi: SmotretApi
   downloadManager: DownloadManager
   broadcast: (channel: string, ...args: unknown[]) => void
@@ -191,7 +191,7 @@ function pickTranslation(
 }
 
 function mostRecentDownloadedTranslation(
-  store: Store<Record<string, unknown>>,
+  store: StorageService,
   animeId: number
 ): { type: string; author: string } | null {
   const all = store.get('downloadedEpisodes') as Record<string, DownloadedEpisodeMeta>
@@ -204,11 +204,7 @@ function mostRecentDownloadedTranslation(
   return null
 }
 
-function isAlreadyDownloaded(
-  store: Store<Record<string, unknown>>,
-  animeId: number,
-  episodeInt: string
-): boolean {
+function isAlreadyDownloaded(store: StorageService, animeId: number, episodeInt: string): boolean {
   const all = store.get('downloadedEpisodes') as Record<string, DownloadedEpisodeMeta>
   const newPrefix = `${animeId}:${episodeInt}:`
   const legacyKey = `${animeId}:${episodeInt}`

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,8 @@ import { app, shell, BrowserWindow, ipcMain, dialog, Notification, protocol, net
 import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'
 import { join } from 'path'
 import { is } from '@electron-toolkit/utils'
-import Store from 'electron-store'
+import { createStorageService } from './store'
+import { type PersistedStoreKey } from './store/keys'
 import { DownloadManager, sanitizeFilename } from './download-manager'
 import type { DownloadRequest } from './download-manager'
 import {
@@ -105,112 +106,119 @@ export interface AutoDownloadSubscription {
   initialEpisodesAired?: number
 }
 
-const store = new Store({
-  defaults: {
-    token: '',
-    translationType: 'subRu',
-    downloadDir: '',
-    library: {} as Record<string, AnimeSearchResult>,
-    autoMerge: false,
-    videoCodec: 'copy' as string,
-    downloadedAnime: {} as Record<string, AnimeSearchResult>,
-    downloadedEpisodes: {} as Record<
-      string,
-      { translationType: string; author: string; quality: number; translationId: number }
-    >,
-    animeCache: {} as Record<string, AnimeCacheEntry>,
-    lastUpdateCheck: 0,
-    notificationMode: 'off' as string,
-    downloadSpeedLimit: 0,
-    concurrentDownloads: 2,
-    keyboardShortcuts: {
-      back: 'Escape',
-      focusSearch: 'CmdOrCtrl+F',
-      goDownloads: 'CmdOrCtrl+D',
-      playerPrevEpisode: 'Shift+ArrowLeft',
-      playerNextEpisode: 'Shift+ArrowRight',
-      shaderModeA: 'CmdOrCtrl+1',
-      shaderModeB: 'CmdOrCtrl+2',
-      shaderModeC: 'CmdOrCtrl+3',
-      shaderOff: 'CmdOrCtrl+Backquote'
-    } as Record<string, string>,
-    shikimoriCredentials: null as shikimori.ShikiCredentials | null,
-    shikimoriUser: null as shikimori.ShikiUser | null,
-    storageMode: 'simple' as 'simple' | 'advanced',
-    hotStorageDir: '' as string,
-    coldStorageDir: '' as string,
-    autoMoveToCold: false,
-    malIdMap: {} as Record<string, AnimeSearchResult>,
-    playerMode: 'system' as 'system' | 'builtin',
-    playerVolume: 1 as number,
-    playerMuted: false,
-    anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
-    hevcTranscodeOnPlay: 'ask' as 'ask' | 'always' | 'never',
-    prefetchNextEpisode: 'progress-50' as 'off' | 'open' | 'time-5min' | 'progress-50',
-    watchProgress: {} as Record<
-      string,
-      {
-        position: number
-        duration: number
-        updatedAt: number
-        watched?: boolean
-        watchedAt?: number
-        translationId?: number
-      }
-    >,
-    watchProgressMigrationV2: false,
-    autoCleanupWatchedDays: 0,
-    autoCleanupConfirm: true,
-    autoCleanupLastRun: null as { ranAt: number; deletedCount: number; freedBytes: number } | null,
-    cleanupLog: [] as {
-      ranAt: number
+const STORE_DEFAULTS = {
+  token: '',
+  translationType: 'subRu',
+  downloadDir: '',
+  library: {} as Record<string, AnimeSearchResult>,
+  autoMerge: false,
+  videoCodec: 'copy' as string,
+  downloadedAnime: {} as Record<string, AnimeSearchResult>,
+  downloadedEpisodes: {} as Record<
+    string,
+    { translationType: string; author: string; quality: number; translationId: number }
+  >,
+  animeCache: {} as Record<string, AnimeCacheEntry>,
+  lastUpdateCheck: 0,
+  notificationMode: 'off' as string,
+  downloadSpeedLimit: 0,
+  concurrentDownloads: 2,
+  keyboardShortcuts: {
+    back: 'Escape',
+    focusSearch: 'CmdOrCtrl+F',
+    goDownloads: 'CmdOrCtrl+D',
+    playerPrevEpisode: 'Shift+ArrowLeft',
+    playerNextEpisode: 'Shift+ArrowRight',
+    shaderModeA: 'CmdOrCtrl+1',
+    shaderModeB: 'CmdOrCtrl+2',
+    shaderModeC: 'CmdOrCtrl+3',
+    shaderOff: 'CmdOrCtrl+Backquote'
+  } as Record<string, string>,
+  shikimoriCredentials: null as shikimori.ShikiCredentials | null,
+  shikimoriUser: null as shikimori.ShikiUser | null,
+  storageMode: 'simple' as 'simple' | 'advanced',
+  hotStorageDir: '' as string,
+  coldStorageDir: '' as string,
+  autoMoveToCold: false,
+  malIdMap: {} as Record<string, AnimeSearchResult>,
+  playerMode: 'system' as 'system' | 'builtin',
+  playerVolume: 1 as number,
+  playerMuted: false,
+  anime4kPreset: 'off' as 'off' | 'mode-a' | 'mode-b' | 'mode-c',
+  hevcTranscodeOnPlay: 'ask' as 'ask' | 'always' | 'never',
+  prefetchNextEpisode: 'progress-50' as 'off' | 'open' | 'time-5min' | 'progress-50',
+  watchProgress: {} as Record<
+    string,
+    {
+      position: number
+      duration: number
+      updatedAt: number
+      watched?: boolean
+      watchedAt?: number
+      translationId?: number
+    }
+  >,
+  watchProgressMigrationV2: false,
+  autoCleanupWatchedDays: 0,
+  autoCleanupConfirm: true,
+  autoCleanupLastRun: null as { ranAt: number; deletedCount: number; freedBytes: number } | null,
+  cleanupLog: [] as {
+    ranAt: number
+    animeId: number
+    animeName: string
+    episodeInt: string
+    bytes: number
+  }[],
+  shikimoriUserRates: [] as unknown[],
+  shikimoriUpdateQueue: [] as unknown[],
+  shikimoriAnimeDetails: {} as Record<
+    string,
+    { details: shikimori.ShikiAnimeDetails; fetchedAt: number }
+  >,
+  autoDownloadSubscriptions: {} as Record<string, AutoDownloadSubscription>,
+  autoDownloadEnabled: true,
+  recentAnimeMeta: {} as Record<string, AnimeSearchResult>,
+  skipDetections: {} as Record<string, ShowSkipDetections>,
+  skipFingerprintCache: {} as Record<string, CachedFingerprint>,
+  enableLocalSkipDetection: true,
+  calendarView: 'week' as 'week' | 'month',
+  syncplay: {
+    lastHost: 'syncplay.pl',
+    lastPort: 8999,
+    lastRoom: '',
+    username: '',
+    autoReconnect: true
+  } as {
+    lastHost: string
+    lastPort: number
+    lastRoom: string
+    username: string
+    autoReconnect: boolean
+  },
+  mp4StreamingStats: {
+    totalChecked: 0,
+    faststartCount: 0,
+    nonFaststartSamples: [] as {
       animeId: number
       animeName: string
       episodeInt: string
-      bytes: number
-    }[],
-    shikimoriUserRates: [] as unknown[],
-    shikimoriUpdateQueue: [] as unknown[],
-    shikimoriAnimeDetails: {} as Record<
-      string,
-      { details: shikimori.ShikiAnimeDetails; fetchedAt: number }
-    >,
-    autoDownloadSubscriptions: {} as Record<string, AutoDownloadSubscription>,
-    autoDownloadEnabled: true,
-    recentAnimeMeta: {} as Record<string, AnimeSearchResult>,
-    skipDetections: {} as Record<string, ShowSkipDetections>,
-    skipFingerprintCache: {} as Record<string, CachedFingerprint>,
-    enableLocalSkipDetection: true,
-    calendarView: 'week' as 'week' | 'month',
-    syncplay: {
-      lastHost: 'syncplay.pl',
-      lastPort: 8999,
-      lastRoom: '',
-      username: '',
-      autoReconnect: true
-    } as {
-      lastHost: string
-      lastPort: number
-      lastRoom: string
-      username: string
-      autoReconnect: boolean
-    },
-    mp4StreamingStats: {
-      totalChecked: 0,
-      faststartCount: 0,
-      nonFaststartSamples: [] as {
-        animeId: number
-        animeName: string
-        episodeInt: string
-        episodeLabel: string
-        filePath: string
-        firstNonFtypBox: string
-        checkedAt: number
-      }[]
-    } as Mp4StreamingStats,
-    autoCleanupSnoozedAnimeIds: {} as Record<string, true>
-  }
-})
+      episodeLabel: string
+      filePath: string
+      firstNonFtypBox: string
+      checkedAt: number
+    }[]
+  } as Mp4StreamingStats,
+  autoCleanupSnoozedAnimeIds: {} as Record<string, true>
+}
+
+const store = createStorageService(STORE_DEFAULTS)
+
+// Compile-time guard: `STORE_DEFAULTS` keys must equal `PERSISTED_STORE_KEYS`.
+// Renaming a default key without updating the tuple breaks this assertion,
+// stopping the build before a release silently orphans user data.
+type _AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never
+const _storeKeysInSync: _AssertExact<keyof typeof STORE_DEFAULTS & string, PersistedStoreKey> = true
+void _storeKeysInSync
 
 function broadcastToAll(channel: string, ...args: unknown[]): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -1841,23 +1849,6 @@ async function runWatchedCleanup(force = false): Promise<{
   } finally {
     cleanupRunning = false
   }
-}
-
-function migrateWatchProgressV2(): void {
-  if (store.get('watchProgressMigrationV2') as boolean) return
-  const all = store.get('watchProgress') as Record<
-    string,
-    { updatedAt: number; watched?: boolean; watchedAt?: number; position: number; duration: number }
-  >
-  let changed = false
-  for (const entry of Object.values(all)) {
-    if (entry.watched && !entry.watchedAt) {
-      entry.watchedAt = entry.updatedAt
-      changed = true
-    }
-  }
-  if (changed) store.set('watchProgress', all)
-  store.set('watchProgressMigrationV2', true)
 }
 
 // Skip detection orchestration. Lifted to module scope so the auto-trigger
@@ -5329,7 +5320,7 @@ app.whenReady().then(async () => {
     )
   }, 30_000)
 
-  migrateWatchProgressV2()
+  store.migrateWatchProgressV2()
 
   // Auto-cleanup of watched episodes — opt-in. Run 60s after launch (warmup),
   // then once every 24h. First run that finds candidates while

--- a/src/main/shikimori.ts
+++ b/src/main/shikimori.ts
@@ -1,4 +1,4 @@
-import type Store from 'electron-store'
+import type { StorageService } from './store/types'
 
 const CLIENT_ID = 'wlhQeTkDVSMFmXqvtDJqPG_ZhWEUnG8iI4YG9nadvLU'
 const CLIENT_SECRET = 'r_lIMZbmFWZmVgP9pC9-9XaS0e96lwduMOegZ3YREfM'
@@ -131,7 +131,7 @@ async function refreshToken(token: string): Promise<ShikiCredentials> {
   return response.json() as Promise<ShikiCredentials>
 }
 
-export async function ensureFreshToken(store: Store): Promise<string> {
+export async function ensureFreshToken(store: StorageService): Promise<string> {
   const creds = store.get('shikimoriCredentials') as ShikiCredentials | null
   if (!creds) throw new Error('Not logged in to Shikimori')
 

--- a/src/main/store/index.ts
+++ b/src/main/store/index.ts
@@ -1,0 +1,35 @@
+import Store from 'electron-store'
+import type { StorageService } from './types'
+import { migrateWatchProgressV2 } from './migrate'
+
+export type { StorageService } from './types'
+export { PERSISTED_STORE_KEYS, type PersistedStoreKey } from './keys'
+
+/**
+ * `StorageService` plus the persisted-schema migrations that must run before
+ * the rest of the app reads the store. Kept on the service (not free
+ * functions) so call sites depend only on the injected instance.
+ */
+export interface MainStorageService<S extends Record<string, unknown>> extends StorageService<S> {
+  migrateWatchProgressV2(): void
+}
+
+/**
+ * Bind the single `electron-store`-backed implementation. The instance is
+ * injected everywhere else (epic decision 7) so no other module imports the
+ * `electron-store` singleton.
+ */
+export function createStorageService<S extends Record<string, unknown>>(
+  defaults: S
+): MainStorageService<S> {
+  const store = new Store<S>({ defaults })
+  const svc: MainStorageService<S> = {
+    get: ((key: string) => store.get(key as keyof S)) as MainStorageService<S>['get'],
+    set: ((key: string, value: unknown) =>
+      store.set(key as keyof S, value as S[keyof S])) as MainStorageService<S>['set'],
+    has: (key: string) => store.has(key as keyof S),
+    delete: (key: string) => store.delete(key as keyof S),
+    migrateWatchProgressV2: () => migrateWatchProgressV2(svc)
+  }
+  return svc
+}

--- a/src/main/store/keys.ts
+++ b/src/main/store/keys.ts
@@ -1,0 +1,58 @@
+/**
+ * Canonical list of persisted `electron-store` keys.
+ *
+ * This is a rename guard: `index.ts` asserts at compile time that the keys of
+ * its `STORE_DEFAULTS` exactly equal this tuple, and a unit test pins the tuple
+ * itself. Silently renaming a persisted key would orphan users' existing data,
+ * so both ends must change together and deliberately.
+ */
+export const PERSISTED_STORE_KEYS = [
+  'token',
+  'translationType',
+  'downloadDir',
+  'library',
+  'autoMerge',
+  'videoCodec',
+  'downloadedAnime',
+  'downloadedEpisodes',
+  'animeCache',
+  'lastUpdateCheck',
+  'notificationMode',
+  'downloadSpeedLimit',
+  'concurrentDownloads',
+  'keyboardShortcuts',
+  'shikimoriCredentials',
+  'shikimoriUser',
+  'storageMode',
+  'hotStorageDir',
+  'coldStorageDir',
+  'autoMoveToCold',
+  'malIdMap',
+  'playerMode',
+  'playerVolume',
+  'playerMuted',
+  'anime4kPreset',
+  'hevcTranscodeOnPlay',
+  'prefetchNextEpisode',
+  'watchProgress',
+  'watchProgressMigrationV2',
+  'autoCleanupWatchedDays',
+  'autoCleanupConfirm',
+  'autoCleanupLastRun',
+  'cleanupLog',
+  'shikimoriUserRates',
+  'shikimoriUpdateQueue',
+  'shikimoriAnimeDetails',
+  'autoDownloadSubscriptions',
+  'autoDownloadEnabled',
+  'recentAnimeMeta',
+  'skipDetections',
+  'skipFingerprintCache',
+  'enableLocalSkipDetection',
+  'calendarView',
+  'syncplay',
+  'mp4StreamingStats',
+  'autoCleanupSnoozedAnimeIds'
+] as const
+
+export type PersistedStoreKey = (typeof PERSISTED_STORE_KEYS)[number]

--- a/src/main/store/migrate.ts
+++ b/src/main/store/migrate.ts
@@ -1,0 +1,26 @@
+import type { StorageService } from './types'
+
+/**
+ * One-shot backfill of `watchProgress[*].watchedAt` for entries that were
+ * marked watched before `watchedAt` existed. Idempotent: guarded by the
+ * `watchProgressMigrationV2` flag. Pure with respect to the injected store —
+ * unit-tested against the in-memory fake.
+ */
+export function migrateWatchProgressV2<S extends Record<string, unknown>>(
+  store: StorageService<S>
+): void {
+  if (store.get('watchProgressMigrationV2') as boolean) return
+  const all = store.get('watchProgress') as Record<
+    string,
+    { updatedAt: number; watched?: boolean; watchedAt?: number; position: number; duration: number }
+  >
+  let changed = false
+  for (const entry of Object.values(all)) {
+    if (entry.watched && !entry.watchedAt) {
+      entry.watchedAt = entry.updatedAt
+      changed = true
+    }
+  }
+  if (changed) store.set('watchProgress', all)
+  store.set('watchProgressMigrationV2', true)
+}

--- a/src/main/store/types.ts
+++ b/src/main/store/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Injected persistence boundary for the main process.
+ *
+ * `StorageService` is the contract every service depends on instead of the
+ * `electron-store` singleton (refactor epic #84, Phase 2 slice 2c). It is the
+ * re-homed counterpart of the Phase 0 in-memory fake — see
+ * `test/helpers/in-memory-storage.ts`, which implements this interface.
+ *
+ * The schema-typed overloads preserve `electron-store`'s precise return types
+ * for literal keys (so existing call sites keep their typing with no churn),
+ * while the `string`-key overloads cover the dynamic `get-setting` /
+ * `set-setting` IPC paths.
+ */
+export interface StorageService<S extends Record<string, unknown> = Record<string, unknown>> {
+  get<K extends keyof S & string>(key: K): S[K]
+  get<T = unknown>(key: string): T
+  set<K extends keyof S & string>(key: K, value: S[K]): void
+  set(key: string, value: unknown): void
+  has(key: string): boolean
+  delete(key: string): void
+}

--- a/test/store/keys.test.ts
+++ b/test/store/keys.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { PERSISTED_STORE_KEYS } from '../../src/main/store/keys'
+
+describe('PERSISTED_STORE_KEYS', () => {
+  // Frozen reference list. Adding a persisted key MUST update both
+  // PERSISTED_STORE_KEYS and this expected list in the same commit — that is
+  // the deliberate change required to widen the persisted schema. Renames
+  // additionally need a migration in src/main/store/migrate.ts.
+  const EXPECTED = [
+    'token',
+    'translationType',
+    'downloadDir',
+    'library',
+    'autoMerge',
+    'videoCodec',
+    'downloadedAnime',
+    'downloadedEpisodes',
+    'animeCache',
+    'lastUpdateCheck',
+    'notificationMode',
+    'downloadSpeedLimit',
+    'concurrentDownloads',
+    'keyboardShortcuts',
+    'shikimoriCredentials',
+    'shikimoriUser',
+    'storageMode',
+    'hotStorageDir',
+    'coldStorageDir',
+    'autoMoveToCold',
+    'malIdMap',
+    'playerMode',
+    'playerVolume',
+    'playerMuted',
+    'anime4kPreset',
+    'hevcTranscodeOnPlay',
+    'prefetchNextEpisode',
+    'watchProgress',
+    'watchProgressMigrationV2',
+    'autoCleanupWatchedDays',
+    'autoCleanupConfirm',
+    'autoCleanupLastRun',
+    'cleanupLog',
+    'shikimoriUserRates',
+    'shikimoriUpdateQueue',
+    'shikimoriAnimeDetails',
+    'autoDownloadSubscriptions',
+    'autoDownloadEnabled',
+    'recentAnimeMeta',
+    'skipDetections',
+    'skipFingerprintCache',
+    'enableLocalSkipDetection',
+    'calendarView',
+    'syncplay',
+    'mp4StreamingStats',
+    'autoCleanupSnoozedAnimeIds'
+  ] as const
+
+  it('matches the frozen expected key set exactly (order and content)', () => {
+    expect([...PERSISTED_STORE_KEYS]).toEqual([...EXPECTED])
+  })
+
+  it('contains no duplicates', () => {
+    expect(new Set(PERSISTED_STORE_KEYS).size).toBe(PERSISTED_STORE_KEYS.length)
+  })
+})

--- a/test/store/migrate.test.ts
+++ b/test/store/migrate.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { migrateWatchProgressV2 } from '../../src/main/store/migrate'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
+
+function entry(updatedAt: number, watched: boolean, watchedAt?: number) {
+  return { position: 0, duration: 100, updatedAt, watched, ...(watchedAt ? { watchedAt } : {}) }
+}
+
+describe('migrateWatchProgressV2', () => {
+  it('backfills watchedAt from updatedAt for watched entries lacking it', () => {
+    const store = new InMemoryStorage({
+      watchProgressMigrationV2: false,
+      watchProgress: {
+        '1:1': entry(1000, true),
+        '1:2': entry(2000, true, 1500),
+        '1:3': entry(3000, false)
+      }
+    })
+    migrateWatchProgressV2(store)
+    const after = store.get<Record<string, { watchedAt?: number }>>('watchProgress')!
+    expect(after['1:1'].watchedAt).toBe(1000)
+    expect(after['1:2'].watchedAt).toBe(1500) // unchanged
+    expect(after['1:3'].watchedAt).toBeUndefined() // not watched, untouched
+    expect(store.get('watchProgressMigrationV2')).toBe(true)
+  })
+
+  it('is a no-op when the migration flag is already set', () => {
+    const seed = { '1:1': entry(1000, true) } // missing watchedAt; would have been backfilled
+    const store = new InMemoryStorage({
+      watchProgressMigrationV2: true,
+      watchProgress: seed
+    })
+    migrateWatchProgressV2(store)
+    const after = store.get<Record<string, { watchedAt?: number }>>('watchProgress')!
+    expect(after['1:1'].watchedAt).toBeUndefined()
+  })
+
+  it('still sets the flag even when nothing needed backfill', () => {
+    const store = new InMemoryStorage({
+      watchProgressMigrationV2: false,
+      watchProgress: { '1:1': entry(1000, false) }
+    })
+    migrateWatchProgressV2(store)
+    expect(store.get('watchProgressMigrationV2')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Second PR of the Phase 2 structure-refactor (#89), implementing slice **2c**. Decouples the main process and its leaf services (`shikimori`, `auto-downloader`) from the `electron-store` singleton by introducing an **injected `StorageService` interface**. **Behavior byte-identical** — no IPC, settings, UI, or logic changes.

Independent of PR #91 (slices 2a+2b). Both branch off `main`; the only overlap is the top-of-file imports in `src/main/index.ts`, a trivial merge.

## Changes

**New `src/main/store/` (4 files):**
- `types.ts` — `StorageService<S>` interface with schema-typed `get`/`set` overloads for literal keys (preserves the precise return types `electron-store` gave to all 187 call sites) and `string`-key overloads for the dynamic `get-setting` / `set-setting` IPC paths. Pure, electron-free; re-homed from the Phase 0 in-memory fake's note.
- `keys.ts` — `PERSISTED_STORE_KEYS` frozen 46-key tuple acting as a rename guard.
- `migrate.ts` — pure `migrateWatchProgressV2(store)` (one-shot `watchedAt` backfill, flag-guarded, idempotent). Unit-tested against the in-memory fake.
- `index.ts` — `createStorageService(defaults)` wraps `new Store<S>` and exposes `migrateWatchProgressV2()` as a method delegating to the pure function.

**`src/main/index.ts`:**
- Inline `defaults: {...}` lifted to top-level `STORE_DEFAULTS`.
- `const store = createStorageService(STORE_DEFAULTS)` replaces `new Store({...})`.
- **Compile-time rename guard:** an `_AssertExact` type-level check asserts `keyof typeof STORE_DEFAULTS & string` exactly equals `PersistedStoreKey`. Renaming a default key without updating the tuple breaks the build.
- Standalone `migrateWatchProgressV2()` deleted; call site uses `store.migrateWatchProgressV2()`. **All ~187 `store.*` call sites unchanged.**

**`src/main/shikimori.ts`, `src/main/auto-downloader.ts`:**
- `import type Store from 'electron-store'` → `import type { StorageService } from './store/types'`.
- `ensureFreshToken(store: Store)` → `ensureFreshToken(store: StorageService)`.
- `AutoDownloaderDeps.store` and two free-function store params: `Store` → `StorageService`.
- Both modules only use `get`/`set`, so the surface change is trivially compatible.

## Behavior

None changed. The `StorageService` schema-typed overloads return the exact same `S[K]` types `electron-store` did, so existing `as` casts and direct typed accesses (e.g. the `store.get('syncplay')` spread at line ~4638) all continue to compile and behave identically.

## Test plan

Full local quality gate (the gate that gated #91 in CI):
- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors, only pre-existing warnings)
- `npm run format:check` ✓
- `npm test` ✓ (13/13 — 5 new across `keys.test.ts` (2) and `migrate.test.ts` (3), plus existing in-memory + IPC tests)
- `npm run build` ✓

## Notes

- `electron-store` import is now confined to `src/main/store/index.ts`. Other main-process modules type-only-import `StorageService` from `./store/types` (pure, no electron). This is the prerequisite for slices 2d–2g (anime-cache, cold-storage, skip-analysis, streaming) which build on the injected boundary.
- Phase 0's `test/helpers/in-memory-storage.ts` already structurally satisfies `StorageService`. Merging its local interface declaration into a single `implements StorageService` is deferred (its existing 2-arg `get(key, default)` test predates this interface and is out of scope for 2c).
- Part of #89. No version bump (structure-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)