### PR TITLE
refactor: Phase 4 slice 4c — usePlayerStore + useSettingsStore (#111)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -135,10 +135,19 @@ Each stacked view (home, search, library, shikimori, friends, calendar)
 tracks its own selected-anime stack. Components call store actions
 directly — there is no @open-anime / @navigate emit chain through App.vue.
 
-App.vue still holds `animePrefs = { [animeId]: { translationType, author } }`
-until slice 4c, where it moves into `usePlayerStore`. AnimeDetailView
-receives initialPrefs and emits prefsChanged to persist translation type
-and author selections across re-mounts.
+Slice 4c adds two more stores:
+  usePlayerStore   — playerState (PlayerPayload | null), animePrefs.
+                     Actions: openPlayer(payload), closePlayer,
+                     saveAnimePrefs. AnimeDetailView calls openPlayer
+                     directly with a typed payload; the old playFile
+                     emit chain through App.vue is gone.
+  useSettingsStore — shortcuts (resolved keyboard bindings),
+                     ffmpegDownloading/Progress, fpcalcDownloading/Progress,
+                     updateStatus (auto-updater banner). Owns three
+                     lifetime-scoped IPC subscriptions
+                     (onFfmpegDownloadProgress, onFpcalcDownloadProgress,
+                     onUpdateStatus) — Pinia singleton, never disposed.
+                     Action: loadShortcuts.
 ```
 
 ### Episode Loading & Translation Selection

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -2,6 +2,8 @@
 import { ref, nextTick, onMounted, onBeforeUnmount, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useLibraryStore } from './stores/library';
+import { usePlayerStore } from './stores/player';
+import { useSettingsStore } from './stores/settings';
 import Sidebar from './components/Sidebar.vue';
 import SearchView from './components/SearchView.vue';
 import LibraryView from './components/LibraryView.vue';
@@ -17,87 +19,20 @@ import CleanupModal from './components/CleanupModal.vue';
 import { formatBytes } from './utils';
 
 const libraryStore = useLibraryStore();
+const playerStore = usePlayerStore();
+const settingsStore = useSettingsStore();
 const { currentView, activeAnimeId, activeFocusEpisodeInt } = storeToRefs(libraryStore);
+const { playerState, animePrefs } = storeToRefs(playerStore);
+const { shortcuts, ffmpegDownloading, ffmpegProgress } = storeToRefs(settingsStore);
 
 const searchViewRef = ref<InstanceType<typeof SearchView> | null>(null);
-const shortcuts = ref<Record<string, string>>({});
 
 const shikimoriLoggedIn = ref(false);
 
 // Reload shortcuts when leaving the settings view in case the user rebound any.
 watch(currentView, (next, prev) => {
-  if (prev === 'settings' && next !== 'settings') loadShortcuts();
+  if (prev === 'settings' && next !== 'settings') void settingsStore.loadShortcuts();
 });
-
-// Player overlay state
-const playerState = ref<{
-  filePath: string;
-  streamUrl: string;
-  subtitleContent: string;
-  animeName: string;
-  episodeLabel: string;
-  availableStreams: { height: number; url: string }[];
-  translationId: number;
-  translations: { id: number; label: string; type: string; height: number }[];
-  downloadedTrIds: number[];
-  allEpisodes: {
-    episodeInt: string;
-    episodeFull: string;
-    translations: { id: number; label: string; type: string; height: number }[];
-    downloadedTrIds: number[];
-  }[];
-  episodeIndex: number;
-  animeId: number;
-  malId: number;
-} | null>(null);
-
-function openPlayer(
-  filePath: string,
-  streamUrl: string,
-  subtitleContent: string,
-  animeName: string,
-  episodeLabel: string,
-  availableStreams: { height: number; url: string }[],
-  translationId: number,
-  translations: { id: number; label: string; type: string; height: number }[] = [],
-  downloadedTrIds: number[] = [],
-  allEpisodes: {
-    episodeInt: string;
-    episodeFull: string;
-    translations: { id: number; label: string; type: string; height: number }[];
-    downloadedTrIds: number[];
-  }[] = [],
-  episodeIndex: number = 0,
-  animeId = 0,
-  malId = 0
-): void {
-  playerState.value = {
-    filePath,
-    streamUrl,
-    subtitleContent,
-    animeName,
-    episodeLabel,
-    availableStreams,
-    translationId,
-    translations,
-    downloadedTrIds,
-    allEpisodes,
-    episodeIndex,
-    animeId,
-    malId
-  };
-}
-
-function closePlayer(): void {
-  playerState.value = null;
-}
-
-// Persist translation type and author selections per anime across re-mounts
-const animePrefs = ref<Record<number, { translationType?: string; author?: string }>>({});
-
-function saveAnimePrefs(animeId: number, translationType: string, author: string): void {
-  animePrefs.value[animeId] = { translationType, author };
-}
 
 const isMac = navigator.platform.toUpperCase().includes('MAC');
 
@@ -156,13 +91,6 @@ function handleKeydown(e: KeyboardEvent): void {
     }
   }
 }
-
-async function loadShortcuts(): Promise<void> {
-  shortcuts.value = (await window.api.getSetting('keyboardShortcuts')) as Record<string, string>;
-}
-
-const ffmpegDownloading = ref(false);
-const ffmpegProgress = ref(0);
 
 // Cleanup prompt (Shikimori "completed" transition)
 const cleanupToast = ref<{
@@ -235,30 +163,21 @@ function closeCleanupModal(): void {
   cleanupModal.value = null;
 }
 
-let unsubFfmpegProgress: Unsubscribe | null = null;
 let unsubCleanupPrompt: Unsubscribe | null = null;
 
 onMounted(async () => {
-  await loadShortcuts();
+  await settingsStore.loadShortcuts();
   const shikiUser = await window.api.shikimoriGetUser();
   shikimoriLoggedIn.value = !!shikiUser;
   window.addEventListener('keydown', handleKeydown);
-  unsubFfmpegProgress = window.api.onFfmpegDownloadProgress((data) => {
-    if (data.status === 'downloading') {
-      ffmpegDownloading.value = true;
-      ffmpegProgress.value = data.progress ?? 0;
-    } else {
-      ffmpegDownloading.value = false;
-    }
-  });
   unsubCleanupPrompt = window.api.onCleanupPrompt(handleCleanupPrompt);
   // Expose test hook for Playwright screenshot script
-  (window as any).__openTestPlayer = openPlayer;
+  (window as any).__openTestPlayer = (payload: Parameters<typeof playerStore.openPlayer>[0]) =>
+    playerStore.openPlayer(payload);
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', handleKeydown);
-  unsubFfmpegProgress?.();
   unsubCleanupPrompt?.();
   if (cleanupToastTimer) clearTimeout(cleanupToastTimer);
 });
@@ -273,8 +192,6 @@ onBeforeUnmount(() => {
       :anime-id="activeAnimeId"
       :initial-prefs="animePrefs[activeAnimeId]"
       :focus-episode-int="activeFocusEpisodeInt"
-      @prefs-changed="saveAnimePrefs"
-      @play-file="openPlayer"
     />
     <HomeView v-show="currentView === 'home' && !activeAnimeId" />
     <SearchView ref="searchViewRef" v-show="currentView === 'search' && !activeAnimeId" />
@@ -299,7 +216,7 @@ onBeforeUnmount(() => {
       :episode-index="playerState.episodeIndex"
       :anime-id="playerState.animeId"
       :mal-id="playerState.malId"
-      @close="closePlayer"
+      @close="playerStore.closePlayer()"
     />
     <CleanupModal
       v-if="cleanupModal"

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -9,6 +9,7 @@ import {
 } from '../utils';
 import CleanupModal from './CleanupModal.vue';
 import { useLibraryStore } from '../stores/library';
+import { usePlayerStore } from '../stores/player';
 
 const props = defineProps<{
   animeId: number;
@@ -16,31 +17,8 @@ const props = defineProps<{
   focusEpisodeInt?: string;
 }>();
 
-const emit = defineEmits<{
-  prefsChanged: [animeId: number, translationType: string, author: string];
-  playFile: [
-    filePath: string,
-    streamUrl: string,
-    subtitleContent: string,
-    animeName: string,
-    episodeLabel: string,
-    availableStreams: { height: number; url: string }[],
-    translationId: number,
-    translations: { id: number; label: string; type: string; height: number }[],
-    downloadedTrIds: number[],
-    allEpisodes: {
-      episodeInt: string;
-      episodeFull: string;
-      translations: { id: number; label: string; type: string; height: number }[];
-      downloadedTrIds: number[];
-    }[],
-    episodeIndex: number,
-    animeId: number,
-    malId: number
-  ];
-}>();
-
 const libraryStore = useLibraryStore();
+const playerStore = usePlayerStore();
 
 const anime = ref<AnimeDetail | null>(null);
 const episodes = ref<Map<number, EpisodeDetail>>(new Map());
@@ -1380,7 +1358,7 @@ function getGroup(episodeFull: string): EpisodeGroup | undefined {
 
 watch([translationType, selectedAuthor], () => {
   episodeOverrides.value = new Map();
-  emit('prefsChanged', props.animeId, translationType.value, selectedAuthor.value);
+  playerStore.saveAnimePrefs(props.animeId, translationType.value, selectedAuthor.value);
   probeSelectedQualities();
 });
 
@@ -1499,22 +1477,21 @@ async function openFile(row: EpisodeRow): Promise<void> {
     const localSubs = await window.api.playerGetLocalSubtitles(info.filePath);
     const allEps = buildAllEpisodes();
     const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt);
-    emit(
-      'playFile',
-      info.filePath,
-      '',
-      localSubs || '',
-      name,
-      row.episode.episodeInt,
-      [],
-      row.selectedTr.id,
-      buildTranslationList(row),
-      [...row.downloadedTrIds],
-      allEps,
-      epIdx,
-      props.animeId,
-      anime.value?.myAnimeListId ?? 0
-    );
+    playerStore.openPlayer({
+      filePath: info.filePath,
+      streamUrl: '',
+      subtitleContent: localSubs || '',
+      animeName: name,
+      episodeLabel: row.episode.episodeInt,
+      availableStreams: [],
+      translationId: row.selectedTr.id,
+      translations: buildTranslationList(row),
+      downloadedTrIds: [...row.downloadedTrIds],
+      allEpisodes: allEps,
+      episodeIndex: epIdx,
+      animeId: props.animeId,
+      malId: anime.value?.myAnimeListId ?? 0
+    });
   } else {
     const result = await window.api.fileOpen(info.filePath);
     if (result) {
@@ -1534,22 +1511,21 @@ async function playStream(row: EpisodeRow): Promise<void> {
   if (result) {
     const allEps = buildAllEpisodes();
     const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt);
-    emit(
-      'playFile',
-      '',
-      result.streamUrl,
-      result.subtitleContent || '',
-      name,
-      row.episode.episodeInt,
-      result.availableStreams,
-      row.selectedTr.id,
-      buildTranslationList(row),
-      [...row.downloadedTrIds],
-      allEps,
-      epIdx,
-      props.animeId,
-      anime.value?.myAnimeListId ?? 0
-    );
+    playerStore.openPlayer({
+      filePath: '',
+      streamUrl: result.streamUrl,
+      subtitleContent: result.subtitleContent || '',
+      animeName: name,
+      episodeLabel: row.episode.episodeInt,
+      availableStreams: result.availableStreams,
+      translationId: row.selectedTr.id,
+      translations: buildTranslationList(row),
+      downloadedTrIds: [...row.downloadedTrIds],
+      allEpisodes: allEps,
+      episodeIndex: epIdx,
+      animeId: props.animeId,
+      malId: anime.value?.myAnimeListId ?? 0
+    });
   }
 }
 

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, onUnmounted, computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useSettingsStore } from '../stores/settings';
 import { formatBytes } from '../utils';
+
+const settingsStore = useSettingsStore();
+const { updateStatus } = storeToRefs(settingsStore);
 
 const activeTab = ref<
   | 'general'
@@ -47,14 +52,9 @@ let savedTimeout: ReturnType<typeof setTimeout> | null = null;
 const tokenStatus = ref<'idle' | 'checking' | 'valid' | 'invalid'>('idle');
 const tokenError = ref('');
 
-// Update state
+// Update state — broadcast subscription owned by `useSettingsStore`; the local
+// "checking" / "error" UI states are written through the same ref.
 const appVersion = ref('');
-const updateStatus = ref<{
-  status: 'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'ready' | 'error';
-  version?: string;
-  percent?: number;
-  error?: string;
-}>({ status: 'idle' });
 
 const notificationMode = ref('off');
 const calendarView = ref<'week' | 'month'>('week');
@@ -78,7 +78,6 @@ let skipQueuePollTimer: ReturnType<typeof setInterval> | null = null;
 
 let unsubScanMerge: Unsubscribe | null = null;
 let unsubFixMetadata: Unsubscribe | null = null;
-let unsubUpdateStatus: Unsubscribe | null = null;
 let unsubMoveToCold: Unsubscribe | null = null;
 let unsubUsageProgress: Unsubscribe | null = null;
 let unsubCleanupPending: Unsubscribe | null = null;
@@ -455,10 +454,6 @@ async function fixMetadata(): Promise<void> {
   }
 }
 
-function onUpdateStatus(data: UpdateStatus): void {
-  updateStatus.value = data;
-}
-
 async function checkForUpdates(): Promise<void> {
   updateStatus.value = { status: 'checking' };
   try {
@@ -662,7 +657,6 @@ function formatRelativeTime(ts: number): string {
 onMounted(async () => {
   unsubScanMerge = window.api.onScanMergeProgress(onScanProgress);
   unsubFixMetadata = window.api.onFixMetadataProgress(onFixProgress);
-  unsubUpdateStatus = window.api.onUpdateStatus(onUpdateStatus);
   unsubMoveToCold = window.api.onStorageMoveToColdProgress(onMoveProgress);
   unsubUsageProgress = window.api.onStorageUsageProgress(onUsageProgress);
   unsubCleanupPending = window.api.onStorageCleanupPending(onCleanupPending);
@@ -685,7 +679,6 @@ watch(activeTab, (tab) => {
 onUnmounted(() => {
   unsubScanMerge?.();
   unsubFixMetadata?.();
-  unsubUpdateStatus?.();
   unsubMoveToCold?.();
   unsubUsageProgress?.();
   unsubCleanupPending?.();

--- a/src/renderer/src/stores/player.ts
+++ b/src/renderer/src/stores/player.ts
@@ -1,0 +1,69 @@
+// Player overlay + per-anime translation prefs store (Phase 4 slice 4c, #111).
+//
+// Owns the payload App.vue used to assemble for the PlayerView overlay and the
+// per-anime translation/author cache that survives across AnimeDetailView
+// re-mounts. The settings/library stores own other cross-view state; the player
+// store is scoped to "what is currently playing + what did the user pick last
+// time."
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type PlayerTranslation = {
+  id: number
+  label: string
+  type: string
+  height: number
+}
+
+export type PlayerEpisode = {
+  episodeInt: string
+  episodeFull: string
+  translations: PlayerTranslation[]
+  downloadedTrIds: number[]
+}
+
+export type PlayerStream = { height: number; url: string }
+
+export type PlayerPayload = {
+  filePath: string
+  streamUrl: string
+  subtitleContent: string
+  animeName: string
+  episodeLabel: string
+  availableStreams: PlayerStream[]
+  translationId: number
+  translations: PlayerTranslation[]
+  downloadedTrIds: number[]
+  allEpisodes: PlayerEpisode[]
+  episodeIndex: number
+  animeId: number
+  malId: number
+}
+
+export type AnimePrefs = { translationType?: string; author?: string }
+
+export const usePlayerStore = defineStore('player', () => {
+  const playerState = ref<PlayerPayload | null>(null)
+  const animePrefs = ref<Record<number, AnimePrefs>>({})
+
+  function openPlayer(payload: PlayerPayload): void {
+    playerState.value = payload
+  }
+
+  function closePlayer(): void {
+    playerState.value = null
+  }
+
+  function saveAnimePrefs(animeId: number, translationType: string, author: string): void {
+    animePrefs.value[animeId] = { translationType, author }
+  }
+
+  return {
+    playerState,
+    animePrefs,
+    openPlayer,
+    closePlayer,
+    saveAnimePrefs
+  }
+})

--- a/src/renderer/src/stores/settings.ts
+++ b/src/renderer/src/stores/settings.ts
@@ -1,0 +1,74 @@
+// Settings / global progress + status store (Phase 4 slice 4c, #111).
+//
+// Owns:
+// - `shortcuts` — the resolved keyboard binding map used by App.vue to match
+//   keydown events. Loaded from `getSetting('keyboardShortcuts')` and refreshed
+//   whenever the user leaves the Settings tab.
+// - `ffmpegDownloading` / `ffmpegProgress` — drives the global "Downloading
+//   ffmpeg…" overlay App.vue renders on first launch.
+// - `fpcalcDownloading` / `fpcalcProgress` — parallel state for the chromaprint
+//   binary; no UI surface today, plumbed for future use.
+// - `updateStatus` — last seen auto-update status. Broader local UI type than
+//   the IPC payload because SettingsView surfaces "idle" / "checking" states
+//   that the main process never broadcasts.
+//
+// The three broadcast subscriptions are owned by the store and live for the
+// app's lifetime (Pinia stores are singletons; the disposers are intentionally
+// discarded — the listeners die with the renderer process).
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type UiUpdateStatus = {
+  status: 'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'ready' | 'error'
+  version?: string
+  percent?: number
+  error?: string
+}
+
+export const useSettingsStore = defineStore('settings', () => {
+  const shortcuts = ref<Record<string, string>>({})
+  const ffmpegDownloading = ref(false)
+  const ffmpegProgress = ref(0)
+  const fpcalcDownloading = ref(false)
+  const fpcalcProgress = ref(0)
+  const updateStatus = ref<UiUpdateStatus>({ status: 'idle' })
+
+  async function loadShortcuts(): Promise<void> {
+    shortcuts.value =
+      ((await window.api.getSetting('keyboardShortcuts')) as Record<string, string>) ?? {}
+  }
+
+  // Eager, lifetime-scoped subscriptions. Pinia instantiates the store exactly
+  // once on first useSettingsStore() call, so this runs once for the app. The
+  // returned disposers are discarded — the listeners die with the renderer.
+  void window.api.onFfmpegDownloadProgress((data) => {
+    if (data.status === 'downloading') {
+      ffmpegDownloading.value = true
+      ffmpegProgress.value = data.progress ?? 0
+    } else {
+      ffmpegDownloading.value = false
+    }
+  })
+  void window.api.onFpcalcDownloadProgress((data) => {
+    if (data.status === 'downloading') {
+      fpcalcDownloading.value = true
+      fpcalcProgress.value = data.progress ?? 0
+    } else {
+      fpcalcDownloading.value = false
+    }
+  })
+  void window.api.onUpdateStatus((data) => {
+    updateStatus.value = data as UiUpdateStatus
+  })
+
+  return {
+    shortcuts,
+    ffmpegDownloading,
+    ffmpegProgress,
+    fpcalcDownloading,
+    fpcalcProgress,
+    updateStatus,
+    loadShortcuts
+  }
+})

--- a/test/renderer/player-store.test.ts
+++ b/test/renderer/player-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { usePlayerStore, type PlayerPayload } from '../../src/renderer/src/stores/player'
+
+function payload(overrides: Partial<PlayerPayload> = {}): PlayerPayload {
+  return {
+    filePath: '',
+    streamUrl: 'https://example/test.mp4',
+    subtitleContent: '',
+    animeName: 'Test',
+    episodeLabel: '1',
+    availableStreams: [{ height: 720, url: 'https://example/test.mp4' }],
+    translationId: 1,
+    translations: [{ id: 1, label: 'Sub', type: 'subRu', height: 720 }],
+    downloadedTrIds: [],
+    allEpisodes: [],
+    episodeIndex: 0,
+    animeId: 100,
+    malId: 200,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('usePlayerStore', () => {
+  it('opens and closes the player overlay', () => {
+    const store = usePlayerStore()
+    expect(store.playerState).toBeNull()
+    store.openPlayer(payload())
+    expect(store.playerState?.animeId).toBe(100)
+    store.closePlayer()
+    expect(store.playerState).toBeNull()
+  })
+
+  it('persists per-anime translation/author prefs', () => {
+    const store = usePlayerStore()
+    store.saveAnimePrefs(42, 'subEn', 'Anidub')
+    store.saveAnimePrefs(7, 'voiceRu', 'AniLibria')
+    expect(store.animePrefs[42]).toEqual({ translationType: 'subEn', author: 'Anidub' })
+    expect(store.animePrefs[7]).toEqual({ translationType: 'voiceRu', author: 'AniLibria' })
+  })
+
+  it('overwrites prior prefs for the same anime', () => {
+    const store = usePlayerStore()
+    store.saveAnimePrefs(1, 'subRu', 'A')
+    store.saveAnimePrefs(1, 'voiceEn', 'B')
+    expect(store.animePrefs[1]).toEqual({ translationType: 'voiceEn', author: 'B' })
+  })
+
+  it('reopens with a fresh payload', () => {
+    const store = usePlayerStore()
+    store.openPlayer(payload({ animeId: 1 }))
+    store.openPlayer(payload({ animeId: 2 }))
+    expect(store.playerState?.animeId).toBe(2)
+  })
+})


### PR DESCRIPTION
> Stacked on slice 4b (#114). Base = \`phase4-slice-4b-pinia-library-store\`. Retarget to \`main\` (or to the next surviving slice base) when #112/#114 land.

## Summary

Extract the player overlay state, per-anime translation/author prefs, keyboard shortcuts, ffmpeg/fpcalc progress, and the auto-update status broadcast out of \`App.vue\` into two new Pinia stores. App.vue keeps shrinking toward routing-only.

## Changes

**New stores:**

- \`src/renderer/src/stores/player.ts\` (\`usePlayerStore\`):
  - State: \`playerState\` (\`PlayerPayload | null\`), \`animePrefs\` (per-anime translation/author cache).
  - Actions: \`openPlayer(payload)\`, \`closePlayer()\`, \`saveAnimePrefs(animeId, type, author)\`.
  - Exports the \`PlayerPayload\` type so AnimeDetailView and the test hook can construct one as a single object instead of 14 positional args.

- \`src/renderer/src/stores/settings.ts\` (\`useSettingsStore\`):
  - State: \`shortcuts\`, \`ffmpegDownloading\`/\`ffmpegProgress\`, \`fpcalcDownloading\`/\`fpcalcProgress\`, \`updateStatus\`.
  - Action: \`loadShortcuts()\`.
  - Owns three lifetime-scoped IPC subscriptions on first store use: \`onFfmpegDownloadProgress\`, \`onFpcalcDownloadProgress\`, \`onUpdateStatus\`. Pinia store is a singleton so disposers are intentionally discarded — the listeners die with the renderer.

**\`App.vue\`:**
- Drops \`playerState\` ref + \`openPlayer\`/\`closePlayer\` (incl. 14-arg positional player-state assembly).
- Drops \`animePrefs\` ref + \`saveAnimePrefs\` fn.
- Drops \`shortcuts\` ref + \`loadShortcuts\` fn.
- Drops \`ffmpegDownloading\`/\`ffmpegProgress\` refs + the \`onFfmpegDownloadProgress\` subscription/disposer.
- Reads all five values via \`storeToRefs(playerStore)\` / \`storeToRefs(settingsStore)\`.
- \`watch(currentView, …)\` now calls \`settingsStore.loadShortcuts()\` when leaving the Settings tab.
- Template drops \`@prefs-changed\` and \`@play-file\` bindings on AnimeDetailView; \`@close\` on PlayerView calls \`playerStore.closePlayer\` directly.
- Playwright test hook (\`__openTestPlayer\`) now takes a typed PlayerPayload.

**\`AnimeDetailView.vue\`:**
- Drops \`prefsChanged\` + \`playFile\` emit declarations entirely.
- Two \`emit('playFile', ...)\` call sites (\`openFile\` / \`playStream\`) replaced with \`playerStore.openPlayer({...})\` — positional → object payload.
- \`emit('prefsChanged', ...)\` → \`playerStore.saveAnimePrefs(...)\`.

**\`SettingsView.vue\`:**
- Drops the local \`updateStatus\` ref + the \`onUpdateStatus\` handler + the \`onUpdateStatus\` subscription/disposer.
- Imports \`settingsStore\` and uses \`storeToRefs\` to keep both template reads and setter mutations (the \`checkForUpdates\` / \`downloadUpdate\` error paths) working through the store ref.

**Tests:**
- New \`test/renderer/player-store.test.ts\` (4 tests): open/close, prefs persistence, prefs overwrite, fresh-payload replacement.
- \`useSettingsStore\` left untested in this slice — its three eager IPC subscriptions need a global \`window.api\` stub set up before module import, which is more naturally handled by the Phase 7 dedicated coverage slice.

**Docs:**
- \`DESIGN.md\` "Navigation State" section grows a slice-4c addendum describing the two new stores.

## What's still in App.vue (slices 4d–4e)

- \`shikimoriLoggedIn\` boot probe — moves into \`useShikimoriStore\` in slice 4d.
- Cleanup toast UI + \`handleCleanupPrompt\` subscription — stays as global UI.
- ffmpeg-overlay/cleanup-modal template fragments — stay as global UI surfaces in App.vue's template.
- Final App.vue shrink to routing+layout-only + CI grep gate — slice 4e.

## Behavior

No user-visible change. Player open/close, per-anime translation memory, keyboard shortcuts, ffmpeg first-run overlay, and the Settings auto-update banner all behave identically; their state just lives in Pinia now.

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — 0 errors, 8 pre-existing warnings unchanged
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — 111/111 (incl. 4 new player-store tests, 7 library-store from 4b, 3 contract tests from 4a)
- [x] \`npm run build\` — green
- [ ] Manual: open AnimeDetailView → built-in player on a local MKV; close, reopen; switch translation type — prefs should persist on re-mount; trigger ffmpeg first-run overlay (delete cached ffmpeg via Settings); Settings auto-update banner visible after onUpdateStatus broadcast

## Out of scope (later slices of #111)

- Slice 4d: \`useShikimoriStore\` + \`useDownloadsStore\` (broadcast-owning stores for Shikimori rate/refresh/sync-status + download/scan-merge progress aggregations).
- Slice 4e: App.vue final shrink + CI grep gate forbidding \`window.api.off\` / \`removeAllListeners\`.

Part of #111. Epic: #84. Stacked on #114.