### PR TITLE
refactor: Phase 2 PR4 — extract SkipAnalysisService leaf surface (#89)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -45,6 +45,7 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/main/store/keys.ts` | `PERSISTED_STORE_KEYS` frozen tuple — rename guard, compile-time-asserted against `keyof STORE_DEFAULTS` in `index.ts` |
 | `src/main/store/migrate.ts` | Pure `migrateWatchProgressV2(store)` (one-shot `watchedAt` backfill) |
 | `src/main/services/anime-cache/index.ts` | `createAnimeCacheService` — `AnimeCacheEntry` CRUD + poster file cache + `cleanupStale` orphan sweep; deps-injected (`store`, `userDataDir`, `fetchPoster`, `isCachable`) |
+| `src/main/services/skip-analysis/index.ts` | `createSkipAnalysisService` — `normalizeDetections`, fingerprint cache `pruneCacheFor{Episode,Anime}` + `sweepFingerprintCache`, `dropDetectionsFor{Anime,Episode}`, `buildAutoSkipEpisodes`; deps-injected (`store`, `scanEpisodeFiles`, `sanitizeFilename`, `broadcast`). Auto-skip queue/drain machinery still lives in `index.ts` (deferred — entangled with stream-skip state). |
 | `src/preload/index.ts` | contextBridge API exposure to renderer |
 | `src/preload/index.d.ts` | Shared TypeScript interfaces for IPC communication |
 | `src/renderer/src/main.ts` | Vue app entry point |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,6 +77,7 @@ process.stdout?.on('error', () => {})
 process.stderr?.on('error', () => {})
 
 import { createAnimeCacheService, type AnimeCacheEntry } from './services/anime-cache'
+import { createSkipAnalysisService } from './services/skip-analysis'
 
 export interface AutoDownloadSubscription {
   animeId: number
@@ -885,6 +886,14 @@ const animeCacheService = createAnimeCacheService({
   userDataDir: app.getPath('userData'),
   fetchPoster: (url) => smotretApi.fetchPoster(url),
   isCachable: isCachableAnime
+})
+
+const skipAnalysisService = createSkipAnalysisService({
+  store,
+  scanEpisodeFiles,
+  sanitizeFilename,
+  broadcast: broadcastToAll,
+  signatureUpdatedChannel: EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED
 })
 let downloadManager: DownloadManager
 let ffmpegPath = ''
@@ -1771,24 +1780,6 @@ function broadcastSkipProgress(animeId: number, p: AnalyzeProgress): void {
   broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS, { animeId, ...p })
 }
 
-function normalizeSkipDetections(detections: ShowSkipDetections | null): ShowSkipDetections | null {
-  if (!detections) return null
-  if (detections.algorithm?.source === 'local') return detections
-  const alg = detections.algorithm
-  return {
-    ...detections,
-    algorithm: {
-      source: 'local',
-      sampleRate: alg?.sampleRate ?? 11025,
-      matchBitThreshold: alg?.matchBitThreshold ?? 6,
-      minRunSec: alg?.minRunSec ?? 18,
-      windowSec: alg?.windowSec ?? 6,
-      refineBitThreshold: alg?.refineBitThreshold ?? 4,
-      refineSustainHashes: alg?.refineSustainHashes ?? 5
-    }
-  }
-}
-
 function runSkipAnalysisInternal(
   animeId: number,
   episodes: EpisodeInput[]
@@ -1897,29 +1888,6 @@ function runStreamSkipDetectionInternal(
   return runPromise
 }
 
-// Build EpisodeInput[] from disk for an anime folder. Mirrors the renderer's
-// skipEpisodeInputs computed: prefer .mkv (merged) over .mp4 (raw), one entry
-// per episodeInt, sorted by numeric episode.
-function buildAutoSkipEpisodes(animeName: string): EpisodeInput[] {
-  const scan = scanEpisodeFiles(animeName)
-  const sanitized = sanitizeFilename(animeName)
-  const inputs: EpisodeInput[] = []
-  for (const [base, files] of Object.entries(scan)) {
-    if (!base.startsWith(sanitized + ' - ')) continue
-    const tail = base.slice(sanitized.length + 3)
-    const m = tail.match(/^(\d+(?:\.\d+)?)/)
-    if (!m) continue
-    const episodeInt = m[1].replace(/^0+(?=\d)/, '')
-    const mkv = files.find((f) => f.type === 'mkv')
-    const pick = mkv || files[0]
-    if (!pick || !pick.filePath) continue
-    if (inputs.some((e) => e.episodeInt === episodeInt)) continue
-    inputs.push({ episodeInt, episodeLabel: `Episode ${episodeInt}`, filePath: pick.filePath })
-  }
-  inputs.sort((a, b) => parseFloat(a.episodeInt) - parseFloat(b.episodeInt))
-  return inputs
-}
-
 function scheduleAutoSkipAnalysis(animeId: number, animeName: string): void {
   if (animeId <= 0) return
   if (!(store.get('enableLocalSkipDetection') as boolean)) return
@@ -1952,7 +1920,7 @@ async function drainAutoSkipQueue(): Promise<void> {
     while (autoSkipQueue.length > 0 && !currentSkipAnalysis) {
       const next = autoSkipQueue.shift()!
       try {
-        const episodes = buildAutoSkipEpisodes(next.animeName)
+        const episodes = skipAnalysisService.buildAutoSkipEpisodes(next.animeName)
         if (episodes.length < 2) continue
         await runSkipAnalysisInternal(next.animeId, episodes)
       } catch (e) {
@@ -1973,134 +1941,6 @@ async function drainAutoSkipQueue(): Promise<void> {
 // common cases immediately; `sweepSkipFingerprintCache` runs at startup
 // as a backstop for anything we miss (external rm, file replaced,
 // in-place rename outside the app).
-
-function pruneSkipCacheForEpisode(animeId: number, episodeInt: string): number {
-  if (animeId <= 0 || !episodeInt) return 0
-  const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
-  const prefix = `${animeId}:${episodeInt}:`
-  let dropped = 0
-  for (const key of Object.keys(cache)) {
-    if (key.startsWith(prefix)) {
-      delete cache[key]
-      dropped++
-    }
-  }
-  if (dropped > 0) store.set('skipFingerprintCache', cache)
-  return dropped
-}
-
-function pruneSkipCacheForAnime(animeId: number): number {
-  if (animeId <= 0) return 0
-  const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
-  const prefix = `${animeId}:`
-  let dropped = 0
-  for (const key of Object.keys(cache)) {
-    if (key.startsWith(prefix)) {
-      delete cache[key]
-      dropped++
-    }
-  }
-  if (dropped > 0) store.set('skipFingerprintCache', cache)
-  return dropped
-}
-
-// Reconcile the cache against disk. Per anime: scan the folder, stat each
-// file, compute the (size, mtime) tuple the cache would key under, and
-// drop any cache entry for that animeId that doesn't match a live file.
-// Anime missing from `downloadedAnime` → all entries for that animeId go.
-function sweepSkipFingerprintCache(): { kept: number; dropped: number } {
-  const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
-  const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
-
-  const byAnimeId = new Map<
-    string,
-    { key: string; episodeInt: string; fileSize: number; fileMtimeMs: number }[]
-  >()
-  for (const [key, val] of Object.entries(cache)) {
-    const parts = key.split(':')
-    if (parts.length < 4) continue
-    const [animeIdStr, episodeInt] = parts
-    const list = byAnimeId.get(animeIdStr) ?? []
-    list.push({ key, episodeInt, fileSize: val.fileSize, fileMtimeMs: val.fileMtimeMs })
-    byAnimeId.set(animeIdStr, list)
-  }
-
-  const next: Record<string, CachedFingerprint> = {}
-  let kept = 0
-  let dropped = 0
-
-  for (const [animeIdStr, entries] of byAnimeId) {
-    const meta = downloaded[animeIdStr]
-    if (!meta) {
-      dropped += entries.length
-      continue
-    }
-    const scan = scanEpisodeFiles(meta.title)
-    const sanitized = sanitizeFilename(meta.title)
-    const expectedByEpisode = new Map<string, { fileSize: number; fileMtimeMs: number }[]>()
-    for (const [base, files] of Object.entries(scan)) {
-      if (!base.startsWith(sanitized + ' - ')) continue
-      const tail = base.slice(sanitized.length + 3)
-      const m = tail.match(/^(\d+(?:\.\d+)?)/)
-      if (!m) continue
-      const episodeInt = m[1].replace(/^0+(?=\d)/, '')
-      for (const f of files) {
-        if (!f.filePath) continue
-        try {
-          const stat = fs.statSync(f.filePath)
-          const list = expectedByEpisode.get(episodeInt) ?? []
-          list.push({ fileSize: stat.size, fileMtimeMs: stat.mtimeMs })
-          expectedByEpisode.set(episodeInt, list)
-        } catch {
-          /* file vanished between scan and stat — skip */
-        }
-      }
-    }
-
-    for (const e of entries) {
-      const candidates = expectedByEpisode.get(e.episodeInt) ?? []
-      const match = candidates.some(
-        (c) => c.fileSize === e.fileSize && Math.floor(c.fileMtimeMs) === Math.floor(e.fileMtimeMs)
-      )
-      if (match) {
-        next[e.key] = cache[e.key]
-        kept++
-      } else {
-        dropped++
-      }
-    }
-  }
-
-  if (dropped > 0) store.set('skipFingerprintCache', next)
-  return { kept, dropped }
-}
-
-function dropSkipDetectionsForAnime(animeId: number): boolean {
-  const detections = store.get('skipDetections') as Record<string, ShowSkipDetections>
-  const key = String(animeId)
-  if (!(key in detections)) return false
-  delete detections[key]
-  store.set('skipDetections', detections)
-  broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, { animeId, perEpisode: {} })
-  return true
-}
-
-function dropSkipDetectionsForEpisode(animeId: number, episodeInt: string): boolean {
-  const detections = store.get('skipDetections') as Record<string, ShowSkipDetections>
-  const key = String(animeId)
-  const show = detections[key]
-  if (!show || !show.perEpisode[episodeInt]) return false
-  delete show.perEpisode[episodeInt]
-  if (Object.keys(show.perEpisode).length === 0) {
-    delete detections[key]
-  }
-  store.set('skipDetections', detections)
-  broadcastToAll(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, {
-    animeId,
-    perEpisode: detections[key]?.perEpisode ?? {}
-  })
-  return true
-}
 
 function registerIpcHandlers(): void {
   ipcMain.handle(CHANNELS.APP_VERSION, () => app.getVersion())
@@ -2639,8 +2479,8 @@ function registerIpcHandlers(): void {
     }
     // Clean cache
     animeCacheService.deleteEntry(animeId)
-    pruneSkipCacheForAnime(animeId)
-    dropSkipDetectionsForAnime(animeId)
+    skipAnalysisService.pruneCacheForAnime(animeId)
+    skipAnalysisService.dropDetectionsForAnime(animeId)
   })
 
   ipcMain.handle(CHANNELS.CLEANUP_GET_SIZE, async (_event, _animeId: number, animeName: string) => {
@@ -2684,8 +2524,8 @@ function registerIpcHandlers(): void {
 
     fileCheckCache.delete(animeName)
     animeCacheService.deleteEntry(animeId)
-    pruneSkipCacheForAnime(animeId)
-    dropSkipDetectionsForAnime(animeId)
+    skipAnalysisService.pruneCacheForAnime(animeId)
+    skipAnalysisService.dropDetectionsForAnime(animeId)
   })
 
   ipcMain.handle(CHANNELS.CLEANUP_GET_SNOOZED, () => {
@@ -3166,7 +3006,7 @@ function registerIpcHandlers(): void {
   // single-flight state as these handlers.
   ipcMain.handle(CHANNELS.SKIP_DETECTOR_GET_DETECTIONS, (_event, animeId: number) => {
     const all = store.get('skipDetections') as Record<string, ShowSkipDetections>
-    return normalizeSkipDetections(all[String(animeId)] ?? null)
+    return skipAnalysisService.normalizeDetections(all[String(animeId)] ?? null)
   })
 
   ipcMain.handle(CHANNELS.SKIP_DETECTOR_GET_STATUS, () => {
@@ -3199,7 +3039,7 @@ function registerIpcHandlers(): void {
       streamUrl: string
     ): Promise<EpisodeSkipDetection | null> => {
       const all = store.get('skipDetections') as Record<string, ShowSkipDetections>
-      const detections = normalizeSkipDetections(all[String(animeId)] ?? null)
+      const detections = skipAnalysisService.normalizeDetections(all[String(animeId)] ?? null)
       if (!detections) return null
       if (!streamUrl) return null
       return runStreamSkipDetectionInternal(
@@ -3234,7 +3074,7 @@ function registerIpcHandlers(): void {
         alreadyAnalyzed++
         continue
       }
-      const eps = buildAutoSkipEpisodes(meta.title)
+      const eps = skipAnalysisService.buildAutoSkipEpisodes(meta.title)
       if (eps.length < 2) {
         skippedFewEpisodes++
         continue
@@ -3409,8 +3249,8 @@ function registerIpcHandlers(): void {
     (_event, animeName: string, episodeInt: string, animeId?: number, translationId?: number) => {
       deleteEpisodeFiles(animeName, episodeInt, animeId, translationId)
       if (animeId && animeId > 0) {
-        pruneSkipCacheForEpisode(animeId, episodeInt)
-        dropSkipDetectionsForEpisode(animeId, episodeInt)
+        skipAnalysisService.pruneCacheForEpisode(animeId, episodeInt)
+        skipAnalysisService.dropDetectionsForEpisode(animeId, episodeInt)
       }
     }
   )
@@ -5231,7 +5071,7 @@ app.whenReady().then(async () => {
   // file replaced outside the app, leftover .mp4 cache after merge, etc.).
   setTimeout(() => {
     try {
-      const r = sweepSkipFingerprintCache()
+      const r = skipAnalysisService.sweepFingerprintCache()
       if (r.dropped > 0) {
         console.log(
           `[skip-detector] cache sweep: kept ${r.kept}, dropped ${r.dropped} stale entries`

--- a/src/main/services/skip-analysis/index.ts
+++ b/src/main/services/skip-analysis/index.ts
@@ -1,0 +1,219 @@
+import * as fs from 'fs'
+import type { StorageService } from '../../store/types'
+import type { EpisodeInput, ShowSkipDetections, CachedFingerprint } from '../../skip-detector'
+
+export type SkipAnalysisFileCheckResult = Record<
+  string,
+  { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
+>
+
+export interface SkipAnalysisServiceDeps {
+  store: StorageService
+  scanEpisodeFiles: (animeName: string) => SkipAnalysisFileCheckResult
+  sanitizeFilename: (s: string) => string
+  /** Broadcast helper (`broadcastToAll`); used by `dropDetections*`. */
+  broadcast: (channel: string, ...args: unknown[]) => void
+  /** Event channel for SKIP_DETECTOR_SIGNATURE_UPDATED. */
+  signatureUpdatedChannel: string
+}
+
+export interface SkipAnalysisService {
+  /** Normalize legacy detection rows so callers always see a `local` algorithm block with defaults filled. */
+  normalizeDetections(detections: ShowSkipDetections | null): ShowSkipDetections | null
+  /** Drop fingerprint cache rows for a specific episode. Returns how many keys were dropped. */
+  pruneCacheForEpisode(animeId: number, episodeInt: string): number
+  /** Drop fingerprint cache rows for an entire anime. Returns how many keys were dropped. */
+  pruneCacheForAnime(animeId: number): number
+  /** Reconcile the fingerprint cache against disk; drops entries with no live file backing. */
+  sweepFingerprintCache(): { kept: number; dropped: number }
+  /** Delete cached detections for an anime; broadcasts a clearing event. Returns true if anything was removed. */
+  dropDetectionsForAnime(animeId: number): boolean
+  /** Delete one episode's detections; broadcasts the new per-episode map. Returns true if anything was removed. */
+  dropDetectionsForEpisode(animeId: number, episodeInt: string): boolean
+  /** Build `EpisodeInput[]` from disk (one entry per episodeInt, mkv preferred over mp4). */
+  buildAutoSkipEpisodes(animeName: string): EpisodeInput[]
+}
+
+export function createSkipAnalysisService(deps: SkipAnalysisServiceDeps): SkipAnalysisService {
+  const { store, scanEpisodeFiles, sanitizeFilename, broadcast, signatureUpdatedChannel } = deps
+
+  function normalizeDetections(detections: ShowSkipDetections | null): ShowSkipDetections | null {
+    if (!detections) return null
+    if (detections.algorithm?.source === 'local') return detections
+    const alg = detections.algorithm
+    return {
+      ...detections,
+      algorithm: {
+        source: 'local',
+        sampleRate: alg?.sampleRate ?? 11025,
+        matchBitThreshold: alg?.matchBitThreshold ?? 6,
+        minRunSec: alg?.minRunSec ?? 18,
+        windowSec: alg?.windowSec ?? 6,
+        refineBitThreshold: alg?.refineBitThreshold ?? 4,
+        refineSustainHashes: alg?.refineSustainHashes ?? 5
+      }
+    }
+  }
+
+  function pruneCacheForEpisode(animeId: number, episodeInt: string): number {
+    if (animeId <= 0 || !episodeInt) return 0
+    const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
+    const prefix = `${animeId}:${episodeInt}:`
+    let dropped = 0
+    for (const key of Object.keys(cache)) {
+      if (key.startsWith(prefix)) {
+        delete cache[key]
+        dropped++
+      }
+    }
+    if (dropped > 0) store.set('skipFingerprintCache', cache)
+    return dropped
+  }
+
+  function pruneCacheForAnime(animeId: number): number {
+    if (animeId <= 0) return 0
+    const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
+    const prefix = `${animeId}:`
+    let dropped = 0
+    for (const key of Object.keys(cache)) {
+      if (key.startsWith(prefix)) {
+        delete cache[key]
+        dropped++
+      }
+    }
+    if (dropped > 0) store.set('skipFingerprintCache', cache)
+    return dropped
+  }
+
+  // Reconcile the cache against disk. Per anime: scan the folder, stat each
+  // file, compute the (size, mtime) tuple the cache would key under, and
+  // drop any cache entry for that animeId that doesn't match a live file.
+  // Anime missing from `downloadedAnime` → all entries for that animeId go.
+  function sweepFingerprintCache(): { kept: number; dropped: number } {
+    const cache = store.get('skipFingerprintCache') as Record<string, CachedFingerprint>
+    const downloaded = store.get('downloadedAnime') as Record<string, { title: string }>
+
+    const byAnimeId = new Map<
+      string,
+      { key: string; episodeInt: string; fileSize: number; fileMtimeMs: number }[]
+    >()
+    for (const [key, val] of Object.entries(cache)) {
+      const parts = key.split(':')
+      if (parts.length < 4) continue
+      const [animeIdStr, episodeInt] = parts
+      const list = byAnimeId.get(animeIdStr) ?? []
+      list.push({ key, episodeInt, fileSize: val.fileSize, fileMtimeMs: val.fileMtimeMs })
+      byAnimeId.set(animeIdStr, list)
+    }
+
+    const next: Record<string, CachedFingerprint> = {}
+    let kept = 0
+    let dropped = 0
+
+    for (const [animeIdStr, entries] of byAnimeId) {
+      const meta = downloaded[animeIdStr]
+      if (!meta) {
+        dropped += entries.length
+        continue
+      }
+      const scan = scanEpisodeFiles(meta.title)
+      const sanitized = sanitizeFilename(meta.title)
+      const expectedByEpisode = new Map<string, { fileSize: number; fileMtimeMs: number }[]>()
+      for (const [base, files] of Object.entries(scan)) {
+        if (!base.startsWith(sanitized + ' - ')) continue
+        const tail = base.slice(sanitized.length + 3)
+        const m = tail.match(/^(\d+(?:\.\d+)?)/)
+        if (!m) continue
+        const episodeInt = m[1].replace(/^0+(?=\d)/, '')
+        for (const f of files) {
+          if (!f.filePath) continue
+          try {
+            const stat = fs.statSync(f.filePath)
+            const list = expectedByEpisode.get(episodeInt) ?? []
+            list.push({ fileSize: stat.size, fileMtimeMs: stat.mtimeMs })
+            expectedByEpisode.set(episodeInt, list)
+          } catch {
+            /* file vanished between scan and stat — skip */
+          }
+        }
+      }
+
+      for (const e of entries) {
+        const candidates = expectedByEpisode.get(e.episodeInt) ?? []
+        const match = candidates.some(
+          (c) =>
+            c.fileSize === e.fileSize && Math.floor(c.fileMtimeMs) === Math.floor(e.fileMtimeMs)
+        )
+        if (match) {
+          next[e.key] = cache[e.key]
+          kept++
+        } else {
+          dropped++
+        }
+      }
+    }
+
+    if (dropped > 0) store.set('skipFingerprintCache', next)
+    return { kept, dropped }
+  }
+
+  function dropDetectionsForAnime(animeId: number): boolean {
+    const detections = store.get('skipDetections') as Record<string, ShowSkipDetections>
+    const key = String(animeId)
+    if (!(key in detections)) return false
+    delete detections[key]
+    store.set('skipDetections', detections)
+    broadcast(signatureUpdatedChannel, { animeId, perEpisode: {} })
+    return true
+  }
+
+  function dropDetectionsForEpisode(animeId: number, episodeInt: string): boolean {
+    const detections = store.get('skipDetections') as Record<string, ShowSkipDetections>
+    const key = String(animeId)
+    const show = detections[key]
+    if (!show || !show.perEpisode[episodeInt]) return false
+    delete show.perEpisode[episodeInt]
+    if (Object.keys(show.perEpisode).length === 0) {
+      delete detections[key]
+    }
+    store.set('skipDetections', detections)
+    broadcast(signatureUpdatedChannel, {
+      animeId,
+      perEpisode: detections[key]?.perEpisode ?? {}
+    })
+    return true
+  }
+
+  // Build EpisodeInput[] from disk for an anime folder. Mirrors the renderer's
+  // skipEpisodeInputs computed: prefer .mkv (merged) over .mp4 (raw), one entry
+  // per episodeInt, sorted by numeric episode.
+  function buildAutoSkipEpisodes(animeName: string): EpisodeInput[] {
+    const scan = scanEpisodeFiles(animeName)
+    const sanitized = sanitizeFilename(animeName)
+    const inputs: EpisodeInput[] = []
+    for (const [base, files] of Object.entries(scan)) {
+      if (!base.startsWith(sanitized + ' - ')) continue
+      const tail = base.slice(sanitized.length + 3)
+      const m = tail.match(/^(\d+(?:\.\d+)?)/)
+      if (!m) continue
+      const episodeInt = m[1].replace(/^0+(?=\d)/, '')
+      const mkv = files.find((f) => f.type === 'mkv')
+      const pick = mkv || files[0]
+      if (!pick || !pick.filePath) continue
+      if (inputs.some((e) => e.episodeInt === episodeInt)) continue
+      inputs.push({ episodeInt, episodeLabel: `Episode ${episodeInt}`, filePath: pick.filePath })
+    }
+    inputs.sort((a, b) => parseFloat(a.episodeInt) - parseFloat(b.episodeInt))
+    return inputs
+  }
+
+  return {
+    normalizeDetections,
+    pruneCacheForEpisode,
+    pruneCacheForAnime,
+    sweepFingerprintCache,
+    dropDetectionsForAnime,
+    dropDetectionsForEpisode,
+    buildAutoSkipEpisodes
+  }
+}

--- a/test/services/skip-analysis.test.ts
+++ b/test/services/skip-analysis.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createSkipAnalysisService,
+  type SkipAnalysisService,
+  type SkipAnalysisFileCheckResult
+} from '../../src/main/services/skip-analysis'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
+import type { ShowSkipDetections } from '../../src/main/skip-detector'
+
+function mkDetections(per: Record<string, unknown>, source?: 'local'): ShowSkipDetections {
+  return {
+    perEpisode: per,
+    algorithm: source ? { source } : undefined
+  } as unknown as ShowSkipDetections
+}
+
+describe('SkipAnalysisService', () => {
+  let store: InMemoryStorage
+  let broadcasts: { channel: string; args: unknown[] }[]
+  let scanResult: SkipAnalysisFileCheckResult
+  let svc: SkipAnalysisService
+
+  beforeEach(() => {
+    store = new InMemoryStorage({
+      skipFingerprintCache: {},
+      skipDetections: {},
+      downloadedAnime: {}
+    })
+    broadcasts = []
+    scanResult = {}
+    svc = createSkipAnalysisService({
+      store,
+      scanEpisodeFiles: () => scanResult,
+      sanitizeFilename: (s) => s,
+      broadcast: (channel, ...args) => broadcasts.push({ channel, args }),
+      signatureUpdatedChannel: 'sig-updated'
+    })
+  })
+
+  describe('normalizeDetections', () => {
+    it('returns null untouched', () => {
+      expect(svc.normalizeDetections(null)).toBeNull()
+    })
+    it('passes through when algorithm.source is already local', () => {
+      const d = mkDetections({}, 'local')
+      expect(svc.normalizeDetections(d)).toBe(d)
+    })
+    it('coerces legacy detections to a `local` algorithm block with defaults', () => {
+      const out = svc.normalizeDetections(mkDetections({}))!
+      expect(out.algorithm).toEqual({
+        source: 'local',
+        sampleRate: 11025,
+        matchBitThreshold: 6,
+        minRunSec: 18,
+        windowSec: 6,
+        refineBitThreshold: 4,
+        refineSustainHashes: 5
+      })
+    })
+  })
+
+  describe('pruneCacheForEpisode', () => {
+    it('drops only matching prefix and writes when something changed', () => {
+      store.set('skipFingerprintCache', {
+        '1:5:1000:1700000000000': { fileSize: 1, fileMtimeMs: 1 },
+        '1:5:2000:1700000000000': { fileSize: 1, fileMtimeMs: 1 },
+        '1:6:3000:1700000000000': { fileSize: 1, fileMtimeMs: 1 },
+        '2:5:4000:1700000000000': { fileSize: 1, fileMtimeMs: 1 }
+      })
+      expect(svc.pruneCacheForEpisode(1, '5')).toBe(2)
+      const after = store.get<Record<string, unknown>>('skipFingerprintCache')!
+      expect(Object.keys(after).sort()).toEqual([
+        '1:6:3000:1700000000000',
+        '2:5:4000:1700000000000'
+      ])
+    })
+    it('returns 0 and is a no-op for invalid input', () => {
+      expect(svc.pruneCacheForEpisode(0, '5')).toBe(0)
+      expect(svc.pruneCacheForEpisode(1, '')).toBe(0)
+    })
+  })
+
+  describe('pruneCacheForAnime', () => {
+    it('drops everything keyed under the anime prefix', () => {
+      store.set('skipFingerprintCache', {
+        '1:5:x:y': { fileSize: 1, fileMtimeMs: 1 },
+        '1:6:x:y': { fileSize: 1, fileMtimeMs: 1 },
+        '2:5:x:y': { fileSize: 1, fileMtimeMs: 1 }
+      })
+      expect(svc.pruneCacheForAnime(1)).toBe(2)
+      expect(Object.keys(store.get<Record<string, unknown>>('skipFingerprintCache')!)).toEqual([
+        '2:5:x:y'
+      ])
+    })
+  })
+
+  describe('dropDetectionsForAnime', () => {
+    it('removes the row and broadcasts a clear event', () => {
+      store.set('skipDetections', { '1': mkDetections({ '1': {} }, 'local') })
+      expect(svc.dropDetectionsForAnime(1)).toBe(true)
+      expect(store.get<Record<string, unknown>>('skipDetections')).toEqual({})
+      expect(broadcasts).toEqual([
+        { channel: 'sig-updated', args: [{ animeId: 1, perEpisode: {} }] }
+      ])
+    })
+    it('returns false without broadcasting when nothing matched', () => {
+      expect(svc.dropDetectionsForAnime(42)).toBe(false)
+      expect(broadcasts).toEqual([])
+    })
+  })
+
+  describe('dropDetectionsForEpisode', () => {
+    it('removes one episode but keeps the show row when others remain', () => {
+      store.set('skipDetections', {
+        '1': mkDetections({ '1': { a: 1 }, '2': { a: 2 } }, 'local')
+      })
+      expect(svc.dropDetectionsForEpisode(1, '1')).toBe(true)
+      const remaining = store.get<Record<string, ShowSkipDetections>>('skipDetections')!['1']
+      expect(Object.keys(remaining.perEpisode)).toEqual(['2'])
+      expect(broadcasts[0].args[0]).toMatchObject({ animeId: 1, perEpisode: { '2': { a: 2 } } })
+    })
+    it('removes the show row when the last episode is dropped', () => {
+      store.set('skipDetections', { '1': mkDetections({ '1': { a: 1 } }, 'local') })
+      expect(svc.dropDetectionsForEpisode(1, '1')).toBe(true)
+      expect(store.get<Record<string, unknown>>('skipDetections')).toEqual({})
+    })
+    it('returns false without broadcasting when the episode is unknown', () => {
+      expect(svc.dropDetectionsForEpisode(1, '9')).toBe(false)
+      expect(broadcasts).toEqual([])
+    })
+  })
+
+  describe('buildAutoSkipEpisodes', () => {
+    it('prefers mkv over mp4, deduplicates by episodeInt, sorts numerically', () => {
+      scanResult = {
+        'show - 10': [{ type: 'mp4', filePath: '/x/show - 10.mp4' }],
+        'show - 02': [
+          { type: 'mp4', filePath: '/x/show - 02.mp4' },
+          { type: 'mkv', filePath: '/x/show - 02.mkv' }
+        ],
+        'show - 1': [{ type: 'mp4', filePath: '/x/show - 1.mp4' }]
+      }
+      const ep = svc.buildAutoSkipEpisodes('show')
+      expect(ep.map((e) => e.episodeInt)).toEqual(['1', '2', '10'])
+      expect(ep[1].filePath).toBe('/x/show - 02.mkv') // mkv preferred
+    })
+    it('skips entries whose folder name does not match', () => {
+      scanResult = { 'other - 01': [{ type: 'mp4', filePath: '/x/other - 01.mp4' }] }
+      expect(svc.buildAutoSkipEpisodes('show')).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Fourth PR of the Phase 2 structure-refactor (#89), implementing the **leaf surface of slice 2f** (skip-analysis). Extracts the non-stateful, deps-injectable parts of the skip-analysis subsystem out of `src/main/index.ts` into a dedicated service. **Behavior byte-identical.**

**Stacked on #93 (PR3 — AnimeCacheService).** Base is `phase2-pr3-anime-cache-service`. Each predecessor PR in the chain must be retargeted to `main` (or the next surviving base) *before* its branch is deleted (memory: stacked-PR base branches).

## What's extracted (`src/main/services/skip-analysis/index.ts`)

- `normalizeDetections` — pure: coerce legacy detection rows to a `local` algorithm block with defaults
- `pruneCacheForEpisode`, `pruneCacheForAnime` — store-only fingerprint-cache GC
- `sweepFingerprintCache` — reconcile cache vs. disk; drops orphans
- `dropDetectionsForAnime`, `dropDetectionsForEpisode` — store mutators + broadcast
- `buildAutoSkipEpisodes` — scan-based `EpisodeInput[]` construction (mkv preferred, sorted)

**Deps-injected:** `store`, `scanEpisodeFiles`, `sanitizeFilename`, `broadcast`, `signatureUpdatedChannel`. All fs / store side effects flow through deps.

## What stays in `index.ts` (deferred)

- `autoSkipDebounce` / `autoSkipQueue` / `autoSkipDraining` state
- `scheduleAutoSkipAnalysis` / `enqueueAutoSkipAnalysis` / `drainAutoSkipQueue`
- `runSkipAnalysisInternal` + `broadcastSkipProgress` + `currentSkipAnalysis` state
- `runStreamSkipDetectionInternal` + `currentStreamSkipDetections` state

These entangle the **auto-skip queue with stream-skip detection** through shared module-level state (`currentSkipAnalysis`). A clean extraction requires resolving that entanglement first, which is non-trivial and would extend the slice beyond a behavior-identical move. The PR4 surface is the largest behavior-identical chunk that lifts out without touching that state machine; the queue/drain extraction is queued as a follow-up.

## Tests

`test/services/skip-analysis.test.ts` — 13 cases against `InMemoryStorage`:
- `normalizeDetections` (3): null pass-through, local pass-through, defaults filled
- `pruneCacheForEpisode` (2): prefix drop, no-op for invalid input
- `pruneCacheForAnime` (1): anime-prefix drop
- `dropDetectionsForAnime` (2): row + broadcast, no-op + no broadcast on miss
- `dropDetectionsForEpisode` (3): partial, full (row removed), miss
- `buildAutoSkipEpisodes` (2): mkv preference + numeric sort + dedup, non-match skip

`sweepFingerprintCache` is fs-heavy; covered by manual + integration testing.

## Test plan

Full local quality gate (per the standing rule):
- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors, only pre-existing warnings)
- `npm run format:check` ✓
- `npm test` ✓ (34/34 — 13 new skip-analysis + existing)
- `npm run build` ✓

## Stack

- PR1 #91 — slices 2a + 2b (pure helpers + codec strings)
- PR2 #92 — slice 2c (StorageService)
- PR3 #93 — slice 2d (AnimeCacheService)
- **PR4 (this)** — slice 2f leaf surface (SkipAnalysisService)
- PR5 (next) — slice 2e (cold-storage), to stack on this
- PR6 — slice 2g (streaming), to stack on PR5 with PR1 merged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)