### PR TITLE
refactor: Phase 4 slice 4b — Pinia + useLibraryStore (#111)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -124,13 +124,21 @@ SearchView uses `v-show` (never destroyed) so search state persists across tab s
 ### Navigation State
 
 ```
-App.vue manages per-view anime selection:
-  animeByView = { search: null | animeId, library: null | animeId }
-  animePrefs  = { [animeId]: { translationType, author } }
+Pinia store `useLibraryStore` (src/renderer/src/stores/library.ts) owns:
+  currentView                — active top-level view ('home' | 'search' | ...)
+  animeByView[view]          — currently-opened anime per stacked view
+  animeHistoryByView[view]   — back-stack per stacked view
+  focusEpisodeIntForAnime    — episode to scroll to on AnimeDetailView mount
+  actions: navigate, openAnime, closeAnime, clearFocusEpisode
 
-Each view (search, library) tracks its own selected anime independently.
-AnimeDetailView receives initialPrefs and emits prefsChanged to persist
-translation type and author selections across re-mounts.
+Each stacked view (home, search, library, shikimori, friends, calendar)
+tracks its own selected-anime stack. Components call store actions
+directly — there is no @open-anime / @navigate emit chain through App.vue.
+
+App.vue still holds `animePrefs = { [animeId]: { translationType, author } }`
+until slice 4c, where it moves into `usePlayerStore`. AnimeDetailView
+receives initialPrefs and emits prefsChanged to persist translation type
+and author selections across re-mounts.
 ```
 
 ### Episode Loading & Translation Selection

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "jassub": "^2.4.2",
         "libass-wasm": "^4.1.0",
+        "pinia": "^3.0.4",
         "vue": "^3.5.31"
       },
       "devDependencies": {
@@ -2771,6 +2772,39 @@
         "@vue/shared": "3.5.32"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
     "node_modules/@vue/language-core": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.6.tgz",
@@ -3342,6 +3376,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/bl": {
@@ -4040,6 +4083,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -6071,6 +6129,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -6352,6 +6416,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/isarray": {
@@ -6979,6 +7055,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -7468,6 +7550,12 @@
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -7491,6 +7579,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pkg-up": {
@@ -7886,6 +7995,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -8210,6 +8325,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -8390,6 +8514,18 @@
       },
       "engines": {
         "node": ">= 8.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "jassub": "^2.4.2",
     "libass-wasm": "^4.1.0",
+    "pinia": "^3.0.4",
     "vue": "^3.5.31"
   }
 }

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import { ref, nextTick, onMounted, onBeforeUnmount, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useLibraryStore } from './stores/library';
 import Sidebar from './components/Sidebar.vue';
 import SearchView from './components/SearchView.vue';
 import LibraryView from './components/LibraryView.vue';
@@ -14,28 +16,18 @@ import PlayerView from './components/PlayerView.vue';
 import CleanupModal from './components/CleanupModal.vue';
 import { formatBytes } from './utils';
 
-const currentView = ref('home');
+const libraryStore = useLibraryStore();
+const { currentView, activeAnimeId, activeFocusEpisodeInt } = storeToRefs(libraryStore);
+
 const searchViewRef = ref<InstanceType<typeof SearchView> | null>(null);
 const shortcuts = ref<Record<string, string>>({});
-const animeByView = ref<Record<string, number | null>>({
-  home: null,
-  search: null,
-  library: null,
-  shikimori: null,
-  friends: null,
-  calendar: null
-});
-const animeHistoryByView = ref<Record<string, number[]>>({
-  home: [],
-  search: [],
-  library: [],
-  shikimori: [],
-  friends: [],
-  calendar: []
-});
-const focusEpisodeIntForAnime = ref<Record<number, string | undefined>>({});
 
 const shikimoriLoggedIn = ref(false);
+
+// Reload shortcuts when leaving the settings view in case the user rebound any.
+watch(currentView, (next, prev) => {
+  if (prev === 'settings' && next !== 'settings') loadShortcuts();
+});
 
 // Player overlay state
 const playerState = ref<{
@@ -103,39 +95,8 @@ function closePlayer(): void {
 // Persist translation type and author selections per anime across re-mounts
 const animePrefs = ref<Record<number, { translationType?: string; author?: string }>>({});
 
-const activeAnimeId = computed(() => animeByView.value[currentView.value] ?? null);
-
-function openAnime(id: number, focusEpisodeInt?: string): void {
-  const view = currentView.value;
-  const current = animeByView.value[view];
-  if (current != null && current !== id) {
-    animeHistoryByView.value[view].push(current);
-  }
-  if (focusEpisodeInt) {
-    focusEpisodeIntForAnime.value[id] = focusEpisodeInt;
-  }
-  animeByView.value[view] = id;
-}
-
-function clearFocusEpisode(id: number): void {
-  if (focusEpisodeIntForAnime.value[id] !== undefined) {
-    delete focusEpisodeIntForAnime.value[id];
-  }
-}
-
-function closeAnime(): void {
-  const view = currentView.value;
-  const stack = animeHistoryByView.value[view];
-  animeByView.value[view] = stack.length > 0 ? stack.pop()! : null;
-}
-
 function saveAnimePrefs(animeId: number, translationType: string, author: string): void {
   animePrefs.value[animeId] = { translationType, author };
-}
-
-function navigate(view: string): void {
-  if (currentView.value === 'settings' && view !== 'settings') loadShortcuts();
-  currentView.value = view;
 }
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
@@ -165,15 +126,15 @@ function matchesBinding(e: KeyboardEvent, binding: string): boolean {
 function executeAction(action: string): void {
   switch (action) {
     case 'back':
-      if (activeAnimeId.value) closeAnime();
+      if (activeAnimeId.value) libraryStore.closeAnime();
       break;
     case 'focusSearch':
-      navigate('search');
-      animeByView.value.search = null;
+      libraryStore.navigate('search');
+      libraryStore.animeByView.search = null;
       nextTick(() => searchViewRef.value?.focusInput());
       break;
     case 'goDownloads':
-      navigate('downloads');
+      libraryStore.navigate('downloads');
       break;
   }
 }
@@ -305,40 +266,22 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="app">
-    <Sidebar
-      :current-view="currentView"
-      :shikimori-logged-in="shikimoriLoggedIn"
-      @navigate="navigate"
-    />
+    <Sidebar :shikimori-logged-in="shikimoriLoggedIn" />
     <AnimeDetailView
       v-if="activeAnimeId"
       :key="activeAnimeId"
       :anime-id="activeAnimeId"
       :initial-prefs="animePrefs[activeAnimeId]"
-      :focus-episode-int="focusEpisodeIntForAnime[activeAnimeId]"
-      @back="closeAnime"
+      :focus-episode-int="activeFocusEpisodeInt"
       @prefs-changed="saveAnimePrefs"
       @play-file="openPlayer"
-      @open-anime="openAnime"
-      @focus-applied="clearFocusEpisode"
     />
-    <HomeView
-      v-show="currentView === 'home' && !activeAnimeId"
-      @open-anime="openAnime"
-      @navigate="navigate"
-    />
-    <SearchView
-      ref="searchViewRef"
-      v-show="currentView === 'search' && !activeAnimeId"
-      @open-anime="openAnime"
-    />
-    <LibraryView v-if="currentView === 'library' && !activeAnimeId" @open-anime="openAnime" />
-    <ShikimoriView v-show="currentView === 'shikimori' && !activeAnimeId" @open-anime="openAnime" />
-    <FriendsActivityView
-      v-show="currentView === 'friends' && !activeAnimeId"
-      @open-anime="openAnime"
-    />
-    <CalendarView v-if="currentView === 'calendar' && !activeAnimeId" @open-anime="openAnime" />
+    <HomeView v-show="currentView === 'home' && !activeAnimeId" />
+    <SearchView ref="searchViewRef" v-show="currentView === 'search' && !activeAnimeId" />
+    <LibraryView v-if="currentView === 'library' && !activeAnimeId" />
+    <ShikimoriView v-show="currentView === 'shikimori' && !activeAnimeId" />
+    <FriendsActivityView v-show="currentView === 'friends' && !activeAnimeId" />
+    <CalendarView v-if="currentView === 'calendar' && !activeAnimeId" />
     <SettingsView v-if="currentView === 'settings'" />
     <DownloadsView v-if="currentView === 'downloads'" />
     <PlayerView

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -8,6 +8,7 @@ import {
   sanitizeFilename
 } from '../utils';
 import CleanupModal from './CleanupModal.vue';
+import { useLibraryStore } from '../stores/library';
 
 const props = defineProps<{
   animeId: number;
@@ -16,7 +17,6 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  back: [];
   prefsChanged: [animeId: number, translationType: string, author: string];
   playFile: [
     filePath: string,
@@ -38,9 +38,9 @@ const emit = defineEmits<{
     animeId: number,
     malId: number
   ];
-  openAnime: [animeId: number, focusEpisodeInt?: string];
-  focusApplied: [animeId: number];
 }>();
+
+const libraryStore = useLibraryStore();
 
 const anime = ref<AnimeDetail | null>(null);
 const episodes = ref<Map<number, EpisodeDetail>>(new Map());
@@ -403,7 +403,7 @@ function onEpisodeTranslationChange(
 function onMouseBack(e: MouseEvent): void {
   if (e.button === 3) {
     e.preventDefault();
-    emit('back');
+    libraryStore.closeAnime();
   }
 }
 
@@ -1230,7 +1230,7 @@ async function applyFocusEpisode(target: string): Promise<void> {
   const targetIdx = eps.findIndex((e) => e.episodeInt === target);
   if (targetIdx < 0) {
     focusApplied.value = true;
-    emit('focusApplied', props.animeId);
+    libraryStore.clearFocusEpisode(props.animeId);
     return;
   }
   const targetPage = isPaginated.value ? Math.floor(targetIdx / PAGE_SIZE) : 0;
@@ -1243,7 +1243,7 @@ async function applyFocusEpisode(target: string): Promise<void> {
   ) as HTMLElement | null;
   if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
   focusApplied.value = true;
-  emit('focusApplied', props.animeId);
+  libraryStore.clearFocusEpisode(props.animeId);
 }
 
 watch(
@@ -1597,7 +1597,7 @@ function typeChip(type: string): { short: string; color: string } {
 <template>
   <main class="detail-view">
     <header class="topbar">
-      <button class="back-btn" @click="emit('back')">
+      <button class="back-btn" @click="libraryStore.closeAnime()">
         <svg
           viewBox="0 0 24 24"
           fill="none"
@@ -1876,13 +1876,19 @@ function typeChip(type: string): { short: string; color: string } {
               :role="entry.smotretAnime && !entry.isCurrent ? 'button' : undefined"
               :tabindex="entry.smotretAnime && !entry.isCurrent ? 0 : undefined"
               @click="
-                entry.smotretAnime && !entry.isCurrent && emit('openAnime', entry.smotretAnime.id)
+                entry.smotretAnime &&
+                !entry.isCurrent &&
+                libraryStore.openAnime(entry.smotretAnime.id)
               "
               @keydown.enter.prevent="
-                entry.smotretAnime && !entry.isCurrent && emit('openAnime', entry.smotretAnime.id)
+                entry.smotretAnime &&
+                !entry.isCurrent &&
+                libraryStore.openAnime(entry.smotretAnime.id)
               "
               @keydown.space.prevent="
-                entry.smotretAnime && !entry.isCurrent && emit('openAnime', entry.smotretAnime.id)
+                entry.smotretAnime &&
+                !entry.isCurrent &&
+                libraryStore.openAnime(entry.smotretAnime.id)
               "
             >
               <img

--- a/src/renderer/src/components/CalendarView.vue
+++ b/src/renderer/src/components/CalendarView.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number];
-}>();
+const libraryStore = useLibraryStore();
 
 const entries = ref<CalendarEntry[]>([]);
 const loading = ref(false);
@@ -173,7 +172,7 @@ async function load(force = false): Promise<void> {
 }
 
 function handleClick(entry: CalendarEntry): void {
-  if (entry.animeId !== null) emit('openAnime', entry.animeId);
+  if (entry.animeId !== null) libraryStore.openAnime(entry.animeId);
 }
 
 function onCalendarViewChanged(): void {

--- a/src/renderer/src/components/FriendsActivityView.vue
+++ b/src/renderer/src/components/FriendsActivityView.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number];
-}>();
+const libraryStore = useLibraryStore();
 
 const activities = ref<ShikiFriendActivityEntry[]>([]);
 const loading = ref(false);
@@ -59,7 +58,7 @@ async function load(force = false): Promise<void> {
 }
 
 function handleClick(entry: ShikiFriendActivityEntry): void {
-  if (entry.smotretAnime) emit('openAnime', entry.smotretAnime.id);
+  if (entry.smotretAnime) libraryStore.openAnime(entry.smotretAnime.id);
 }
 
 function posterUrl(entry: ShikiFriendActivityEntry): string {

--- a/src/renderer/src/components/HomeView.vue
+++ b/src/renderer/src/components/HomeView.vue
@@ -1,10 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number, focusEpisodeInt?: string];
-  navigate: [view: string];
-}>();
+const libraryStore = useLibraryStore();
 
 const entries = ref<ContinueWatchingEntry[]>([]);
 const loading = ref(true);
@@ -77,7 +75,7 @@ function progressPercent(entry: ContinueWatchingEntry): number {
 
 function onClick(entry: ContinueWatchingEntry): void {
   if (!entry.animeId) return;
-  emit('openAnime', entry.animeId, entry.episodeInt);
+  libraryStore.openAnime(entry.animeId, entry.episodeInt);
 }
 
 let unsubShikiRatesRefreshed: Unsubscribe | null = null;
@@ -111,7 +109,7 @@ onUnmounted(() => {
       <div v-if="loading && entries.length === 0" class="status-text">Loading...</div>
       <div v-else-if="entries.length === 0" class="empty">
         <p>Nothing to resume yet.</p>
-        <button class="cta-btn" @click="emit('navigate', 'search')">Browse Search</button>
+        <button class="cta-btn" @click="libraryStore.navigate('search')">Browse Search</button>
       </div>
       <div v-else class="grid">
         <button

--- a/src/renderer/src/components/LibraryView.vue
+++ b/src/renderer/src/components/LibraryView.vue
@@ -2,10 +2,9 @@
 import { ref, onMounted } from 'vue';
 import AnimeCard from './AnimeCard.vue';
 import { getAnimeName } from '../utils';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number];
-}>();
+const libraryStore = useLibraryStore();
 
 const library = ref<AnimeSearchResult[]>([]);
 const starredIds = ref(new Set<number>());
@@ -51,7 +50,7 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
             :anime="anime"
             :starred="starredIds.has(anime.id)"
             @toggle-star="toggleStar"
-            @click="emit('openAnime', anime.id)"
+            @click="libraryStore.openAnime(anime.id)"
           />
           <button
             v-if="downloadedIds.has(anime.id)"

--- a/src/renderer/src/components/SearchView.vue
+++ b/src/renderer/src/components/SearchView.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { ref, reactive } from 'vue';
 import AnimeCard from './AnimeCard.vue';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number];
-}>();
+const libraryStore = useLibraryStore();
 
 const query = ref('');
 const searchInput = ref<HTMLInputElement | null>(null);
@@ -94,7 +93,7 @@ async function toggleStar(anime: AnimeSearchResult): Promise<void> {
           :anime="anime"
           :starred="starredIds.has(anime.id)"
           @toggle-star="toggleStar"
-          @click="emit('openAnime', anime.id)"
+          @click="libraryStore.openAnime(anime.id)"
         />
       </div>
       <div v-else-if="searched" class="status-text">No results found</div>

--- a/src/renderer/src/components/ShikimoriView.vue
+++ b/src/renderer/src/components/ShikimoriView.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import AnimeCard from './AnimeCard.vue';
+import { useLibraryStore } from '../stores/library';
 
-const emit = defineEmits<{
-  openAnime: [id: number];
-}>();
+const libraryStore = useLibraryStore();
 
 const entries = ref<ShikiAnimeRateEntry[]>([]);
 const loading = ref(false);
@@ -184,7 +183,7 @@ onUnmounted(() => {
               :anime="entry.smotretAnime"
               :starred="starredIds.has(entry.smotretAnime.id)"
               @toggle-star="toggleStar"
-              @click="emit('openAnime', entry.smotretAnime.id)"
+              @click="libraryStore.openAnime(entry.smotretAnime.id)"
             />
           </template>
           <template v-else>

--- a/src/renderer/src/components/Sidebar.vue
+++ b/src/renderer/src/components/Sidebar.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useLibraryStore, type LibraryView } from '../stores/library';
 
 const props = defineProps<{
-  currentView: string;
   shikimoriLoggedIn?: boolean;
 }>();
 
-const emit = defineEmits<{
-  navigate: [view: string];
-}>();
+const libraryStore = useLibraryStore();
+const { currentView } = storeToRefs(libraryStore);
 
-const baseItems = [
+type MenuItem = { id: LibraryView; label: string; icon: string };
+
+const baseItems: MenuItem[] = [
   {
     id: 'home',
     label: 'Home',
@@ -33,23 +35,23 @@ const baseItems = [
   }
 ];
 
-const shikimoriItem = {
+const shikimoriItem: MenuItem = {
   id: 'shikimori',
   label: 'Shikimori',
   icon: 'M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z'
 };
-const friendsItem = {
+const friendsItem: MenuItem = {
   id: 'friends',
   label: 'Friends',
   icon: 'M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z'
 };
-const calendarItem = {
+const calendarItem: MenuItem = {
   id: 'calendar',
   label: 'Calendar',
   icon: 'M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5'
 };
 
-const settingsItem = {
+const settingsItem: MenuItem = {
   id: 'settings',
   label: 'Settings',
   icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a6.759 6.759 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.28z M15 12a3 3 0 11-6 0 3 3 0 016 0z'
@@ -78,7 +80,7 @@ const menuItems = computed(() => {
         :key="item.id"
         class="menu-item"
         :class="{ active: currentView === item.id }"
-        @click="emit('navigate', item.id)"
+        @click="libraryStore.navigate(item.id)"
       >
         <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" :d="item.icon" />

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 
-createApp(App).mount('#app')
+createApp(App).use(createPinia()).mount('#app')

--- a/src/renderer/src/stores/library.ts
+++ b/src/renderer/src/stores/library.ts
@@ -1,0 +1,110 @@
+// Library/navigation store (Phase 4 slice 4b, #111).
+//
+// Owns the per-view anime selection stacks, the current top-level view, and the
+// focus-episode-per-anime map that AnimeDetailView reads on mount. Previously
+// these lived as refs on App.vue and were prop-drilled / event-emitted to every
+// view; the store collapses that into direct action calls.
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export type LibraryView =
+  | 'home'
+  | 'search'
+  | 'library'
+  | 'shikimori'
+  | 'friends'
+  | 'calendar'
+  | 'downloads'
+  | 'settings'
+
+// Views that have an inline AnimeDetailView overlay (open an anime within the
+// view, keep a back-stack per view). `downloads`/`settings` are top-level only.
+const STACKED_VIEWS = ['home', 'search', 'library', 'shikimori', 'friends', 'calendar'] as const
+type StackedView = (typeof STACKED_VIEWS)[number]
+
+function emptyStacks(): Record<StackedView, number | null> {
+  return {
+    home: null,
+    search: null,
+    library: null,
+    shikimori: null,
+    friends: null,
+    calendar: null
+  }
+}
+
+function emptyHistory(): Record<StackedView, number[]> {
+  return {
+    home: [],
+    search: [],
+    library: [],
+    shikimori: [],
+    friends: [],
+    calendar: []
+  }
+}
+
+export const useLibraryStore = defineStore('library', () => {
+  const currentView = ref<LibraryView>('home')
+  const animeByView = ref<Record<StackedView, number | null>>(emptyStacks())
+  const animeHistoryByView = ref<Record<StackedView, number[]>>(emptyHistory())
+  const focusEpisodeIntForAnime = ref<Record<number, string | undefined>>({})
+
+  function isStackedView(view: LibraryView): view is StackedView {
+    return (STACKED_VIEWS as readonly string[]).includes(view)
+  }
+
+  const activeAnimeId = computed<number | null>(() => {
+    const view = currentView.value
+    if (!isStackedView(view)) return null
+    return animeByView.value[view]
+  })
+
+  const activeFocusEpisodeInt = computed<string | undefined>(() =>
+    activeAnimeId.value != null ? focusEpisodeIntForAnime.value[activeAnimeId.value] : undefined
+  )
+
+  function navigate(view: LibraryView): void {
+    currentView.value = view
+  }
+
+  function openAnime(id: number, focusEpisodeInt?: string): void {
+    const view = currentView.value
+    if (!isStackedView(view)) return
+    const current = animeByView.value[view]
+    if (current != null && current !== id) {
+      animeHistoryByView.value[view].push(current)
+    }
+    if (focusEpisodeInt) {
+      focusEpisodeIntForAnime.value[id] = focusEpisodeInt
+    }
+    animeByView.value[view] = id
+  }
+
+  function closeAnime(): void {
+    const view = currentView.value
+    if (!isStackedView(view)) return
+    const stack = animeHistoryByView.value[view]
+    animeByView.value[view] = stack.length > 0 ? stack.pop()! : null
+  }
+
+  function clearFocusEpisode(id: number): void {
+    if (focusEpisodeIntForAnime.value[id] !== undefined) {
+      delete focusEpisodeIntForAnime.value[id]
+    }
+  }
+
+  return {
+    currentView,
+    animeByView,
+    animeHistoryByView,
+    focusEpisodeIntForAnime,
+    activeAnimeId,
+    activeFocusEpisodeInt,
+    navigate,
+    openAnime,
+    closeAnime,
+    clearFocusEpisode
+  }
+})

--- a/test/renderer/library-store.test.ts
+++ b/test/renderer/library-store.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useLibraryStore } from '../../src/renderer/src/stores/library'
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('useLibraryStore', () => {
+  it('opens an anime on the current view and tracks active', () => {
+    const store = useLibraryStore()
+    store.navigate('library')
+    store.openAnime(42)
+    expect(store.animeByView.library).toBe(42)
+    expect(store.activeAnimeId).toBe(42)
+  })
+
+  it('pushes the previous selection onto the history stack', () => {
+    const store = useLibraryStore()
+    store.navigate('search')
+    store.openAnime(1)
+    store.openAnime(2)
+    expect(store.animeByView.search).toBe(2)
+    expect(store.animeHistoryByView.search).toEqual([1])
+  })
+
+  it('does not push onto history when reopening the same anime', () => {
+    const store = useLibraryStore()
+    store.navigate('home')
+    store.openAnime(7)
+    store.openAnime(7)
+    expect(store.animeHistoryByView.home).toEqual([])
+  })
+
+  it('keeps per-view stacks isolated', () => {
+    const store = useLibraryStore()
+    store.navigate('home')
+    store.openAnime(10)
+    store.navigate('library')
+    store.openAnime(20)
+    expect(store.animeByView.home).toBe(10)
+    expect(store.animeByView.library).toBe(20)
+    expect(store.activeAnimeId).toBe(20)
+    store.navigate('home')
+    expect(store.activeAnimeId).toBe(10)
+  })
+
+  it('pops history on closeAnime; nulls out when stack is empty', () => {
+    const store = useLibraryStore()
+    store.navigate('search')
+    store.openAnime(1)
+    store.openAnime(2)
+    store.closeAnime()
+    expect(store.animeByView.search).toBe(1)
+    store.closeAnime()
+    expect(store.animeByView.search).toBe(null)
+  })
+
+  it('stores focusEpisodeInt per anime and clears on demand', () => {
+    const store = useLibraryStore()
+    store.navigate('home')
+    store.openAnime(11, '5')
+    expect(store.focusEpisodeIntForAnime[11]).toBe('5')
+    expect(store.activeFocusEpisodeInt).toBe('5')
+    store.clearFocusEpisode(11)
+    expect(store.focusEpisodeIntForAnime[11]).toBeUndefined()
+    expect(store.activeFocusEpisodeInt).toBeUndefined()
+  })
+
+  it('treats non-stacked views (downloads/settings) as having no active anime', () => {
+    const store = useLibraryStore()
+    store.navigate('home')
+    store.openAnime(3)
+    store.navigate('settings')
+    expect(store.activeAnimeId).toBe(null)
+    store.openAnime(99) // no-op on a non-stacked view
+    expect(store.animeByView.home).toBe(3)
+  })
+})


### PR DESCRIPTION
> Stacked on top of slice 4a (#112). Base = `phase4-slice-4a-preload-disposer`. Retarget to `main` once #112 lands.

## Summary

Introduce the renderer state layer that the Phase 4 epic plans (#84 decision 4, #111 slice 4b). Pinia is the only new renderer dep. `useLibraryStore` owns the per-view anime selection stacks, the back-history per stacked view, the focus-episode map, and `currentView` navigation that `App.vue` previously prop-drilled and event-emitted through every view.

## Changes

**New deps / wiring:**
- `package.json` adds `pinia ^3.0.4`. `src/renderer/src/main.ts` wires `createPinia()`.

**New `src/renderer/src/stores/library.ts`** (`useLibraryStore`):
- State: `currentView`, `animeByView`, `animeHistoryByView`, `focusEpisodeIntForAnime`.
- Computed: `activeAnimeId`, `activeFocusEpisodeInt`.
- Actions: `navigate`, `openAnime`, `closeAnime`, `clearFocusEpisode`.
- `STACKED_VIEWS` narrows the type so non-stacked views (`downloads`, `settings`) are no-ops on per-view-stack actions.

**`App.vue`:**
- Drops `currentView`, `animeByView`, `animeHistoryByView`, `focusEpisodeIntForAnime` refs + `activeAnimeId` computed + `openAnime`/`closeAnime`/`clearFocusEpisode`/`navigate` functions.
- Reads from store via `storeToRefs(libraryStore)`.
- Replaces the old `navigate()` side effect (shortcut reload on leaving settings) with a `watch(currentView, …)`.
- Template drops every `@open-anime` / `@navigate` / `@back` / `@focus-applied` binding — children call the store directly. `AnimeDetailView` still receives `focus-episode-int` via the store's `activeFocusEpisodeInt` computed (kept as a prop so `:key="activeAnimeId"` re-mount semantics stay intact).
- `executeAction('focusSearch')` and `'back'` and `'goDownloads'` now call store actions directly.

**`Sidebar.vue`:**
- Reads `currentView` from store; `@click` calls `libraryStore.navigate(item.id)` directly.
- Typed menu items via `MenuItem = { id: LibraryView; … }`.

**Six "emitter" views** call store actions directly and drop their `openAnime` (+ `navigate` in HomeView) emit declarations:
`HomeView`, `SearchView`, `LibraryView`, `ShikimoriView`, `FriendsActivityView`, `CalendarView`.

**`AnimeDetailView.vue`:**
- Back button + middle-click handler call `libraryStore.closeAnime()`.
- `focus-applied` flow → `libraryStore.clearFocusEpisode()`.
- Chronology panel clicks (3 sites) → `libraryStore.openAnime(...)`.
- Removes `back`, `openAnime`, `focusApplied` emit declarations entirely.

**Tests:**
- New `test/renderer/library-store.test.ts` (7 tests): per-view stack lifecycle, history push/pop, dedup-same-anime, focus-episode set/clear, non-stacked-view no-ops.

**Docs:**
- `DESIGN.md` "Navigation State" section rewritten to describe the store contract.

## What stays in App.vue (moves later)

- `animePrefs` per-anime translation/author cache — slice 4c (`usePlayerStore`)
- `playerState` overlay payload — slice 4c
- `shortcuts` + ffmpeg overlay state + cleanup toast — slices 4c–4e

## Behavior

No user-visible change. Per-view back-stacks behave identically; navigation, focus-episode, and chronology-open flows are functionally the same — the state just lives in Pinia now.

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — 0 errors, 8 pre-existing warnings unchanged
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — 107/107 (incl. 7 new library-store tests, 3 prior contract tests from slice 4a)
- [x] \`npm run build\` — green
- [ ] Manual: Sidebar nav between Home/Search/Library/Shikimori/Friends/Calendar; open anime on Home, switch view, come back, anime restored; back button + middle-click on AnimeDetailView; chronology panel "open this related anime"; "Browse Search" CTA on empty Home

## Notes

`npm install pinia` surfaced 11 pre-existing npm audit warnings — none introduced by pinia itself. Filed as #113 (defer to a separate PR).

## Out of scope (later 4 slices of #111)

- Slice 4c: `usePlayerStore` (player overlay + animePrefs) + `useSettingsStore` (shortcuts, ffmpeg/fpcalc progress, update status)
- Slice 4d: `useShikimoriStore` + `useDownloadsStore`
- Slice 4e: `App.vue` final shrink + CI grep gate

Part of #111. Epic: #84. Stacked on #112.