### PR TITLE
refactor: Phase 4 slice 4a — preload subscribe-returns-disposer (#111)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -327,6 +327,16 @@ LibraryView shows both with indicators:
 
 ## IPC Handlers
 
+### Broadcast subscription contract (Phase 4 slice 4a, #111)
+
+`send`-direction event channels expose `on*` subscribers on `window.api` of shape
+`EventSubscriber<T> = (listener) => Unsubscribe` (see `src/shared/ipc/channels.ts`).
+Each call registers a dedicated listener and returns a disposer that removes only
+that listener — never `ipcRenderer.removeAllListeners`, which would clobber every
+other subscriber on the channel. Renderer callers capture the returned `Unsubscribe`
+and invoke it in `onBeforeUnmount`/`onUnmounted` (or store disposal in Phase 4b+).
+There are no `off*` methods on `window.api`.
+
 | Channel | Direction | Purpose |
 |---------|-----------|---------|
 | `validate-token` | invoke | Validate API token against smotret-anime.ru |

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,34 +1,6 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron'
-import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'
-
-// Per-channel map of {original-callback → wrapped-handler} so the matching
-// off* helper can call ipcRenderer.removeListener with the actual wrapped
-// function (the one we registered on ipcRenderer.on). Without this map,
-// the only way to remove a listener is removeAllListeners — which would
-// also rip out listeners installed by other components in the same view.
-type SyncplayHandler<T> = (data: T) => void
-type SyncplayWrapped = (event: IpcRendererEvent, data: unknown) => void
-const syncplayWrappers = new Map<string, Map<SyncplayHandler<unknown>, SyncplayWrapped>>()
-
-function syncplayOn<T>(channel: string, cb: SyncplayHandler<T>): void {
-  const wrapped: SyncplayWrapped = (_event, data) => cb(data as T)
-  let bucket = syncplayWrappers.get(channel)
-  if (!bucket) {
-    bucket = new Map()
-    syncplayWrappers.set(channel, bucket)
-  }
-  bucket.set(cb as SyncplayHandler<unknown>, wrapped)
-  ipcRenderer.on(channel, wrapped)
-}
-
-function syncplayOff<T>(channel: string, cb: SyncplayHandler<T>): void {
-  const bucket = syncplayWrappers.get(channel)
-  if (!bucket) return
-  const wrapped = bucket.get(cb as SyncplayHandler<unknown>)
-  if (!wrapped) return
-  ipcRenderer.removeListener(channel, wrapped)
-  bucket.delete(cb as SyncplayHandler<unknown>)
-}
+import { CHANNELS, EVENT_CHANNELS, type Unsubscribe } from '@shared/ipc/channels'
+import { subscribe } from './subscribe'
 
 const api = {
   validateToken: () => ipcRenderer.invoke(CHANNELS.VALIDATE_TOKEN),
@@ -98,14 +70,9 @@ const api = {
     >,
   cleanupSetSnoozed: (animeId: number, snoozed: boolean) =>
     ipcRenderer.invoke(CHANNELS.CLEANUP_SET_SNOOZED, animeId, snoozed) as Promise<void>,
-  onCleanupPrompt: (
-    callback: (data: { animeId: number; animeName: string; malId: number }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.CLEANUP_PROMPT, (_event, data) => callback(data))
-  },
-  offCleanupPrompt: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.CLEANUP_PROMPT)
-  },
+  onCleanupPrompt: subscribe<{ animeId: number; animeName: string; malId: number }>(
+    EVENT_CHANNELS.CLEANUP_PROMPT
+  ),
   getSetting: (key: string) => ipcRenderer.invoke(CHANNELS.GET_SETTING, key),
   setSetting: (key: string, value: unknown) => ipcRenderer.invoke(CHANNELS.SET_SETTING, key, value),
 
@@ -185,7 +152,21 @@ const api = {
     translationId?: number
   ) =>
     ipcRenderer.invoke(CHANNELS.FILE_DELETE_EPISODE, animeName, episodeInt, animeId, translationId),
-  onFileEpisodesChanged: (
+  // FILE_EPISODES_CHANGED is broadcast with two positional args (animeName + map),
+  // unlike every other channel which sends a single payload. Inlined rather than
+  // shoehorning the helper to support multi-arg events.
+  onFileEpisodesChanged: ((callback) => {
+    type Episodes = Record<
+      string,
+      { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
+    >
+    const wrapped = (_event: IpcRendererEvent, animeName: string, data: Episodes): void =>
+      callback(animeName, data)
+    ipcRenderer.on(EVENT_CHANNELS.FILE_EPISODES_CHANGED, wrapped)
+    return (): void => {
+      ipcRenderer.removeListener(EVENT_CHANNELS.FILE_EPISODES_CHANGED, wrapped)
+    }
+  }) as (
     callback: (
       animeName: string,
       data: Record<
@@ -193,82 +174,38 @@ const api = {
         { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
       >
     ) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.FILE_EPISODES_CHANGED, (_event, animeName, data) =>
-      callback(animeName, data)
-    )
-  },
-  offFileEpisodesChanged: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FILE_EPISODES_CHANGED)
-  },
+  ) => Unsubscribe,
 
   // Storage
   storagePickHotDir: () => ipcRenderer.invoke(CHANNELS.STORAGE_PICK_HOT_DIR),
   storagePickColdDir: () => ipcRenderer.invoke(CHANNELS.STORAGE_PICK_COLD_DIR),
   storageMoveToCold: () => ipcRenderer.invoke(CHANNELS.STORAGE_MOVE_TO_COLD),
-  onStorageMoveToColdProgress: (
-    callback: (data: { current: number; total: number; file: string }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS, (_event, data) => callback(data))
-  },
-  offStorageMoveToColdProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS)
-  },
+  onStorageMoveToColdProgress: subscribe<{ current: number; total: number; file: string }>(
+    EVENT_CHANNELS.STORAGE_MOVE_TO_COLD_PROGRESS
+  ),
   storageGetUsage: () => ipcRenderer.invoke(CHANNELS.STORAGE_GET_USAGE) as Promise<StorageUsage>,
   storageRunCleanup: (opts?: { force?: boolean }) =>
     ipcRenderer.invoke(CHANNELS.STORAGE_RUN_CLEANUP, opts) as Promise<CleanupResult>,
-  onStorageUsageProgress: (callback: (data: { scanned: number; total: number }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS, (_event, data) => callback(data))
-  },
-  offStorageUsageProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_USAGE_PROGRESS)
-  },
-  onStorageCleanupPending: (callback: (data: { candidates: CleanupCandidate[] }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.STORAGE_CLEANUP_PENDING, (_event, data) => callback(data))
-  },
-  offStorageCleanupPending: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_CLEANUP_PENDING)
-  },
-  onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED, (_event, data) => callback(data))
-  },
-  offStorageCleanupFinished: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED)
-  },
+  onStorageUsageProgress: subscribe<{ scanned: number; total: number }>(
+    EVENT_CHANNELS.STORAGE_USAGE_PROGRESS
+  ),
+  onStorageCleanupPending: subscribe<{ candidates: CleanupCandidate[] }>(
+    EVENT_CHANNELS.STORAGE_CLEANUP_PENDING
+  ),
+  onStorageCleanupFinished: subscribe<CleanupResult>(EVENT_CHANNELS.STORAGE_CLEANUP_FINISHED),
 
   downloadScanMerge: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_SCAN_MERGE),
   downloadFixMetadata: () => ipcRenderer.invoke(CHANNELS.DOWNLOAD_FIX_METADATA),
-  onFixMetadataProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.FIX_METADATA_PROGRESS, (_event, data) => callback(data))
-  },
-  offFixMetadataProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FIX_METADATA_PROGRESS)
-  },
+  onFixMetadataProgress: subscribe<unknown>(EVENT_CHANNELS.FIX_METADATA_PROGRESS),
 
-  onDownloadProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.DOWNLOAD_PROGRESS, (_event, data) => callback(data))
-  },
-  offDownloadProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.DOWNLOAD_PROGRESS)
-  },
-  onScanMergeProgress: (callback: (data: unknown) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.SCAN_MERGE_PROGRESS, (_event, data) => callback(data))
-  },
-  offScanMergeProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SCAN_MERGE_PROGRESS)
-  },
-  onFfmpegDownloadProgress: (callback: (data: { status: string; progress?: number }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS, (_event, data) => callback(data))
-  },
-  offFfmpegDownloadProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS)
-  },
-  onFpcalcDownloadProgress: (callback: (data: { status: string; progress?: number }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS, (_event, data) => callback(data))
-  },
-  offFpcalcDownloadProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS)
-  },
+  onDownloadProgress: subscribe<unknown>(EVENT_CHANNELS.DOWNLOAD_PROGRESS),
+  onScanMergeProgress: subscribe<unknown>(EVENT_CHANNELS.SCAN_MERGE_PROGRESS),
+  onFfmpegDownloadProgress: subscribe<{ status: string; progress?: number }>(
+    EVENT_CHANNELS.FFMPEG_DOWNLOAD_PROGRESS
+  ),
+  onFpcalcDownloadProgress: subscribe<{ status: string; progress?: number }>(
+    EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS
+  ),
 
   // Skip detection (Phase 1: debug panel only)
   skipDetectorAnalyzeShow: (
@@ -314,20 +251,13 @@ const api = {
       currentAnimeId: number | null
       queueLength: number
     }>,
-  onSkipDetectorProgress: (callback: (data: SkipDetectorProgress) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS, (_event, data) => callback(data))
-  },
-  offSkipDetectorProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS)
-  },
-  onSkipDetectorSignatureUpdated: (
-    callback: (data: { animeId: number; perEpisode: Record<string, EpisodeSkipDetection> }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED, (_event, data) => callback(data))
-  },
-  offSkipDetectorSignatureUpdated: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED)
-  },
+  onSkipDetectorProgress: subscribe<SkipDetectorProgress>(
+    EVENT_CHANNELS.SKIP_DETECTOR_ANALYZE_PROGRESS
+  ),
+  onSkipDetectorSignatureUpdated: subscribe<{
+    animeId: number
+    perEpisode: Record<string, EpisodeSkipDetection>
+  }>(EVENT_CHANNELS.SKIP_DETECTOR_SIGNATURE_UPDATED),
 
   injectChapters: (
     animeId: number,
@@ -339,12 +269,7 @@ const api = {
       failed: number
       total: number
     }>,
-  onChapterInjectProgress: (callback: (data: ChapterInjectProgress) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS, (_event, data) => callback(data))
-  },
-  offChapterInjectProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS)
-  },
+  onChapterInjectProgress: subscribe<ChapterInjectProgress>(EVENT_CHANNELS.CHAPTER_INJECT_PROGRESS),
 
   shellOpenExternal: (url: string) =>
     ipcRenderer.invoke(CHANNELS.SHELL_OPEN_EXTERNAL, url) as Promise<boolean>,
@@ -409,45 +334,22 @@ const api = {
       { ok: true; generation: number; keyframeTime: number } | { error: string }
     >,
   playerCleanupRemux: () => ipcRenderer.invoke(CHANNELS.PLAYER_CLEANUP_REMUX) as Promise<void>,
-  onPlayerStreamSubtitles: (callback: (data: { sessionId: string; content: string }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES, (_event, data) => callback(data))
-  },
-  offPlayerStreamSubtitles: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES)
-  },
-  onPlayerStreamChunk: (
-    callback: (data: { sessionId: string; gen: number; data: Uint8Array }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_CHUNK, (_event, data) => callback(data))
-  },
-  offPlayerStreamChunk: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_CHUNK)
-  },
-  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_END, (_event, data) => callback(data))
-  },
-  offPlayerStreamEnd: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_END)
-  },
-  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_ERROR, (_event, data) => callback(data))
-  },
-  offPlayerStreamError: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_ERROR)
-  },
-  onPlayerStreamProgress: (
-    callback: (data: {
-      sessionId: string
-      gen: number
-      speed: number | null
-      time: number | null
-    }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS, (_event, data) => callback(data))
-  },
-  offPlayerStreamProgress: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS)
-  },
+  onPlayerStreamSubtitles: subscribe<{ sessionId: string; content: string }>(
+    EVENT_CHANNELS.PLAYER_STREAM_SUBTITLES
+  ),
+  onPlayerStreamChunk: subscribe<{ sessionId: string; gen: number; data: Uint8Array }>(
+    EVENT_CHANNELS.PLAYER_STREAM_CHUNK
+  ),
+  onPlayerStreamEnd: subscribe<{ sessionId: string }>(EVENT_CHANNELS.PLAYER_STREAM_END),
+  onPlayerStreamError: subscribe<{ sessionId: string; error: string }>(
+    EVENT_CHANNELS.PLAYER_STREAM_ERROR
+  ),
+  onPlayerStreamProgress: subscribe<{
+    sessionId: string
+    gen: number
+    speed: number | null
+    time: number | null
+  }>(EVENT_CHANNELS.PLAYER_STREAM_PROGRESS),
 
   // Shikimori
   shikimoriGetAuthUrl: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_AUTH_URL) as Promise<string>,
@@ -478,26 +380,15 @@ const api = {
     ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_CALENDAR, force) as Promise<CalendarEntry[]>,
   shikimoriGetRelated: (malId: number) =>
     ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_RELATED, malId) as Promise<ShikiRelatedEntry[]>,
-  onShikimoriRateUpdated: (callback: (entry: ShikiAnimeRateEntry) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED, (_event, entry) => callback(entry))
-  },
-  offShikimoriRateUpdated: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED)
-  },
-  onShikimoriRatesRefreshed: (callback: (entries: ShikiAnimeRateEntry[]) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED, (_event, entries) => callback(entries))
-  },
-  offShikimoriRatesRefreshed: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED)
-  },
+  onShikimoriRateUpdated: subscribe<ShikiAnimeRateEntry>(EVENT_CHANNELS.SHIKIMORI_RATE_UPDATED),
+  onShikimoriRatesRefreshed: subscribe<ShikiAnimeRateEntry[]>(
+    EVENT_CHANNELS.SHIKIMORI_RATES_REFRESHED
+  ),
   shikimoriGetOfflineQueueLength: () =>
     ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_OFFLINE_QUEUE_LENGTH) as Promise<number>,
-  onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED, (_event, data) => callback(data))
-  },
-  offShikimoriOfflineQueueChanged: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED)
-  },
+  onShikimoriOfflineQueueChanged: subscribe<{ length: number }>(
+    EVENT_CHANNELS.SHIKIMORI_OFFLINE_QUEUE_CHANGED
+  ),
   shikimoriGetSyncStatus: () =>
     ipcRenderer.invoke(CHANNELS.SHIKIMORI_GET_SYNC_STATUS) as Promise<{
       state: 'idle' | 'syncing'
@@ -506,19 +397,12 @@ const api = {
       lastSyncError: string | null
     }>,
   shikimoriTriggerSync: () => ipcRenderer.invoke(CHANNELS.SHIKIMORI_TRIGGER_SYNC) as Promise<void>,
-  onShikimoriSyncStatus: (
-    callback: (data: {
-      state: 'idle' | 'syncing'
-      queueLength: number
-      lastSyncAt: number
-      lastSyncError: string | null
-    }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS, (_event, data) => callback(data))
-  },
-  offShikimoriSyncStatus: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS)
-  },
+  onShikimoriSyncStatus: subscribe<{
+    state: 'idle' | 'syncing'
+    queueLength: number
+    lastSyncAt: number
+    lastSyncError: string | null
+  }>(EVENT_CHANNELS.SHIKIMORI_SYNC_STATUS),
   shikimoriGetAnimeDetails: (malId: number) =>
     ipcRenderer.invoke(
       CHANNELS.SHIKIMORI_GET_ANIME_DETAILS,
@@ -526,14 +410,9 @@ const api = {
     ) as Promise<ShikiAnimeDetails | null>,
   shikimoriTriggerDetailPrefetch: () =>
     ipcRenderer.invoke(CHANNELS.SHIKIMORI_TRIGGER_DETAIL_PREFETCH) as Promise<void>,
-  onShikimoriAnimeDetailsUpdated: (
-    callback: (data: { malId: number; details: ShikiAnimeDetails }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED, (_event, data) => callback(data))
-  },
-  offShikimoriAnimeDetailsUpdated: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED)
-  },
+  onShikimoriAnimeDetailsUpdated: subscribe<{ malId: number; details: ShikiAnimeDetails }>(
+    EVENT_CHANNELS.SHIKIMORI_ANIME_DETAILS_UPDATED
+  ),
 
   // Syncplay (Watch Together)
   syncplayConnect: (cfg: {
@@ -564,31 +443,16 @@ const api = {
     ipcRenderer.invoke(CHANNELS.SYNCPLAY_SET_READY, isReady) as Promise<void>,
   syncplayGetStatus: () =>
     ipcRenderer.invoke(CHANNELS.SYNCPLAY_GET_STATUS) as Promise<SyncplayStatus>,
-  onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS, callback),
-  offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) =>
-    syncplayOff(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS, callback),
-  onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE, callback),
-  offSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) =>
-    syncplayOff(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE, callback),
-  onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS, callback),
-  offSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) =>
-    syncplayOff(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS, callback),
-  onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT, callback),
-  offSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) =>
-    syncplayOff(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT, callback),
-  onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE, callback),
-  offSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) =>
-    syncplayOff(EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE, callback),
-  onSyncplayTrace: (callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void) =>
-    syncplayOn(EVENT_CHANNELS.SYNCPLAY_TRACE, callback),
-  offSyncplayTrace: (
-    callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void
-  ) => syncplayOff(EVENT_CHANNELS.SYNCPLAY_TRACE, callback),
+  onSyncplayConnectionStatus: subscribe<SyncplayStatus>(EVENT_CHANNELS.SYNCPLAY_CONNECTION_STATUS),
+  onSyncplayRemoteState: subscribe<SyncplayRemoteState>(EVENT_CHANNELS.SYNCPLAY_REMOTE_STATE),
+  onSyncplayRoomUsers: subscribe<SyncplayRoomUser[]>(EVENT_CHANNELS.SYNCPLAY_ROOM_USERS),
+  onSyncplayRoomEvent: subscribe<SyncplayRoomEvent>(EVENT_CHANNELS.SYNCPLAY_ROOM_EVENT),
+  onSyncplayRemoteEpisodeChange: subscribe<SyncplayRemoteEpisode>(
+    EVENT_CHANNELS.SYNCPLAY_REMOTE_EPISODE_CHANGE
+  ),
+  onSyncplayTrace: subscribe<{ dir: 'in' | 'out'; keys: string; msg: unknown }>(
+    EVENT_CHANNELS.SYNCPLAY_TRACE
+  ),
 
   // Auto-downloader
   autoDlGetSubscription: (animeId: number) =>
@@ -619,32 +483,17 @@ const api = {
   autoDlGetEnabled: () => ipcRenderer.invoke(CHANNELS.AUTO_DL_GET_ENABLED) as Promise<boolean>,
   autoDlSetEnabled: (enabled: boolean) =>
     ipcRenderer.invoke(CHANNELS.AUTO_DL_SET_ENABLED, enabled) as Promise<boolean>,
-  onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, (_event, result) => callback(result))
-  },
-  offAutoDlTickResult: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.AUTO_DL_TICK_RESULT)
-  },
-  onAutoDlEnqueued: (
-    callback: (data: { animeId: number; episodeInt: string; animeName: string }) => void
-  ) => {
-    ipcRenderer.on(EVENT_CHANNELS.AUTO_DL_ENQUEUED, (_event, data) => callback(data))
-  },
-  offAutoDlEnqueued: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.AUTO_DL_ENQUEUED)
-  },
+  onAutoDlTickResult: subscribe<AutoDlTickResult>(EVENT_CHANNELS.AUTO_DL_TICK_RESULT),
+  onAutoDlEnqueued: subscribe<{ animeId: number; episodeInt: string; animeName: string }>(
+    EVENT_CHANNELS.AUTO_DL_ENQUEUED
+  ),
 
   // Updates
   appVersion: () => ipcRenderer.invoke(CHANNELS.APP_VERSION),
   updateCheck: () => ipcRenderer.invoke(CHANNELS.UPDATE_CHECK),
   updateDownload: () => ipcRenderer.invoke(CHANNELS.UPDATE_DOWNLOAD),
   updateInstall: () => ipcRenderer.invoke(CHANNELS.UPDATE_INSTALL),
-  onUpdateStatus: (callback: (data: unknown) => void) => {
-    ipcRenderer.on(EVENT_CHANNELS.UPDATE_STATUS, (_event, data) => callback(data))
-  },
-  offUpdateStatus: () => {
-    ipcRenderer.removeAllListeners(EVENT_CHANNELS.UPDATE_STATUS)
-  }
+  onUpdateStatus: subscribe<unknown>(EVENT_CHANNELS.UPDATE_STATUS)
 }
 
 if (process.contextIsolated) {

--- a/src/preload/subscribe.ts
+++ b/src/preload/subscribe.ts
@@ -1,0 +1,18 @@
+import { ipcRenderer, type IpcRendererEvent } from 'electron'
+import type { EventSubscriber } from '@shared/ipc/channels'
+
+/**
+ * Build a broadcast subscription on `window.api`. Each call creates a fresh
+ * wrapped listener and returns a disposer that removes only that listener
+ * (epic #84, decision 2). Never call `ipcRenderer.removeAllListeners` — that
+ * would clobber every other subscriber on the same channel.
+ */
+export function subscribe<T>(channel: string): EventSubscriber<T> {
+  return (callback) => {
+    const wrapped = (_event: IpcRendererEvent, data: T): void => callback(data)
+    ipcRenderer.on(channel, wrapped)
+    return (): void => {
+      ipcRenderer.removeListener(channel, wrapped)
+    }
+  }
+}

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -2,10 +2,15 @@
 //
 // Domain types (AnimeDetail, ShikiUserRate, EpisodeGroup, …) were relocated to
 // `src/shared/types/*.d.ts` in #84 Phase 1 (slice 1a). They are still declared as
-// ambient globals there — no import is needed here or at any call site, and the
-// `Api` shape below is byte-identical to before the split. Later Phase 1 slices
-// (1b/1c) introduce the typed channel contract and regenerate the preload from
-// it; until then this hand-written surface stays authoritative.
+// ambient globals there — no import is needed here or at any call site.
+//
+// Phase 4 slice 4a (#111) replaced the `on*`/`off*` subscription pairs with
+// `EventSubscriber<T>`-shaped subscribers that return an `Unsubscribe` disposer.
+// `Unsubscribe` is mirrored locally as an ambient alias so this file can stay
+// declaration-only (importing from `@shared/ipc/channels` would convert it into
+// a module and force renderer callers to import `Api`/`Window`).
+
+type Unsubscribe = () => void
 
 declare module 'libass-wasm/dist/js/subtitles-octopus.js' {
   export default class SubtitlesOctopus {
@@ -54,8 +59,7 @@ interface Api {
   cleanupSetSnoozed: (animeId: number, snoozed: boolean) => Promise<void>
   onCleanupPrompt: (
     callback: (data: { animeId: number; animeName: string; malId: number }) => void
-  ) => void
-  offCleanupPrompt: () => void
+  ) => Unsubscribe
   getSetting: (key: string) => Promise<unknown>
   setSetting: (key: string, value: unknown) => Promise<void>
 
@@ -92,8 +96,7 @@ interface Api {
   downloadFixMetadata: () => Promise<{ fixed: number; failed: string[] }>
   onFixMetadataProgress: (
     callback: (data: { current: number; total: number; file: string }) => void
-  ) => void
-  offFixMetadataProgress: () => void
+  ) => Unsubscribe
   ffmpegCheck: () => Promise<{
     available: boolean
     version: string
@@ -108,16 +111,16 @@ interface Api {
   storageMoveToCold: () => Promise<{ moved: number; failed: string[] }>
   onStorageMoveToColdProgress: (
     callback: (data: { current: number; total: number; file: string }) => void
-  ) => void
-  offStorageMoveToColdProgress: () => void
+  ) => Unsubscribe
   storageGetUsage: () => Promise<StorageUsage>
   storageRunCleanup: (opts?: { force?: boolean }) => Promise<CleanupResult>
-  onStorageUsageProgress: (callback: (data: { scanned: number; total: number }) => void) => void
-  offStorageUsageProgress: () => void
-  onStorageCleanupPending: (callback: (data: { candidates: CleanupCandidate[] }) => void) => void
-  offStorageCleanupPending: () => void
-  onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => void
-  offStorageCleanupFinished: () => void
+  onStorageUsageProgress: (
+    callback: (data: { scanned: number; total: number }) => void
+  ) => Unsubscribe
+  onStorageCleanupPending: (
+    callback: (data: { candidates: CleanupCandidate[] }) => void
+  ) => Unsubscribe
+  onStorageCleanupFinished: (callback: (data: CleanupResult) => void) => Unsubscribe
   // File management
   fileCheckEpisodes: (
     animeName: string,
@@ -144,21 +147,16 @@ interface Api {
         { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
       >
     ) => void
-  ) => void
-  offFileEpisodesChanged: () => void
+  ) => Unsubscribe
 
-  onDownloadProgress: (callback: (data: EpisodeGroup[]) => void) => void
-  offDownloadProgress: () => void
-  onScanMergeProgress: (callback: (data: ScanMergeProgress) => void) => void
-  offScanMergeProgress: () => void
+  onDownloadProgress: (callback: (data: EpisodeGroup[]) => void) => Unsubscribe
+  onScanMergeProgress: (callback: (data: ScanMergeProgress) => void) => Unsubscribe
   onFfmpegDownloadProgress: (
     callback: (data: { status: string; progress?: number }) => void
-  ) => void
-  offFfmpegDownloadProgress: () => void
+  ) => Unsubscribe
   onFpcalcDownloadProgress: (
     callback: (data: { status: string; progress?: number }) => void
-  ) => void
-  offFpcalcDownloadProgress: () => void
+  ) => Unsubscribe
 
   // Skip detection (Chromaprint)
   skipDetectorAnalyzeShow: (
@@ -185,19 +183,16 @@ interface Api {
     total: number
   }>
   skipDetectorQueueStatus: () => Promise<{ currentAnimeId: number | null; queueLength: number }>
-  onSkipDetectorProgress: (callback: (data: SkipDetectorProgress) => void) => void
-  offSkipDetectorProgress: () => void
+  onSkipDetectorProgress: (callback: (data: SkipDetectorProgress) => void) => Unsubscribe
   onSkipDetectorSignatureUpdated: (
     callback: (data: { animeId: number; perEpisode: Record<string, EpisodeSkipDetection> }) => void
-  ) => void
-  offSkipDetectorSignatureUpdated: () => void
+  ) => Unsubscribe
 
   injectChapters: (
     animeId: number,
     episodes: { episodeInt: string; episodeLabel: string; filePath: string }[]
   ) => Promise<{ written: number; skipped: number; failed: number; total: number }>
-  onChapterInjectProgress: (callback: (data: ChapterInjectProgress) => void) => void
-  offChapterInjectProgress: () => void
+  onChapterInjectProgress: (callback: (data: ChapterInjectProgress) => void) => Unsubscribe
 
   shellOpenExternal: (url: string) => Promise<boolean>
   shellOpenExternalFile: (filePath: string) => Promise<{ ok: boolean; error?: string }>
@@ -258,16 +253,14 @@ interface Api {
   playerCleanupRemux: () => Promise<void>
   onPlayerStreamSubtitles: (
     callback: (data: { sessionId: string; content: string }) => void
-  ) => void
-  offPlayerStreamSubtitles: () => void
+  ) => Unsubscribe
   onPlayerStreamChunk: (
     callback: (data: { sessionId: string; gen: number; data: Uint8Array }) => void
-  ) => void
-  offPlayerStreamChunk: () => void
-  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => void
-  offPlayerStreamEnd: () => void
-  onPlayerStreamError: (callback: (data: { sessionId: string; error: string }) => void) => void
-  offPlayerStreamError: () => void
+  ) => Unsubscribe
+  onPlayerStreamEnd: (callback: (data: { sessionId: string }) => void) => Unsubscribe
+  onPlayerStreamError: (
+    callback: (data: { sessionId: string; error: string }) => void
+  ) => Unsubscribe
   onPlayerStreamProgress: (
     callback: (data: {
       sessionId: string
@@ -275,8 +268,7 @@ interface Api {
       speed: number | null
       time: number | null
     }) => void
-  ) => void
-  offPlayerStreamProgress: () => void
+  ) => Unsubscribe
 
   // Shikimori
   shikimoriGetAuthUrl: () => Promise<string>
@@ -296,13 +288,10 @@ interface Api {
   shikimoriGetFriendsActivity: () => Promise<ShikiFriendActivityEntry[]>
   shikimoriGetCalendar: (force?: boolean) => Promise<CalendarEntry[]>
   shikimoriGetRelated: (malId: number) => Promise<ShikiRelatedEntry[]>
-  onShikimoriRateUpdated: (callback: (entry: ShikiAnimeRateEntry) => void) => void
-  offShikimoriRateUpdated: () => void
-  onShikimoriRatesRefreshed: (callback: (entries: ShikiAnimeRateEntry[]) => void) => void
-  offShikimoriRatesRefreshed: () => void
+  onShikimoriRateUpdated: (callback: (entry: ShikiAnimeRateEntry) => void) => Unsubscribe
+  onShikimoriRatesRefreshed: (callback: (entries: ShikiAnimeRateEntry[]) => void) => Unsubscribe
   shikimoriGetOfflineQueueLength: () => Promise<number>
-  onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => void
-  offShikimoriOfflineQueueChanged: () => void
+  onShikimoriOfflineQueueChanged: (callback: (data: { length: number }) => void) => Unsubscribe
   shikimoriGetSyncStatus: () => Promise<{
     state: 'idle' | 'syncing'
     queueLength: number
@@ -317,14 +306,12 @@ interface Api {
       lastSyncAt: number
       lastSyncError: string | null
     }) => void
-  ) => void
-  offShikimoriSyncStatus: () => void
+  ) => Unsubscribe
   shikimoriGetAnimeDetails: (malId: number) => Promise<ShikiAnimeDetails | null>
   shikimoriTriggerDetailPrefetch: () => Promise<void>
   onShikimoriAnimeDetailsUpdated: (
     callback: (data: { malId: number; details: ShikiAnimeDetails }) => void
-  ) => void
-  offShikimoriAnimeDetailsUpdated: () => void
+  ) => Unsubscribe
 
   // Syncplay (Watch Together)
   syncplayConnect: (cfg: SyncplayConnectConfig) => Promise<void>
@@ -338,22 +325,14 @@ interface Api {
   syncplaySendLocalSnapshot: (snap: { position: number; paused: boolean }) => Promise<void>
   syncplaySetReady: (isReady: boolean) => Promise<void>
   syncplayGetStatus: () => Promise<SyncplayStatus>
-  onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) => void
-  offSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) => void
-  onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) => void
-  offSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) => void
-  onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) => void
-  offSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) => void
-  onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) => void
-  offSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) => void
-  onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) => void
-  offSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) => void
+  onSyncplayConnectionStatus: (callback: (status: SyncplayStatus) => void) => Unsubscribe
+  onSyncplayRemoteState: (callback: (state: SyncplayRemoteState) => void) => Unsubscribe
+  onSyncplayRoomUsers: (callback: (users: SyncplayRoomUser[]) => void) => Unsubscribe
+  onSyncplayRoomEvent: (callback: (ev: SyncplayRoomEvent) => void) => Unsubscribe
+  onSyncplayRemoteEpisodeChange: (callback: (ep: SyncplayRemoteEpisode) => void) => Unsubscribe
   onSyncplayTrace: (
     callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void
-  ) => void
-  offSyncplayTrace: (
-    callback: (entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void
-  ) => void
+  ) => Unsubscribe
 
   // Auto-downloader
   autoDlGetSubscription: (animeId: number) => Promise<AutoDownloadSubscription | null>
@@ -371,20 +350,17 @@ interface Api {
   }>
   autoDlGetEnabled: () => Promise<boolean>
   autoDlSetEnabled: (enabled: boolean) => Promise<boolean>
-  onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => void
-  offAutoDlTickResult: () => void
+  onAutoDlTickResult: (callback: (result: AutoDlTickResult) => void) => Unsubscribe
   onAutoDlEnqueued: (
     callback: (data: { animeId: number; episodeInt: string; animeName: string }) => void
-  ) => void
-  offAutoDlEnqueued: () => void
+  ) => Unsubscribe
 
   // Updates
   appVersion: () => Promise<string>
   updateCheck: () => Promise<void>
   updateDownload: () => Promise<void>
   updateInstall: () => void
-  onUpdateStatus: (callback: (data: UpdateStatus) => void) => void
-  offUpdateStatus: () => void
+  onUpdateStatus: (callback: (data: UpdateStatus) => void) => Unsubscribe
 }
 
 interface Window {

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -274,12 +274,15 @@ function closeCleanupModal(): void {
   cleanupModal.value = null;
 }
 
+let unsubFfmpegProgress: Unsubscribe | null = null;
+let unsubCleanupPrompt: Unsubscribe | null = null;
+
 onMounted(async () => {
   await loadShortcuts();
   const shikiUser = await window.api.shikimoriGetUser();
   shikimoriLoggedIn.value = !!shikiUser;
   window.addEventListener('keydown', handleKeydown);
-  window.api.onFfmpegDownloadProgress((data) => {
+  unsubFfmpegProgress = window.api.onFfmpegDownloadProgress((data) => {
     if (data.status === 'downloading') {
       ffmpegDownloading.value = true;
       ffmpegProgress.value = data.progress ?? 0;
@@ -287,15 +290,15 @@ onMounted(async () => {
       ffmpegDownloading.value = false;
     }
   });
-  window.api.onCleanupPrompt(handleCleanupPrompt);
+  unsubCleanupPrompt = window.api.onCleanupPrompt(handleCleanupPrompt);
   // Expose test hook for Playwright screenshot script
   (window as any).__openTestPlayer = openPlayer;
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKeydown);
-  window.api.offFfmpegDownloadProgress();
-  window.api.offCleanupPrompt();
+  unsubFfmpegProgress?.();
+  unsubCleanupPrompt?.();
   if (cleanupToastTimer) clearTimeout(cleanupToastTimer);
 });
 </script>

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -55,6 +55,17 @@ const isOffline = computed(() => dataSource.value === 'cache');
 let loadGeneration = 0;
 let disposed = false;
 
+let unsubDownloadProgress: Unsubscribe | null = null;
+let unsubFileEpisodesChanged: Unsubscribe | null = null;
+let unsubShikimoriRateUpdated: Unsubscribe | null = null;
+let unsubShikimoriRatesRefreshed: Unsubscribe | null = null;
+let unsubShikimoriAnimeDetailsUpdated: Unsubscribe | null = null;
+let unsubShikimoriOfflineQueueChanged: Unsubscribe | null = null;
+let unsubShikimoriSyncStatus: Unsubscribe | null = null;
+let unsubSkipDetectorProgress: Unsubscribe | null = null;
+let unsubSkipDetectorSignatureUpdated: Unsubscribe | null = null;
+let unsubChapterInjectProgress: Unsubscribe | null = null;
+
 const isStarred = ref(false);
 const autoDlSubscription = ref<AutoDownloadSubscription | null>(null);
 const autoDlSaving = ref(false);
@@ -684,10 +695,10 @@ onMounted(async () => {
   // Subscribe to download progress
   const queue = await window.api.downloadGetQueue();
   updateDownloadGroups(queue);
-  window.api.onDownloadProgress(updateDownloadGroups);
+  unsubDownloadProgress = window.api.onDownloadProgress(updateDownloadGroups);
 
   // Subscribe to background file rescan updates
-  window.api.onFileEpisodesChanged((animeName, data) => {
+  unsubFileEpisodesChanged = window.api.onFileEpisodesChanged((animeName, data) => {
     if (anime.value && animeName === getAnimeName()) {
       const episodeInts = filteredEpisodes.value.map((ep) => ep.episodeInt);
       const baseMap = new Map<string, string>();
@@ -712,7 +723,7 @@ onMounted(async () => {
   loadWatchProgress();
   window.addEventListener('watch-progress-updated', loadWatchProgress);
 
-  window.api.onShikimoriRateUpdated((entry) => {
+  unsubShikimoriRateUpdated = window.api.onShikimoriRateUpdated((entry) => {
     if (anime.value?.myAnimeListId && entry.rate.target_id === anime.value.myAnimeListId) {
       shikiRate.value = {
         id: entry.rate.id,
@@ -730,13 +741,15 @@ onMounted(async () => {
     }
   });
 
-  window.api.onShikimoriAnimeDetailsUpdated(({ malId, details }) => {
-    if (anime.value?.myAnimeListId === malId) {
-      shikiDetails.value = details;
+  unsubShikimoriAnimeDetailsUpdated = window.api.onShikimoriAnimeDetailsUpdated(
+    ({ malId, details }) => {
+      if (anime.value?.myAnimeListId === malId) {
+        shikiDetails.value = details;
+      }
     }
-  });
+  );
 
-  window.api.onShikimoriRatesRefreshed((entries) => {
+  unsubShikimoriRatesRefreshed = window.api.onShikimoriRatesRefreshed((entries) => {
     if (!anime.value?.myAnimeListId) return;
     const match = entries.find((e) => e.rate.target_id === anime.value!.myAnimeListId);
     if (match) {
@@ -759,7 +772,7 @@ onMounted(async () => {
   window.api.shikimoriGetOfflineQueueLength().then((n) => {
     offlineQueueLength.value = n;
   });
-  window.api.onShikimoriOfflineQueueChanged((data) => {
+  unsubShikimoriOfflineQueueChanged = window.api.onShikimoriOfflineQueueChanged((data) => {
     offlineQueueLength.value = data.length;
   });
   window.api.shikimoriGetSyncStatus().then((s) => {
@@ -767,16 +780,16 @@ onMounted(async () => {
     offlineQueueLength.value = s.queueLength;
     lastSyncError.value = s.lastSyncError;
   });
-  window.api.onSkipDetectorProgress((data) => {
+  unsubSkipDetectorProgress = window.api.onSkipDetectorProgress((data) => {
     if (data.animeId !== props.animeId) return;
     skipProgress.value = data;
     skipAnalyzing.value = data.phase !== 'done';
   });
-  window.api.onSkipDetectorSignatureUpdated((data) => {
+  unsubSkipDetectorSignatureUpdated = window.api.onSkipDetectorSignatureUpdated((data) => {
     if (data.animeId !== props.animeId) return;
     loadSkipDetections();
   });
-  window.api.onChapterInjectProgress((data) => {
+  unsubChapterInjectProgress = window.api.onChapterInjectProgress((data) => {
     if (data.animeId !== props.animeId) return;
     chapterInjectProgress.value = data;
     chapterInjecting.value = data.phase !== 'done';
@@ -784,7 +797,7 @@ onMounted(async () => {
   loadSkipDetections();
   hydrateSkipStatus();
 
-  window.api.onShikimoriSyncStatus((data) => {
+  unsubShikimoriSyncStatus = window.api.onShikimoriSyncStatus((data) => {
     syncState.value = data.state;
     offlineQueueLength.value = data.queueLength;
     lastSyncError.value = data.lastSyncError;
@@ -796,16 +809,16 @@ onUnmounted(() => {
   loadGeneration++;
   window.removeEventListener('mouseup', onMouseBack);
   window.removeEventListener('watch-progress-updated', loadWatchProgress);
-  window.api.offDownloadProgress();
-  window.api.offFileEpisodesChanged();
-  window.api.offShikimoriRateUpdated();
-  window.api.offShikimoriRatesRefreshed();
-  window.api.offShikimoriAnimeDetailsUpdated();
-  window.api.offShikimoriOfflineQueueChanged();
-  window.api.offShikimoriSyncStatus();
-  window.api.offSkipDetectorProgress();
-  window.api.offSkipDetectorSignatureUpdated();
-  window.api.offChapterInjectProgress();
+  unsubDownloadProgress?.();
+  unsubFileEpisodesChanged?.();
+  unsubShikimoriRateUpdated?.();
+  unsubShikimoriRatesRefreshed?.();
+  unsubShikimoriAnimeDetailsUpdated?.();
+  unsubShikimoriOfflineQueueChanged?.();
+  unsubShikimoriSyncStatus?.();
+  unsubSkipDetectorProgress?.();
+  unsubSkipDetectorSignatureUpdated?.();
+  unsubChapterInjectProgress?.();
 });
 
 async function triggerSyncNow(): Promise<void> {

--- a/src/renderer/src/components/DownloadsView.vue
+++ b/src/renderer/src/components/DownloadsView.vue
@@ -8,13 +8,15 @@ function onProgress(data: EpisodeGroup[]): void {
   groups.value = data;
 }
 
+let unsubProgress: Unsubscribe | null = null;
+
 onMounted(async () => {
   groups.value = await window.api.downloadGetQueue();
-  window.api.onDownloadProgress(onProgress);
+  unsubProgress = window.api.onDownloadProgress(onProgress);
 });
 
 onUnmounted(() => {
-  window.api.offDownloadProgress();
+  unsubProgress?.();
 });
 
 function progress(item: DownloadProgressItem): number {

--- a/src/renderer/src/components/HomeView.vue
+++ b/src/renderer/src/components/HomeView.vue
@@ -80,11 +80,14 @@ function onClick(entry: ContinueWatchingEntry): void {
   emit('openAnime', entry.animeId, entry.episodeInt);
 }
 
+let unsubShikiRatesRefreshed: Unsubscribe | null = null;
+let unsubShikiRateUpdated: Unsubscribe | null = null;
+
 onMounted(async () => {
   await refresh();
   window.addEventListener('watch-progress-updated', debouncedRefresh);
-  window.api.onShikimoriRatesRefreshed(refresh);
-  window.api.onShikimoriRateUpdated(refresh);
+  unsubShikiRatesRefreshed = window.api.onShikimoriRatesRefreshed(refresh);
+  unsubShikiRateUpdated = window.api.onShikimoriRateUpdated(refresh);
 });
 
 onUnmounted(() => {
@@ -93,8 +96,8 @@ onUnmounted(() => {
     refreshTimer = null;
   }
   window.removeEventListener('watch-progress-updated', debouncedRefresh);
-  window.api.offShikimoriRatesRefreshed();
-  window.api.offShikimoriRateUpdated();
+  unsubShikiRatesRefreshed?.();
+  unsubShikiRateUpdated?.();
 });
 </script>
 

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -428,18 +428,22 @@ let syncplayWaitingTimer: ReturnType<typeof setTimeout> | null = null;
 const WAITING_DEBOUNCE_MS = 600;
 const syncplayPausedBy = ref<string | null>(null);
 
-// Listener functions captured at register-time so onBeforeUnmount can call
-// the matching off* with the same reference — avoids removeAllListeners
-// ripping out listeners installed by other views (e.g. SettingsView's
-// "Test connection" handler).
-let syncplayConnectionStatusHandler: ((status: SyncplayStatus) => void) | null = null;
-let syncplayRemoteStateHandler: ((state: SyncplayRemoteState) => void) | null = null;
-let syncplayRoomUsersHandler: ((users: SyncplayRoomUser[]) => void) | null = null;
-let syncplayRoomEventHandler: ((ev: SyncplayRoomEvent) => void) | null = null;
-let syncplayTraceHandler:
-  | ((entry: { dir: 'in' | 'out'; keys: string; msg: unknown }) => void)
-  | null = null;
-let syncplayRemoteEpisodeChangeHandler: ((ep: SyncplayRemoteEpisode) => void) | null = null;
+// Disposers returned by each broadcast subscription. Each `on*` registers a
+// dedicated listener and returns an Unsubscribe that removes only that one,
+// so independent subscribers on the same channel (e.g. SettingsView's
+// "Test connection") don't clobber each other.
+let unsubSkipDetectorSignatureUpdated: Unsubscribe | null = null;
+let unsubPlayerStreamSubtitles: Unsubscribe | null = null;
+let unsubPlayerStreamChunk: Unsubscribe | null = null;
+let unsubPlayerStreamEnd: Unsubscribe | null = null;
+let unsubPlayerStreamError: Unsubscribe | null = null;
+let unsubPlayerStreamProgress: Unsubscribe | null = null;
+let unsubSyncplayConnectionStatus: Unsubscribe | null = null;
+let unsubSyncplayRemoteState: Unsubscribe | null = null;
+let unsubSyncplayRoomUsers: Unsubscribe | null = null;
+let unsubSyncplayRoomEvent: Unsubscribe | null = null;
+let unsubSyncplayTrace: Unsubscribe | null = null;
+let unsubSyncplayRemoteEpisodeChange: Unsubscribe | null = null;
 
 function showSyncplayToast(text: string, ms = 3500): void {
   syncplayToast.value = text;
@@ -2557,13 +2561,13 @@ onMounted(async () => {
   }
 
   loadSkipDetections();
-  window.api.onSkipDetectorSignatureUpdated((data) => {
+  unsubSkipDetectorSignatureUpdated = window.api.onSkipDetectorSignatureUpdated((data) => {
     if (data.animeId !== props.animeId) return;
     loadSkipDetections();
   });
 
   // Subtitles extracted from MKV streams arrive asynchronously via IPC.
-  window.api.onPlayerStreamSubtitles(({ sessionId, content }) => {
+  unsubPlayerStreamSubtitles = window.api.onPlayerStreamSubtitles(({ sessionId, content }) => {
     if (sessionId !== streamSessionId.value) return;
     if (activeSubtitleContent.value) return;
     activeSubtitleContent.value = content;
@@ -2575,12 +2579,16 @@ onMounted(async () => {
   });
 
   // MSE fragmented MP4 chunks / end / error events.
-  window.api.onPlayerStreamChunk(({ sessionId, gen, data }) =>
+  unsubPlayerStreamChunk = window.api.onPlayerStreamChunk(({ sessionId, gen, data }) =>
     handleStreamChunk(sessionId, gen, data)
   );
-  window.api.onPlayerStreamEnd(({ sessionId }) => handleStreamEnd(sessionId));
-  window.api.onPlayerStreamError(({ sessionId, error }) => handleStreamError(sessionId, error));
-  window.api.onPlayerStreamProgress(({ sessionId, gen, speed }) => {
+  unsubPlayerStreamEnd = window.api.onPlayerStreamEnd(({ sessionId }) =>
+    handleStreamEnd(sessionId)
+  );
+  unsubPlayerStreamError = window.api.onPlayerStreamError(({ sessionId, error }) =>
+    handleStreamError(sessionId, error)
+  );
+  unsubPlayerStreamProgress = window.api.onPlayerStreamProgress(({ sessionId, gen, speed }) => {
     if (sessionId !== streamSessionId.value) return;
     if (gen !== currentStreamGen) return;
     if (typeof speed === 'number' && isFinite(speed)) transcodeSpeed.value = speed;
@@ -2595,7 +2603,7 @@ onMounted(async () => {
   const cfg = (await window.api.getSetting('syncplay')) as { lastRoom?: string } | null;
   if (cfg?.lastRoom) syncplayRoomInput.value = cfg.lastRoom;
 
-  syncplayConnectionStatusHandler = (status): void => {
+  unsubSyncplayConnectionStatus = window.api.onSyncplayConnectionStatus((status) => {
     const wasReady = syncplayStatus.value.state === 'ready';
     console.log('[syncplay] status:', status.state, status.error ? `error=${status.error}` : '');
     syncplayStatus.value = status;
@@ -2620,15 +2628,15 @@ onMounted(async () => {
         8000
       );
     }
-  };
-  syncplayRemoteStateHandler = (state): void => {
+  });
+  unsubSyncplayRemoteState = window.api.onSyncplayRemoteState((state) => {
     applyRemoteState(state);
-  };
-  syncplayRoomUsersHandler = (users): void => {
+  });
+  unsubSyncplayRoomUsers = window.api.onSyncplayRoomUsers((users) => {
     syncplayRoomUsers.value = users;
     applySyncplayReadyGate();
-  };
-  syncplayRoomEventHandler = (ev): void => {
+  });
+  unsubSyncplayRoomEvent = window.api.onSyncplayRoomEvent((ev) => {
     if (ev.level === 'warn' || ev.level === 'error') {
       console.warn('[syncplay]', ev.text);
     } else {
@@ -2636,8 +2644,8 @@ onMounted(async () => {
     }
     const ms = ev.level === 'warn' || ev.level === 'error' ? 8000 : 3500;
     showSyncplayToast(ev.text, ms);
-  };
-  syncplayTraceHandler = (entry): void => {
+  });
+  unsubSyncplayTrace = window.api.onSyncplayTrace((entry) => {
     const arrow = entry.dir === 'in' ? '<<' : '>>';
     let flat: string;
     try {
@@ -2646,8 +2654,8 @@ onMounted(async () => {
       flat = String(entry.msg);
     }
     console.log(`[syncplay] ${arrow} ${entry.keys} ${flat}`);
-  };
-  syncplayRemoteEpisodeChangeHandler = (ep): void => {
+  });
+  unsubSyncplayRemoteEpisodeChange = window.api.onSyncplayRemoteEpisodeChange((ep) => {
     if (ep.animeId !== props.animeId) {
       showSyncplayToast(`${ep.fromUser} switched to a different anime — not loaded here`);
       return;
@@ -2667,14 +2675,7 @@ onMounted(async () => {
       }
     };
     stepTowards();
-  };
-
-  window.api.onSyncplayConnectionStatus(syncplayConnectionStatusHandler);
-  window.api.onSyncplayRemoteState(syncplayRemoteStateHandler);
-  window.api.onSyncplayRoomUsers(syncplayRoomUsersHandler);
-  window.api.onSyncplayRoomEvent(syncplayRoomEventHandler);
-  window.api.onSyncplayTrace(syncplayTraceHandler);
-  window.api.onSyncplayRemoteEpisodeChange(syncplayRemoteEpisodeChangeHandler);
+  });
 
   // 1-second snapshot push so main's heartbeat has fresh position.
   syncplaySnapshotTimer = setInterval(() => {
@@ -2828,7 +2829,8 @@ onBeforeUnmount(() => {
     clearTimeout(skipButtonGraceTimer);
     skipButtonGraceTimer = null;
   }
-  window.api.offSkipDetectorSignatureUpdated();
+  unsubSkipDetectorSignatureUpdated?.();
+  unsubSkipDetectorSignatureUpdated = null;
   // Unblock any awaiter of askHevcChoice() so prepareMkvForPlayback unwinds.
   if (hevcPromptResolver) {
     const fn = hevcPromptResolver;
@@ -2851,35 +2853,28 @@ onBeforeUnmount(() => {
     gpuDevice = null;
   }
   // Stop listening for stream events
-  window.api.offPlayerStreamSubtitles();
-  window.api.offPlayerStreamChunk();
-  window.api.offPlayerStreamEnd();
-  window.api.offPlayerStreamError();
-  window.api.offPlayerStreamProgress();
-  if (syncplayConnectionStatusHandler) {
-    window.api.offSyncplayConnectionStatus(syncplayConnectionStatusHandler);
-    syncplayConnectionStatusHandler = null;
-  }
-  if (syncplayRemoteStateHandler) {
-    window.api.offSyncplayRemoteState(syncplayRemoteStateHandler);
-    syncplayRemoteStateHandler = null;
-  }
-  if (syncplayRoomUsersHandler) {
-    window.api.offSyncplayRoomUsers(syncplayRoomUsersHandler);
-    syncplayRoomUsersHandler = null;
-  }
-  if (syncplayRoomEventHandler) {
-    window.api.offSyncplayRoomEvent(syncplayRoomEventHandler);
-    syncplayRoomEventHandler = null;
-  }
-  if (syncplayRemoteEpisodeChangeHandler) {
-    window.api.offSyncplayRemoteEpisodeChange(syncplayRemoteEpisodeChangeHandler);
-    syncplayRemoteEpisodeChangeHandler = null;
-  }
-  if (syncplayTraceHandler) {
-    window.api.offSyncplayTrace(syncplayTraceHandler);
-    syncplayTraceHandler = null;
-  }
+  unsubPlayerStreamSubtitles?.();
+  unsubPlayerStreamSubtitles = null;
+  unsubPlayerStreamChunk?.();
+  unsubPlayerStreamChunk = null;
+  unsubPlayerStreamEnd?.();
+  unsubPlayerStreamEnd = null;
+  unsubPlayerStreamError?.();
+  unsubPlayerStreamError = null;
+  unsubPlayerStreamProgress?.();
+  unsubPlayerStreamProgress = null;
+  unsubSyncplayConnectionStatus?.();
+  unsubSyncplayConnectionStatus = null;
+  unsubSyncplayRemoteState?.();
+  unsubSyncplayRemoteState = null;
+  unsubSyncplayRoomUsers?.();
+  unsubSyncplayRoomUsers = null;
+  unsubSyncplayRoomEvent?.();
+  unsubSyncplayRoomEvent = null;
+  unsubSyncplayRemoteEpisodeChange?.();
+  unsubSyncplayRemoteEpisodeChange = null;
+  unsubSyncplayTrace?.();
+  unsubSyncplayTrace = null;
   if (syncplaySnapshotTimer) {
     clearInterval(syncplaySnapshotTimer);
     syncplaySnapshotTimer = null;

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -76,6 +76,15 @@ const skipQueueStatus = ref<{ currentAnimeId: number | null; queueLength: number
 });
 let skipQueuePollTimer: ReturnType<typeof setInterval> | null = null;
 
+let unsubScanMerge: Unsubscribe | null = null;
+let unsubFixMetadata: Unsubscribe | null = null;
+let unsubUpdateStatus: Unsubscribe | null = null;
+let unsubMoveToCold: Unsubscribe | null = null;
+let unsubUsageProgress: Unsubscribe | null = null;
+let unsubCleanupPending: Unsubscribe | null = null;
+let unsubCleanupFinished: Unsubscribe | null = null;
+let unsubAutoDlTickResult: Unsubscribe | null = null;
+
 const skipQueueStatusLabel = computed<string>(() => {
   const s = skipQueueStatus.value;
   if (s.currentAnimeId === null && s.queueLength === 0) return '';
@@ -651,13 +660,13 @@ function formatRelativeTime(ts: number): string {
 }
 
 onMounted(async () => {
-  window.api.onScanMergeProgress(onScanProgress);
-  window.api.onFixMetadataProgress(onFixProgress);
-  window.api.onUpdateStatus(onUpdateStatus);
-  window.api.onStorageMoveToColdProgress(onMoveProgress);
-  window.api.onStorageUsageProgress(onUsageProgress);
-  window.api.onStorageCleanupPending(onCleanupPending);
-  window.api.onStorageCleanupFinished(onCleanupFinished);
+  unsubScanMerge = window.api.onScanMergeProgress(onScanProgress);
+  unsubFixMetadata = window.api.onFixMetadataProgress(onFixProgress);
+  unsubUpdateStatus = window.api.onUpdateStatus(onUpdateStatus);
+  unsubMoveToCold = window.api.onStorageMoveToColdProgress(onMoveProgress);
+  unsubUsageProgress = window.api.onStorageUsageProgress(onUsageProgress);
+  unsubCleanupPending = window.api.onStorageCleanupPending(onCleanupPending);
+  unsubCleanupFinished = window.api.onStorageCleanupFinished(onCleanupFinished);
   refreshMismatchCount();
   refreshSkipQueueStatus();
   // Poll the skip-detector queue while the Settings page is open so the
@@ -674,14 +683,14 @@ watch(activeTab, (tab) => {
 });
 
 onUnmounted(() => {
-  window.api.offScanMergeProgress();
-  window.api.offFixMetadataProgress();
-  window.api.offUpdateStatus();
-  window.api.offStorageMoveToColdProgress();
-  window.api.offStorageUsageProgress();
-  window.api.offStorageCleanupPending();
-  window.api.offStorageCleanupFinished();
-  window.api.offAutoDlTickResult();
+  unsubScanMerge?.();
+  unsubFixMetadata?.();
+  unsubUpdateStatus?.();
+  unsubMoveToCold?.();
+  unsubUsageProgress?.();
+  unsubCleanupPending?.();
+  unsubCleanupFinished?.();
+  unsubAutoDlTickResult?.();
   if (skipQueuePollTimer) {
     clearInterval(skipQueuePollTimer);
     skipQueuePollTimer = null;
@@ -792,7 +801,7 @@ onMounted(async () => {
   await refreshAutoDlSubscriptions();
   const autoDlStatus = await window.api.autoDlGetStatus();
   autoDlLastResult.value = autoDlStatus.lastResult;
-  window.api.onAutoDlTickResult((result) => {
+  unsubAutoDlTickResult = window.api.onAutoDlTickResult((result) => {
     autoDlLastResult.value = result;
     void refreshAutoDlSubscriptions();
   });
@@ -1068,20 +1077,24 @@ async function testSyncplayConnection(): Promise<void> {
   syncplayTestStatus.value = 'testing';
   syncplayTestError.value = '';
 
-  const handler = (status: SyncplayStatus): void => {
+  let unsub: Unsubscribe | null = null;
+  const dispose = (): void => {
+    unsub?.();
+    unsub = null;
+  };
+  unsub = window.api.onSyncplayConnectionStatus((status) => {
     if (status.state === 'ready') {
       syncplayTestStatus.value = 'ok';
-      window.api.offSyncplayConnectionStatus(handler);
+      dispose();
       window.api.syncplayDisconnect();
     } else if (status.state === 'disconnected') {
       if (syncplayTestStatus.value === 'testing') {
         syncplayTestStatus.value = 'failed';
         syncplayTestError.value = status.error || 'Connection closed';
       }
-      window.api.offSyncplayConnectionStatus(handler);
+      dispose();
     }
-  };
-  window.api.onSyncplayConnectionStatus(handler);
+  });
 
   try {
     await window.api.syncplayConnect({
@@ -1096,14 +1109,14 @@ async function testSyncplayConnection(): Promise<void> {
       if (syncplayTestStatus.value === 'testing') {
         syncplayTestStatus.value = 'failed';
         syncplayTestError.value = 'Timed out after 10s';
-        window.api.offSyncplayConnectionStatus(handler);
+        dispose();
         window.api.syncplayDisconnect();
       }
     }, 10_000);
   } catch (err) {
     syncplayTestStatus.value = 'failed';
     syncplayTestError.value = String(err);
-    window.api.offSyncplayConnectionStatus(handler);
+    dispose();
   }
 }
 </script>

--- a/src/renderer/src/components/ShikimoriView.vue
+++ b/src/renderer/src/components/ShikimoriView.vue
@@ -104,10 +104,13 @@ function shikiTitle(entry: ShikiAnimeRateEntry): string {
   return entry.shikiAnime.russian || entry.shikiAnime.name;
 }
 
+let unsubRateUpdated: Unsubscribe | null = null;
+let unsubRatesRefreshed: Unsubscribe | null = null;
+
 onMounted(() => {
   loadRates();
 
-  window.api.onShikimoriRateUpdated((entry) => {
+  unsubRateUpdated = window.api.onShikimoriRateUpdated((entry) => {
     const idx = entries.value.findIndex((e) => e.rate.target_id === entry.rate.target_id);
     if (idx !== -1) {
       entries.value[idx] = entry;
@@ -115,7 +118,7 @@ onMounted(() => {
     }
   });
 
-  window.api.onShikimoriRatesRefreshed(async (newEntries) => {
+  unsubRatesRefreshed = window.api.onShikimoriRatesRefreshed(async (newEntries) => {
     entries.value = newEntries;
     refreshing.value = false;
     const ids = newEntries.filter((e) => e.smotretAnime).map((e) => e.smotretAnime!.id);
@@ -131,8 +134,8 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-  window.api.offShikimoriRateUpdated();
-  window.api.offShikimoriRatesRefreshed();
+  unsubRateUpdated?.();
+  unsubRatesRefreshed?.();
 });
 </script>
 

--- a/test/preload/subscribe.test.ts
+++ b/test/preload/subscribe.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+type Listener = (event: unknown, ...args: unknown[]) => void
+
+const listenersByChannel = new Map<string, Set<Listener>>()
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    on(channel: string, listener: Listener): void {
+      let bucket = listenersByChannel.get(channel)
+      if (!bucket) {
+        bucket = new Set()
+        listenersByChannel.set(channel, bucket)
+      }
+      bucket.add(listener)
+    },
+    removeListener(channel: string, listener: Listener): void {
+      listenersByChannel.get(channel)?.delete(listener)
+    },
+    removeAllListeners(channel: string): void {
+      // The contract forbids using this; the mock still implements it so tests
+      // can assert "no caller of subscribe() touches it indirectly."
+      listenersByChannel.get(channel)?.clear()
+    }
+  }
+}))
+
+import { subscribe } from '../../src/preload/subscribe'
+
+function emit(channel: string, payload: unknown): void {
+  const bucket = listenersByChannel.get(channel)
+  if (!bucket) return
+  for (const listener of [...bucket]) listener({}, payload)
+}
+
+beforeEach(() => {
+  listenersByChannel.clear()
+})
+
+describe('preload subscribe<T>', () => {
+  it('delivers the payload to the listener', () => {
+    const cb = vi.fn()
+    subscribe<{ x: number }>('test:channel')(cb)
+    emit('test:channel', { x: 1 })
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith({ x: 1 })
+  })
+
+  it('returns an Unsubscribe that removes only the caller listener', () => {
+    const cbA = vi.fn()
+    const cbB = vi.fn()
+    const unsubA = subscribe<number>('test:channel')(cbA)
+    subscribe<number>('test:channel')(cbB)
+
+    emit('test:channel', 1)
+    expect(cbA).toHaveBeenCalledTimes(1)
+    expect(cbB).toHaveBeenCalledTimes(1)
+
+    unsubA()
+
+    emit('test:channel', 2)
+    expect(cbA).toHaveBeenCalledTimes(1) // unchanged — disposer removed it
+    expect(cbB).toHaveBeenCalledTimes(2) // still firing
+  })
+
+  it('keeps subscriptions isolated per channel', () => {
+    const cbA = vi.fn()
+    const cbB = vi.fn()
+    subscribe<string>('chan:a')(cbA)
+    subscribe<string>('chan:b')(cbB)
+
+    emit('chan:a', 'hello')
+    expect(cbA).toHaveBeenCalledTimes(1)
+    expect(cbB).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Apply the Phase 1 decision-2 subscription contract (`Unsubscribe`, `EventSubscriber<T>`) across the contextBridge into the renderer. Every `on*`/`off*` pair on `window.api` collapses into a single `on*` that returns an `Unsubscribe` disposer removing **only the caller's** listener — no more `removeAllListeners` clobbering other subscribers on the same channel. Slice 4a of Phase 4 (#111); part of refactor epic #84.

This is pure plumbing — channel names, payload shapes, and main-process behavior are byte-identical.

## Changes

**Preload (`src/preload/`):**
- New `src/preload/subscribe.ts` exports a generic `subscribe<T>(channel): EventSubscriber<T>` helper. Each call registers a dedicated `ipcRenderer.on` listener and returns a closure invoking `ipcRenderer.removeListener` against that exact listener.
- `src/preload/index.ts` rewrites all **33** broadcast subscriptions to `subscribe<T>(EVENT_CHANNELS.X)` (or, for the one multi-arg channel `FILE_EPISODES_CHANGED`, an inlined variant with the same disposer shape). Deletes the `syncplayWrappers` map and the `syncplayOn`/`syncplayOff` helpers — closure ownership of the wrapped listener obsoletes the external Map. Deletes all **28** `ipcRenderer.removeAllListeners(…)` calls and every `off*` key.
- `src/preload/types.d.ts` adds ambient `type Unsubscribe = () => void`, changes every `on*` return type from `void` to `Unsubscribe`, deletes all 33 `off*` declarations, and drops the now-unused callback-identity arg from the 6 syncplay `on*`s.

**Renderer (`src/renderer/`):**
Migrated **7 files** to capture each `on*` return as `let unsubX: Unsubscribe | null = null` and invoke it in `onBeforeUnmount`/`onUnmounted` (and inline branches for the self-unsubscribing handler in `SettingsView.testSyncplayConnection`):
- `App.vue` — 2 disposers (ffmpeg-download progress, cleanup prompt)
- `AnimeDetailView.vue` — 10 disposers (download progress, file-episodes, 4× shikimori, sync status, 2× skip-detector, chapter-inject)
- `DownloadsView.vue` — 1 disposer (download progress)
- `HomeView.vue` — 2 disposers (shikimori rate/refreshed)
- `PlayerView.vue` — 12 disposers (5 player-stream, 6 syncplay, 1 skip-detector); 6 stored handler refs replaced with disposers
- `SettingsView.vue` — 8 disposers + rewrite of `testSyncplayConnection`'s subscribe/inner-unsubscribe flow to a captured closure disposer
- `ShikimoriView.vue` — 2 disposers (shikimori rate/refreshed)

**Tests:**
- `test/preload/subscribe.test.ts` (new, 3 tests) asserts the contract by stubbing `ipcRenderer`: delivery works, the returned disposer removes only the caller's listener (subscribe twice, dispose one, the other still fires), and subscriptions stay isolated per channel.

**Docs:**
- `DESIGN.md` gains a "Broadcast subscription contract" section above the IPC handlers table, summarising the new pattern.

## What's unchanged

- All 117 request channels and 33 event channels — names and payloads frozen.
- Main process — no edits under `src/main/`.
- Behavior in the renderer — subscriptions still fire the same callbacks, just with disposable handles.

## Behavior

No user-visible change. The pattern enforces per-listener removal, so two views subscribing to the same broadcast no longer fight over a global slot — but the previous `removeAllListeners` behavior was only ever wrong as a latent risk, not a current bug, so no behavior actually shifts in shipped flows.

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — 0 errors, 8 pre-existing warnings unchanged
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — 100/100 (incl. 3 new contract tests)
- [x] \`npm run build\` — green
- [x] \`grep -rn "window.api.off\\|removeAllListeners" src/preload/ src/renderer/\` — only the contract-doc comment in subscribe.ts matches
- [ ] Manual: SettingsView mount/unmount; DownloadsView progress; HomeView Shikimori rate edit; PlayerView local MKV open + close; SettingsView "Test connection" against unreachable host (handler self-unsubscribes via disposer, no leak)

## Out of scope (later 4 slices of #111)

- Pinia install / \`stores/\` directory — slice 4b
- \`App.vue\` state migration to stores — slices 4b–4d
- \`App.vue\` final shrink to routing+layout — slice 4e
- CI grep gate forbidding \`window.api.off\` / \`removeAllListeners\` — slice 4e

Part of #111. Epic: #84.