### PR TITLE
ci: trigger check.yml on PRs to any base branch (#89 stack)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,6 @@ name: Check Build
 
 on:
   pull_request:
-    branches:
-      - main
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
## Summary

Drop the \`pull_request.branches: [main]\` filter from \`.github/workflows/check.yml\` so the \`quality\` + \`build\` + \`comment-artifacts\` jobs fire on PRs targeting *any* base branch, not just \`main\`.

## Why

The Phase 2 refactor (#89) ships as a linear stack of 5 PRs (#91, #92, #93, #94, #95). PR3+ target \`phase2-pr*-*\` branches, so the existing filter prevented CI from running on them at all (literally \"no checks reported\" on the PR page). Each stacked PR still needs the full local quality gate — but losing the CI signal for stacked work is worth fixing once at the workflow level.

## Behavior change

- **Before:** CI only ran on PRs whose **base** is \`main\`.
- **After:** CI runs on every PR, regardless of base branch.

## Cost

Some duplicate work as a stacked PR rebases forward (the same commits get checked once per PR they appear in). \`quality\` is cheap (typecheck + lint + format + tests + smoke) and the build job already has a \`paths-filter\` gate that skips it when only docs change. Net: small.

## Test plan

The next push to PR #93 / #94 / #95 will trigger CI for the first time — that's the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)