### PR TITLE
refactor: Phase 2 PR3 — extract AnimeCacheService (#89) [re-merge]

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -44,6 +44,7 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/main/store/index.ts` | `createStorageService(defaults)` electron-store binding + `MainStorageService.migrateWatchProgressV2()` |
 | `src/main/store/keys.ts` | `PERSISTED_STORE_KEYS` frozen tuple — rename guard, compile-time-asserted against `keyof STORE_DEFAULTS` in `index.ts` |
 | `src/main/store/migrate.ts` | Pure `migrateWatchProgressV2(store)` (one-shot `watchedAt` backfill) |
+| `src/main/services/anime-cache/index.ts` | `createAnimeCacheService` — `AnimeCacheEntry` CRUD + poster file cache + `cleanupStale` orphan sweep; deps-injected (`store`, `userDataDir`, `fetchPoster`, `isCachable`) |
 | `src/preload/index.ts` | contextBridge API exposure to renderer |
 | `src/preload/index.d.ts` | Shared TypeScript interfaces for IPC communication |
 | `src/renderer/src/main.ts` | Vue app entry point |

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,13 +32,7 @@ import { isNetworkError } from './lib/errors'
 import { consolidateQueue, type QueuedShikimoriUpdate } from './lib/shikimori-queue'
 import { parseEpisodeFromFilename } from './lib/filename'
 import { avcCodecString, hevcCodecString, aacCodecString } from './streaming/codec-strings'
-import type {
-  AnimeSearchResult,
-  AnimeDetail,
-  EpisodeSummary,
-  EpisodeDetail,
-  Translation
-} from './smotret-api'
+import type { AnimeSearchResult, AnimeDetail, EpisodeSummary, Translation } from './smotret-api'
 import { ensureFpcalc, getFpcalcPath } from './fpcalc-binaries'
 import {
   analyzeShow,
@@ -82,15 +76,7 @@ protocol.registerSchemesAsPrivileged([
 process.stdout?.on('error', () => {})
 process.stderr?.on('error', () => {})
 
-interface AnimeCacheEntry {
-  animeDetail: AnimeDetail | null
-  episodes: Record<number, EpisodeDetail>
-  qualityProbes: Record<number, number>
-  cachedAt: number
-  posterCached: boolean
-  fullProbeAt?: number
-  fullProbeEpisodeCount?: number
-}
+import { createAnimeCacheService, type AnimeCacheEntry } from './services/anime-cache'
 
 export interface AutoDownloadSubscription {
   animeId: number
@@ -892,111 +878,14 @@ async function backgroundRescan(animeName: string): Promise<void> {
   }
 }
 
-function getCacheEntry(animeId: number): AnimeCacheEntry | null {
-  const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
-  return cache[String(animeId)] || null
-}
-
-function setCacheEntry(animeId: number, entry: AnimeCacheEntry): void {
-  const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
-  cache[String(animeId)] = entry
-  store.set('animeCache', cache)
-}
-
-function deleteCacheEntry(animeId: number): void {
-  const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
-  delete cache[String(animeId)]
-  store.set('animeCache', cache)
-  // Also delete cached poster
-  const posterPath = getPosterCachePath(animeId)
-  try {
-    fs.unlinkSync(posterPath)
-  } catch {
-    /* ignore */
-  }
-}
-
-function getPosterCacheDir(): string {
-  return path.join(app.getPath('userData'), 'poster-cache')
-}
-
-function getPosterCachePath(animeId: number): string {
-  return path.join(getPosterCacheDir(), `${animeId}.jpg`)
-}
-
-async function cachePosterImage(animeId: number, posterUrl: string): Promise<void> {
-  if (!posterUrl) return
-  const destPath = getPosterCachePath(animeId)
-  if (fs.existsSync(destPath)) return
-  try {
-    fs.mkdirSync(getPosterCacheDir(), { recursive: true })
-    const buffer = await smotretApi.fetchPoster(posterUrl)
-    if (!buffer) return
-    fs.writeFileSync(destPath, buffer)
-  } catch {
-    // Non-critical, ignore
-  }
-}
-
-function ensureCacheEntry(animeId: number): AnimeCacheEntry {
-  const existing = getCacheEntry(animeId)
-  if (existing) return existing
-  return { animeDetail: null, episodes: {}, qualityProbes: {}, cachedAt: 0, posterCached: false }
-}
-
-function updateAnimeDetailCache(animeId: number, detail: AnimeDetail): void {
-  if (!isCachableAnime(animeId)) return
-  const entry = ensureCacheEntry(animeId)
-  entry.animeDetail = detail
-  entry.cachedAt = Date.now()
-  setCacheEntry(animeId, entry)
-  // Cache poster in background
-  if (!entry.posterCached) {
-    cachePosterImage(animeId, detail.posterUrl || detail.posterUrlSmall)
-      .then(() => {
-        entry.posterCached = true
-        setCacheEntry(animeId, entry)
-      })
-      .catch(() => {})
-  }
-}
-
-function updateEpisodeCache(animeId: number, episodeId: number, detail: EpisodeDetail): void {
-  if (!isCachableAnime(animeId)) return
-  const entry = ensureCacheEntry(animeId)
-  entry.episodes[episodeId] = detail
-  entry.cachedAt = Date.now()
-  setCacheEntry(animeId, entry)
-}
-
-function updateQualityProbeCache(animeId: number, translationId: number, height: number): void {
-  if (!isCachableAnime(animeId)) return
-  const entry = ensureCacheEntry(animeId)
-  entry.qualityProbes[translationId] = height
-  setCacheEntry(animeId, entry)
-}
-
-function cleanupStaleCache(): void {
-  const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
-  const downloaded = store.get('downloadedAnime') as Record<string, AnimeSearchResult>
-  const lib = store.get('library') as Record<string, AnimeSearchResult>
-  let changed = false
-  for (const key of Object.keys(cache)) {
-    if (!downloaded[key] && !lib[key]) {
-      delete cache[key]
-      const posterPath = getPosterCachePath(Number(key))
-      try {
-        fs.unlinkSync(posterPath)
-      } catch {
-        /* ignore */
-      }
-      changed = true
-    }
-  }
-  if (changed) store.set('animeCache', cache)
-}
-
 const smotretApi = new SmotretApi(() => store.get('token') as string)
+
+const animeCacheService = createAnimeCacheService({
+  store,
+  userDataDir: app.getPath('userData'),
+  fetchPoster: (url) => smotretApi.fetchPoster(url),
+  isCachable: isCachableAnime
+})
 let downloadManager: DownloadManager
 let ffmpegPath = ''
 let ffprobePath = ''
@@ -2263,11 +2152,11 @@ function registerIpcHandlers(): void {
   ipcMain.handle(CHANNELS.GET_ANIME, async (_event, id: number) => {
     try {
       const result = await smotretApi.getAnime(id)
-      updateAnimeDetailCache(id, result.data)
+      animeCacheService.updateAnimeDetail(id, result.data)
       rememberAnimeMeta(result.data)
       return { ...result, source: 'api' }
     } catch (err) {
-      const cached = getCacheEntry(id)
+      const cached = animeCacheService.getEntry(id)
       if (cached?.animeDetail) {
         return { data: cached.animeDetail, source: 'cache' }
       }
@@ -2283,11 +2172,11 @@ function registerIpcHandlers(): void {
         const streams = embed.stream || []
         if (streams.length === 0) return null
         const best = streams.reduce((a, b) => (a.height > b.height ? a : b))
-        if (animeId) updateQualityProbeCache(animeId, translationId, best.height)
+        if (animeId) animeCacheService.updateQualityProbe(animeId, translationId, best.height)
         return best.height
       } catch {
         if (animeId) {
-          const cached = getCacheEntry(animeId)
+          const cached = animeCacheService.getEntry(animeId)
           return cached?.qualityProbes[translationId] ?? null
         }
         return null
@@ -2298,7 +2187,7 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     CHANNELS.PROBE_FULL_SCAN_NEEDED,
     (_event, animeId: number, episodeCount: number) => {
-      const entry = getCacheEntry(animeId)
+      const entry = animeCacheService.getEntry(animeId)
       if (!entry?.fullProbeAt) return true
       if (entry.fullProbeEpisodeCount !== episodeCount) return true
       const weekMs = 7 * 24 * 60 * 60 * 1000
@@ -2307,11 +2196,11 @@ function registerIpcHandlers(): void {
   )
 
   ipcMain.handle(CHANNELS.PROBE_FULL_SCAN_DONE, (_event, animeId: number, episodeCount: number) => {
-    const entry = getCacheEntry(animeId)
+    const entry = animeCacheService.getEntry(animeId)
     if (!entry) return
     entry.fullProbeAt = Date.now()
     entry.fullProbeEpisodeCount = episodeCount
-    setCacheEntry(animeId, entry)
+    animeCacheService.setEntry(animeId, entry)
   })
 
   const qualityMismatches = new Map<
@@ -2360,11 +2249,11 @@ function registerIpcHandlers(): void {
   ipcMain.handle(CHANNELS.GET_EPISODE, async (_event, id: number, animeId?: number) => {
     try {
       const result = await smotretApi.getEpisode(id)
-      if (animeId) updateEpisodeCache(animeId, id, result.data)
+      if (animeId) animeCacheService.updateEpisode(animeId, id, result.data)
       return { ...result, source: 'api' }
     } catch (err) {
       if (animeId) {
-        const cached = getCacheEntry(animeId)
+        const cached = animeCacheService.getEntry(animeId)
         if (cached?.episodes[id]) {
           return { data: cached.episodes[id], source: 'cache' }
         }
@@ -2395,7 +2284,7 @@ function registerIpcHandlers(): void {
     if (lib[key]) {
       delete lib[key]
       store.set('library', lib)
-      if (!isDownloadedAnime(anime.id)) deleteCacheEntry(anime.id)
+      if (!isDownloadedAnime(anime.id)) animeCacheService.deleteEntry(anime.id)
       return false
     } else {
       lib[key] = anime
@@ -2405,7 +2294,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(CHANNELS.GET_ANIME_CACHE, (_event, id: number) => {
-    const entry = getCacheEntry(id)
+    const entry = animeCacheService.getEntry(id)
     if (!entry?.animeDetail || !entry.cachedAt) return null
     if (Date.now() - entry.cachedAt > ANIME_DETAIL_CACHE_TTL_MS) return null
     return { data: entry.animeDetail, cachedAt: entry.cachedAt }
@@ -2413,7 +2302,7 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(CHANNELS.SET_ANIME_CACHE, (_event, id: number, data: AnimeDetail) => {
     if (!isCachableAnime(id)) return false
-    updateAnimeDetailCache(id, data)
+    animeCacheService.updateAnimeDetail(id, data)
     return true
   })
 
@@ -2749,7 +2638,7 @@ function registerIpcHandlers(): void {
       }
     }
     // Clean cache
-    deleteCacheEntry(animeId)
+    animeCacheService.deleteEntry(animeId)
     pruneSkipCacheForAnime(animeId)
     dropSkipDetectionsForAnime(animeId)
   })
@@ -2794,7 +2683,7 @@ function registerIpcHandlers(): void {
     if (mutated) store.set('downloadedEpisodes', episodes)
 
     fileCheckCache.delete(animeName)
-    deleteCacheEntry(animeId)
+    animeCacheService.deleteEntry(animeId)
     pruneSkipCacheForAnime(animeId)
     dropSkipDetectionsForAnime(animeId)
   })
@@ -3015,7 +2904,7 @@ function registerIpcHandlers(): void {
           if (key) {
             delete downloaded[key]
             store.set('downloadedAnime', downloaded)
-            deleteCacheEntry(Number(key))
+            animeCacheService.deleteEntry(Number(key))
           }
         }
       }
@@ -3267,7 +3156,7 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle(CHANNELS.CACHE_GET_POSTER, (_event, animeId: number) => {
-    const posterPath = getPosterCachePath(animeId)
+    const posterPath = animeCacheService.getPosterCachePath(animeId)
     if (fs.existsSync(posterPath)) return `file://${posterPath}`
     return null
   })
@@ -5198,7 +5087,7 @@ app.whenReady().then(async () => {
     })
   })
 
-  cleanupStaleCache()
+  animeCacheService.cleanupStale()
   createWindow()
   const mainWin = BrowserWindow.getAllWindows()[0]
 

--- a/src/main/services/anime-cache/index.ts
+++ b/src/main/services/anime-cache/index.ts
@@ -1,0 +1,156 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import type { StorageService } from '../../store/types'
+import type { AnimeDetail, EpisodeDetail } from '../../smotret-api'
+
+export interface AnimeCacheEntry {
+  animeDetail: AnimeDetail | null
+  episodes: Record<number, EpisodeDetail>
+  qualityProbes: Record<number, number>
+  cachedAt: number
+  posterCached: boolean
+  fullProbeAt?: number
+  fullProbeEpisodeCount?: number
+}
+
+export interface AnimeCacheServiceDeps {
+  store: StorageService
+  /** `app.getPath('userData')` — the poster cache sits at `<userData>/poster-cache/`. */
+  userDataDir: string
+  /** Smotret-anime poster fetcher. Returning `null` skips the write. */
+  fetchPoster: (posterUrl: string) => Promise<Buffer | null | undefined>
+  /** Index.ts-owned gate: anime is in library or downloaded, so worth caching. */
+  isCachable: (animeId: number) => boolean
+}
+
+export interface AnimeCacheService {
+  getEntry(animeId: number): AnimeCacheEntry | null
+  setEntry(animeId: number, entry: AnimeCacheEntry): void
+  deleteEntry(animeId: number): void
+  ensureEntry(animeId: number): AnimeCacheEntry
+  updateAnimeDetail(animeId: number, detail: AnimeDetail): void
+  updateEpisode(animeId: number, episodeId: number, detail: EpisodeDetail): void
+  updateQualityProbe(animeId: number, translationId: number, height: number): void
+  cachePosterImage(animeId: number, posterUrl: string): Promise<void>
+  getPosterCacheDir(): string
+  getPosterCachePath(animeId: number): string
+  cleanupStale(): void
+}
+
+export function createAnimeCacheService(deps: AnimeCacheServiceDeps): AnimeCacheService {
+  const { store, userDataDir, fetchPoster, isCachable } = deps
+
+  const getPosterCacheDir = (): string => path.join(userDataDir, 'poster-cache')
+  const getPosterCachePath = (animeId: number): string =>
+    path.join(getPosterCacheDir(), `${animeId}.jpg`)
+
+  function getEntry(animeId: number): AnimeCacheEntry | null {
+    const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
+    return cache[String(animeId)] || null
+  }
+
+  function setEntry(animeId: number, entry: AnimeCacheEntry): void {
+    const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
+    cache[String(animeId)] = entry
+    store.set('animeCache', cache)
+  }
+
+  function deleteEntry(animeId: number): void {
+    const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
+    delete cache[String(animeId)]
+    store.set('animeCache', cache)
+    // Also delete cached poster
+    const posterPath = getPosterCachePath(animeId)
+    try {
+      fs.unlinkSync(posterPath)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function cachePosterImage(animeId: number, posterUrl: string): Promise<void> {
+    if (!posterUrl) return
+    const destPath = getPosterCachePath(animeId)
+    if (fs.existsSync(destPath)) return
+    try {
+      fs.mkdirSync(getPosterCacheDir(), { recursive: true })
+      const buffer = await fetchPoster(posterUrl)
+      if (!buffer) return
+      fs.writeFileSync(destPath, buffer)
+    } catch {
+      // Non-critical, ignore
+    }
+  }
+
+  function ensureEntry(animeId: number): AnimeCacheEntry {
+    const existing = getEntry(animeId)
+    if (existing) return existing
+    return { animeDetail: null, episodes: {}, qualityProbes: {}, cachedAt: 0, posterCached: false }
+  }
+
+  function updateAnimeDetail(animeId: number, detail: AnimeDetail): void {
+    if (!isCachable(animeId)) return
+    const entry = ensureEntry(animeId)
+    entry.animeDetail = detail
+    entry.cachedAt = Date.now()
+    setEntry(animeId, entry)
+    // Cache poster in background
+    if (!entry.posterCached) {
+      cachePosterImage(animeId, detail.posterUrl || detail.posterUrlSmall)
+        .then(() => {
+          entry.posterCached = true
+          setEntry(animeId, entry)
+        })
+        .catch(() => {})
+    }
+  }
+
+  function updateEpisode(animeId: number, episodeId: number, detail: EpisodeDetail): void {
+    if (!isCachable(animeId)) return
+    const entry = ensureEntry(animeId)
+    entry.episodes[episodeId] = detail
+    entry.cachedAt = Date.now()
+    setEntry(animeId, entry)
+  }
+
+  function updateQualityProbe(animeId: number, translationId: number, height: number): void {
+    if (!isCachable(animeId)) return
+    const entry = ensureEntry(animeId)
+    entry.qualityProbes[translationId] = height
+    setEntry(animeId, entry)
+  }
+
+  function cleanupStale(): void {
+    const cache = store.get('animeCache') as Record<string, AnimeCacheEntry>
+    const downloaded = store.get('downloadedAnime') as Record<string, unknown>
+    const lib = store.get('library') as Record<string, unknown>
+    let changed = false
+    for (const key of Object.keys(cache)) {
+      if (!downloaded[key] && !lib[key]) {
+        delete cache[key]
+        const posterPath = getPosterCachePath(Number(key))
+        try {
+          fs.unlinkSync(posterPath)
+        } catch {
+          /* ignore */
+        }
+        changed = true
+      }
+    }
+    if (changed) store.set('animeCache', cache)
+  }
+
+  return {
+    getEntry,
+    setEntry,
+    deleteEntry,
+    ensureEntry,
+    updateAnimeDetail,
+    updateEpisode,
+    updateQualityProbe,
+    cachePosterImage,
+    getPosterCacheDir,
+    getPosterCachePath,
+    cleanupStale
+  }
+}

--- a/test/services/anime-cache.test.ts
+++ b/test/services/anime-cache.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  createAnimeCacheService,
+  type AnimeCacheEntry,
+  type AnimeCacheService
+} from '../../src/main/services/anime-cache'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
+import type { AnimeDetail, EpisodeDetail } from '../../src/main/smotret-api'
+
+function mkDetail(): AnimeDetail {
+  return { posterUrl: 'https://example/a.jpg', posterUrlSmall: '' } as unknown as AnimeDetail
+}
+function mkEpisode(): EpisodeDetail {
+  return {} as EpisodeDetail
+}
+
+describe('AnimeCacheService', () => {
+  let tmpDir: string
+  let store: InMemoryStorage
+  let svc: AnimeCacheService
+  let fetchedUrls: string[]
+  let cachable: Set<number>
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'anime-cache-test-'))
+    fetchedUrls = []
+    cachable = new Set([1, 2, 3])
+    store = new InMemoryStorage({ animeCache: {}, downloadedAnime: {}, library: {} })
+    svc = createAnimeCacheService({
+      store,
+      userDataDir: tmpDir,
+      fetchPoster: async (url: string) => {
+        fetchedUrls.push(url)
+        return Buffer.from('poster-bytes')
+      },
+      isCachable: (animeId: number) => cachable.has(animeId)
+    })
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns null for an unknown anime and persists via setEntry', () => {
+    expect(svc.getEntry(1)).toBeNull()
+    const entry: AnimeCacheEntry = {
+      animeDetail: null,
+      episodes: {},
+      qualityProbes: {},
+      cachedAt: 0,
+      posterCached: false
+    }
+    svc.setEntry(1, entry)
+    expect(svc.getEntry(1)).toEqual(entry)
+  })
+
+  it('ensureEntry returns an empty default without writing', () => {
+    const e = svc.ensureEntry(99)
+    expect(e.cachedAt).toBe(0)
+    // Not persisted by ensure alone
+    expect(store.get<Record<string, unknown>>('animeCache')).toEqual({})
+  })
+
+  it('updateAnimeDetail is a no-op when isCachable returns false', () => {
+    cachable.clear()
+    svc.updateAnimeDetail(7, mkDetail())
+    expect(store.get<Record<string, unknown>>('animeCache')).toEqual({})
+  })
+
+  it('updateAnimeDetail persists detail and triggers background poster fetch', async () => {
+    svc.updateAnimeDetail(1, mkDetail())
+    const after = store.get<Record<string, AnimeCacheEntry>>('animeCache')!
+    expect(after['1'].animeDetail).not.toBeNull()
+    expect(after['1'].cachedAt).toBeGreaterThan(0)
+    // Background poster cache resolves on a microtask
+    await new Promise((r) => setImmediate(r))
+    expect(fetchedUrls).toEqual(['https://example/a.jpg'])
+    expect(fs.existsSync(path.join(tmpDir, 'poster-cache', '1.jpg'))).toBe(true)
+  })
+
+  it('updateEpisode and updateQualityProbe stack onto the same entry', () => {
+    svc.updateEpisode(2, 100, mkEpisode())
+    svc.updateQualityProbe(2, 100, 1080)
+    const e = svc.getEntry(2)!
+    expect(e.episodes[100]).toBeDefined()
+    expect(e.qualityProbes[100]).toBe(1080)
+  })
+
+  it('deleteEntry removes from store and unlinks the cached poster file', async () => {
+    svc.updateAnimeDetail(1, mkDetail())
+    await new Promise((r) => setImmediate(r)) // let poster write settle
+    const posterPath = path.join(tmpDir, 'poster-cache', '1.jpg')
+    expect(fs.existsSync(posterPath)).toBe(true)
+    svc.deleteEntry(1)
+    expect(svc.getEntry(1)).toBeNull()
+    expect(fs.existsSync(posterPath)).toBe(false)
+  })
+
+  it('cachePosterImage skips when fetchPoster returns null', async () => {
+    const skippingSvc = createAnimeCacheService({
+      store: new InMemoryStorage({ animeCache: {}, downloadedAnime: {}, library: {} }),
+      userDataDir: tmpDir,
+      fetchPoster: async () => null,
+      isCachable: () => true
+    })
+    await skippingSvc.cachePosterImage(42, 'https://example/x.jpg')
+    expect(fs.existsSync(path.join(tmpDir, 'poster-cache', '42.jpg'))).toBe(false)
+  })
+
+  it('cleanupStale drops cache rows whose anime is neither downloaded nor in library', () => {
+    store.set('animeCache', {
+      '1': { episodes: {}, qualityProbes: {}, cachedAt: 0, posterCached: false, animeDetail: null },
+      '2': { episodes: {}, qualityProbes: {}, cachedAt: 0, posterCached: false, animeDetail: null },
+      '3': { episodes: {}, qualityProbes: {}, cachedAt: 0, posterCached: false, animeDetail: null }
+    })
+    store.set('downloadedAnime', { '1': {} })
+    store.set('library', { '3': {} })
+    svc.cleanupStale()
+    const after = store.get<Record<string, AnimeCacheEntry>>('animeCache')!
+    expect(Object.keys(after).sort()).toEqual(['1', '3'])
+  })
+})


### PR DESCRIPTION
Re-targeted re-open of #93 after stacked-merge mishap left main at PR2.

This PR ships the same content that was reviewed and approved in #93 — the rebased commit on top of current main (PR1+PR2) is byte-identical to the originally-approved tree minus rebase conflict resolution (PR1's already-merged removal of FILENAME_EP_RE).

See #93 for full review + approval history.

## Summary
- Extracts 11 cache-management functions from `src/main/index.ts` into `src/main/services/anime-cache/index.ts`
- Service surface: `getEntry`, `setEntry`, `deleteEntry`, `ensureEntry`, `updateAnimeDetail`, `updateEpisode`, `updateQualityProbe`, `cachePosterImage`, `getPosterCacheDir`, `getPosterCachePath`, `cleanupStale`
- Dependency-injected: `store`, `userDataDir`, `fetchPoster`, `isCachable`
- Unit-tested via `InMemoryStorage` fake (no electron-store dependency in tests)

## Test plan
- [x] typecheck
- [x] lint
- [x] format:check
- [x] vitest
- [x] electron-vite build (linux/main)