### PR TITLE
refactor: Phase 4 slice 4d — shikimori + downloads stores (#111)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -148,6 +148,30 @@ Slice 4c adds two more stores:
                      (onFfmpegDownloadProgress, onFpcalcDownloadProgress,
                      onUpdateStatus) — Pinia singleton, never disposed.
                      Action: loadShortcuts.
+
+Slice 4d adds the last two stores:
+  useShikimoriStore — user, loggedIn (computed), rates list,
+                      animeDetails cache, syncStatus, offlineQueueLength.
+                      Owns 5 lifetime-scoped IPC subscriptions:
+                      onShikimoriRateUpdated (upserts into `rates`),
+                      onShikimoriRatesRefreshed (replaces `rates`),
+                      onShikimoriAnimeDetailsUpdated (upserts into
+                      `animeDetails`), onShikimoriOfflineQueueChanged,
+                      onShikimoriSyncStatus. Actions: refreshUser,
+                      refreshRates, refreshSyncStatus,
+                      refreshOfflineQueueLength, triggerSync. App.vue's
+                      ad-hoc shikimoriGetUser probe + ShikimoriView's,
+                      HomeView's, and AnimeDetailView's per-component
+                      subscriptions are gone — consumers read the store
+                      and (where they need side effects on rate changes)
+                      watch its reactive state.
+  useDownloadsStore — groups (current download queue snapshot),
+                      scanMergeProgress, fixMetadataProgress. Owns
+                      onDownloadProgress, onScanMergeProgress,
+                      onFixMetadataProgress. Action: refreshQueue.
+                      DownloadsView reads from store; AnimeDetailView
+                      watches groups; SettingsView reads
+                      scan/fix progress for its banners.
 ```
 
 ### Episode Loading & Translation Selection

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia';
 import { useLibraryStore } from './stores/library';
 import { usePlayerStore } from './stores/player';
 import { useSettingsStore } from './stores/settings';
+import { useShikimoriStore } from './stores/shikimori';
 import Sidebar from './components/Sidebar.vue';
 import SearchView from './components/SearchView.vue';
 import LibraryView from './components/LibraryView.vue';
@@ -21,13 +22,13 @@ import { formatBytes } from './utils';
 const libraryStore = useLibraryStore();
 const playerStore = usePlayerStore();
 const settingsStore = useSettingsStore();
+const shikimoriStore = useShikimoriStore();
 const { currentView, activeAnimeId, activeFocusEpisodeInt } = storeToRefs(libraryStore);
 const { playerState, animePrefs } = storeToRefs(playerStore);
 const { shortcuts, ffmpegDownloading, ffmpegProgress } = storeToRefs(settingsStore);
+const { loggedIn: shikimoriLoggedIn } = storeToRefs(shikimoriStore);
 
 const searchViewRef = ref<InstanceType<typeof SearchView> | null>(null);
-
-const shikimoriLoggedIn = ref(false);
 
 // Reload shortcuts when leaving the settings view in case the user rebound any.
 watch(currentView, (next, prev) => {
@@ -167,8 +168,7 @@ let unsubCleanupPrompt: Unsubscribe | null = null;
 
 onMounted(async () => {
   await settingsStore.loadShortcuts();
-  const shikiUser = await window.api.shikimoriGetUser();
-  shikimoriLoggedIn.value = !!shikiUser;
+  await shikimoriStore.refreshUser();
   window.addEventListener('keydown', handleKeydown);
   unsubCleanupPrompt = window.api.onCleanupPrompt(handleCleanupPrompt);
   // Expose test hook for Playwright screenshot script

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -10,6 +10,9 @@ import {
 import CleanupModal from './CleanupModal.vue';
 import { useLibraryStore } from '../stores/library';
 import { usePlayerStore } from '../stores/player';
+import { useShikimoriStore } from '../stores/shikimori';
+import { useDownloadsStore } from '../stores/downloads';
+import { storeToRefs } from 'pinia';
 
 const props = defineProps<{
   animeId: number;
@@ -19,6 +22,9 @@ const props = defineProps<{
 
 const libraryStore = useLibraryStore();
 const playerStore = usePlayerStore();
+const shikimoriStore = useShikimoriStore();
+const downloadsStore = useDownloadsStore();
+const { syncStatus, offlineQueueLength } = storeToRefs(shikimoriStore);
 
 const anime = ref<AnimeDetail | null>(null);
 const episodes = ref<Map<number, EpisodeDetail>>(new Map());
@@ -33,13 +39,7 @@ const isOffline = computed(() => dataSource.value === 'cache');
 let loadGeneration = 0;
 let disposed = false;
 
-let unsubDownloadProgress: Unsubscribe | null = null;
 let unsubFileEpisodesChanged: Unsubscribe | null = null;
-let unsubShikimoriRateUpdated: Unsubscribe | null = null;
-let unsubShikimoriRatesRefreshed: Unsubscribe | null = null;
-let unsubShikimoriAnimeDetailsUpdated: Unsubscribe | null = null;
-let unsubShikimoriOfflineQueueChanged: Unsubscribe | null = null;
-let unsubShikimoriSyncStatus: Unsubscribe | null = null;
 let unsubSkipDetectorProgress: Unsubscribe | null = null;
 let unsubSkipDetectorSignatureUpdated: Unsubscribe | null = null;
 let unsubChapterInjectProgress: Unsubscribe | null = null;
@@ -63,9 +63,9 @@ const shikiRewatches = ref(0);
 const shikiLoading = ref(false);
 const shikiSaving = ref(false);
 const shikiError = ref('');
-const offlineQueueLength = ref(0);
-const syncState = ref<'idle' | 'syncing'>('idle');
-const lastSyncError = ref<string | null>(null);
+// syncState + lastSyncError are projections of `shikimoriStore.syncStatus`.
+const syncState = computed(() => syncStatus.value.state);
+const lastSyncError = computed(() => syncStatus.value.lastSyncError);
 
 // Friends state
 const friendsRates = ref<ShikiFriendRate[]>([]);
@@ -670,12 +670,12 @@ onMounted(async () => {
     if (!disposed && gen === loadGeneration) loading.value = false;
   }
 
-  // Subscribe to download progress
-  const queue = await window.api.downloadGetQueue();
-  updateDownloadGroups(queue);
-  unsubDownloadProgress = window.api.onDownloadProgress(updateDownloadGroups);
+  // Render the queue snapshot the store already holds, then watch for any
+  // future updates — the store owns the onDownloadProgress subscription.
+  updateDownloadGroups(downloadsStore.groups);
 
-  // Subscribe to background file rescan updates
+  // Subscribe to background file rescan updates (component-local — keyed off
+  // the currently displayed anime name).
   unsubFileEpisodesChanged = window.api.onFileEpisodesChanged((animeName, data) => {
     if (anime.value && animeName === getAnimeName()) {
       const episodeInts = filteredEpisodes.value.map((ep) => ep.episodeInt);
@@ -701,63 +701,13 @@ onMounted(async () => {
   loadWatchProgress();
   window.addEventListener('watch-progress-updated', loadWatchProgress);
 
-  unsubShikimoriRateUpdated = window.api.onShikimoriRateUpdated((entry) => {
-    if (anime.value?.myAnimeListId && entry.rate.target_id === anime.value.myAnimeListId) {
-      shikiRate.value = {
-        id: entry.rate.id,
-        score: entry.rate.score,
-        status: entry.rate.status,
-        episodes: entry.rate.episodes,
-        rewatches: entry.rate.rewatches ?? 0,
-        target_id: entry.rate.target_id,
-        target_type: 'Anime'
-      };
-      shikiStatus.value = entry.rate.status;
-      shikiEpisodes.value = entry.rate.episodes;
-      shikiScore.value = entry.rate.score;
-      shikiRewatches.value = entry.rate.rewatches ?? 0;
-    }
-  });
+  // Hydrate the store-owned sync-status + offline-queue length on mount; later
+  // updates arrive via the store's broadcasts.
+  void shikimoriStore.refreshOfflineQueueLength();
+  void shikimoriStore.refreshSyncStatus();
 
-  unsubShikimoriAnimeDetailsUpdated = window.api.onShikimoriAnimeDetailsUpdated(
-    ({ malId, details }) => {
-      if (anime.value?.myAnimeListId === malId) {
-        shikiDetails.value = details;
-      }
-    }
-  );
-
-  unsubShikimoriRatesRefreshed = window.api.onShikimoriRatesRefreshed((entries) => {
-    if (!anime.value?.myAnimeListId) return;
-    const match = entries.find((e) => e.rate.target_id === anime.value!.myAnimeListId);
-    if (match) {
-      shikiRate.value = {
-        id: match.rate.id,
-        score: match.rate.score,
-        status: match.rate.status,
-        episodes: match.rate.episodes,
-        rewatches: match.rate.rewatches ?? 0,
-        target_id: match.rate.target_id,
-        target_type: 'Anime'
-      };
-      shikiStatus.value = match.rate.status;
-      shikiEpisodes.value = match.rate.episodes;
-      shikiScore.value = match.rate.score;
-      shikiRewatches.value = match.rate.rewatches ?? 0;
-    }
-  });
-
-  window.api.shikimoriGetOfflineQueueLength().then((n) => {
-    offlineQueueLength.value = n;
-  });
-  unsubShikimoriOfflineQueueChanged = window.api.onShikimoriOfflineQueueChanged((data) => {
-    offlineQueueLength.value = data.length;
-  });
-  window.api.shikimoriGetSyncStatus().then((s) => {
-    syncState.value = s.state;
-    offlineQueueLength.value = s.queueLength;
-    lastSyncError.value = s.lastSyncError;
-  });
+  // Skip-detector + chapter-inject progress are anime-specific, so they stay
+  // as component-local subscriptions (filtered by props.animeId).
   unsubSkipDetectorProgress = window.api.onSkipDetectorProgress((data) => {
     if (data.animeId !== props.animeId) return;
     skipProgress.value = data;
@@ -774,33 +724,61 @@ onMounted(async () => {
   });
   loadSkipDetections();
   hydrateSkipStatus();
-
-  unsubShikimoriSyncStatus = window.api.onShikimoriSyncStatus((data) => {
-    syncState.value = data.state;
-    offlineQueueLength.value = data.queueLength;
-    lastSyncError.value = data.lastSyncError;
-  });
 });
+
+// Sync the editable shiki* refs whenever the store's rate cache for this
+// anime's malId changes (broadcast-driven by the store).
+watch(
+  () => (anime.value?.myAnimeListId ? shikimoriStore.rateByMalId(anime.value.myAnimeListId) : null),
+  (entry) => {
+    if (!entry) return;
+    shikiRate.value = {
+      id: entry.rate.id,
+      score: entry.rate.score,
+      status: entry.rate.status,
+      episodes: entry.rate.episodes,
+      rewatches: entry.rate.rewatches ?? 0,
+      target_id: entry.rate.target_id,
+      target_type: 'Anime'
+    };
+    shikiStatus.value = entry.rate.status;
+    shikiEpisodes.value = entry.rate.episodes;
+    shikiScore.value = entry.rate.score;
+    shikiRewatches.value = entry.rate.rewatches ?? 0;
+  }
+);
+
+// Sync shikiDetails from the store's per-malId cache.
+watch(
+  () =>
+    anime.value?.myAnimeListId
+      ? shikimoriStore.animeDetailsByMalId(anime.value.myAnimeListId)
+      : null,
+  (details) => {
+    if (details) shikiDetails.value = details;
+  }
+);
+
+// Mirror store-owned download progress into the local episode-row projection.
+watch(
+  () => downloadsStore.groups,
+  (groups) => updateDownloadGroups(groups),
+  { deep: false }
+);
 
 onUnmounted(() => {
   disposed = true;
   loadGeneration++;
   window.removeEventListener('mouseup', onMouseBack);
   window.removeEventListener('watch-progress-updated', loadWatchProgress);
-  unsubDownloadProgress?.();
   unsubFileEpisodesChanged?.();
-  unsubShikimoriRateUpdated?.();
-  unsubShikimoriRatesRefreshed?.();
-  unsubShikimoriAnimeDetailsUpdated?.();
-  unsubShikimoriOfflineQueueChanged?.();
-  unsubShikimoriSyncStatus?.();
   unsubSkipDetectorProgress?.();
   unsubSkipDetectorSignatureUpdated?.();
   unsubChapterInjectProgress?.();
 });
 
 async function triggerSyncNow(): Promise<void> {
-  await window.api.shikimoriTriggerSync();
+  await shikimoriStore.triggerSync();
 }
 
 const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [

--- a/src/renderer/src/components/DownloadsView.vue
+++ b/src/renderer/src/components/DownloadsView.vue
@@ -1,22 +1,14 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { ref, onMounted, computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useDownloadsStore } from '../stores/downloads';
 import { formatBytes, formatSpeed, formatEta } from '../utils';
 
-const groups = ref<EpisodeGroup[]>([]);
+const downloadsStore = useDownloadsStore();
+const { groups } = storeToRefs(downloadsStore);
 
-function onProgress(data: EpisodeGroup[]): void {
-  groups.value = data;
-}
-
-let unsubProgress: Unsubscribe | null = null;
-
-onMounted(async () => {
-  groups.value = await window.api.downloadGetQueue();
-  unsubProgress = window.api.onDownloadProgress(onProgress);
-});
-
-onUnmounted(() => {
-  unsubProgress?.();
+onMounted(() => {
+  void downloadsStore.refreshQueue();
 });
 
 function progress(item: DownloadProgressItem): number {

--- a/src/renderer/src/components/HomeView.vue
+++ b/src/renderer/src/components/HomeView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue';
+import { ref, onMounted, onUnmounted, watch } from 'vue';
 import { useLibraryStore } from '../stores/library';
+import { useShikimoriStore } from '../stores/shikimori';
 
 const libraryStore = useLibraryStore();
+const shikimoriStore = useShikimoriStore();
 
 const entries = ref<ContinueWatchingEntry[]>([]);
 const loading = ref(true);
@@ -78,14 +80,17 @@ function onClick(entry: ContinueWatchingEntry): void {
   libraryStore.openAnime(entry.animeId, entry.episodeInt);
 }
 
-let unsubShikiRatesRefreshed: Unsubscribe | null = null;
-let unsubShikiRateUpdated: Unsubscribe | null = null;
+// Rate changes from the Shikimori store (broadcast-driven) re-fetch the
+// continue-watching list since it merges main-process Shikimori state.
+watch(
+  () => shikimoriStore.rates,
+  () => void refresh(),
+  { deep: true }
+);
 
 onMounted(async () => {
   await refresh();
   window.addEventListener('watch-progress-updated', debouncedRefresh);
-  unsubShikiRatesRefreshed = window.api.onShikimoriRatesRefreshed(refresh);
-  unsubShikiRateUpdated = window.api.onShikimoriRateUpdated(refresh);
 });
 
 onUnmounted(() => {
@@ -94,8 +99,6 @@ onUnmounted(() => {
     refreshTimer = null;
   }
   window.removeEventListener('watch-progress-updated', debouncedRefresh);
-  unsubShikiRatesRefreshed?.();
-  unsubShikiRateUpdated?.();
 });
 </script>
 

--- a/src/renderer/src/components/SettingsView.vue
+++ b/src/renderer/src/components/SettingsView.vue
@@ -2,10 +2,14 @@
 import { ref, watch, onMounted, onUnmounted, computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useSettingsStore } from '../stores/settings';
+import { useDownloadsStore } from '../stores/downloads';
 import { formatBytes } from '../utils';
 
 const settingsStore = useSettingsStore();
+const downloadsStore = useDownloadsStore();
 const { updateStatus } = storeToRefs(settingsStore);
+const { scanMergeProgress: scanProgress, fixMetadataProgress: fixProgress } =
+  storeToRefs(downloadsStore);
 
 const activeTab = ref<
   | 'general'
@@ -76,8 +80,6 @@ const skipQueueStatus = ref<{ currentAnimeId: number | null; queueLength: number
 });
 let skipQueuePollTimer: ReturnType<typeof setInterval> | null = null;
 
-let unsubScanMerge: Unsubscribe | null = null;
-let unsubFixMetadata: Unsubscribe | null = null;
 let unsubMoveToCold: Unsubscribe | null = null;
 let unsubUsageProgress: Unsubscribe | null = null;
 let unsubCleanupPending: Unsubscribe | null = null;
@@ -164,16 +166,12 @@ const hevcMseSupported = (() => {
 
 const backgroundQualityProbe = ref(false);
 
-// Debug / scan-merge state
+// Debug / scan-merge state (scanProgress mirrored from downloadsStore above)
 const scanMerging = ref(false);
-const scanProgress = ref<{ current: number; total: number; file: string; percent: number } | null>(
-  null
-);
 const scanResult = ref<{ merged: number; failed: string[] } | null>(null);
 
-// Fix metadata state
+// Fix metadata state (fixProgress mirrored from downloadsStore above)
 const fixingMetadata = ref(false);
-const fixProgress = ref<{ current: number; total: number; file: string } | null>(null);
 const fixResult = ref<{ fixed: number; failed: string[] } | null>(null);
 
 // Quality mismatch dump
@@ -313,10 +311,6 @@ function saveShortcuts(): void {
   showSaved();
 }
 
-function onScanProgress(data: ScanMergeProgress): void {
-  scanProgress.value = data;
-}
-
 async function scanAndMerge(): Promise<void> {
   scanMerging.value = true;
   scanProgress.value = null;
@@ -330,10 +324,6 @@ async function scanAndMerge(): Promise<void> {
     scanMerging.value = false;
     scanProgress.value = null;
   }
-}
-
-function onFixProgress(data: { current: number; total: number; file: string }): void {
-  fixProgress.value = data;
 }
 
 async function refreshMismatchCount(): Promise<void> {
@@ -655,8 +645,6 @@ function formatRelativeTime(ts: number): string {
 }
 
 onMounted(async () => {
-  unsubScanMerge = window.api.onScanMergeProgress(onScanProgress);
-  unsubFixMetadata = window.api.onFixMetadataProgress(onFixProgress);
   unsubMoveToCold = window.api.onStorageMoveToColdProgress(onMoveProgress);
   unsubUsageProgress = window.api.onStorageUsageProgress(onUsageProgress);
   unsubCleanupPending = window.api.onStorageCleanupPending(onCleanupPending);
@@ -677,8 +665,6 @@ watch(activeTab, (tab) => {
 });
 
 onUnmounted(() => {
-  unsubScanMerge?.();
-  unsubFixMetadata?.();
   unsubMoveToCold?.();
   unsubUsageProgress?.();
   unsubCleanupPending?.();

--- a/src/renderer/src/components/ShikimoriView.vue
+++ b/src/renderer/src/components/ShikimoriView.vue
@@ -61,8 +61,9 @@ async function refreshStarredFromEntries(list: ShikiAnimeRateEntry[]): Promise<v
 }
 
 async function loadRates(): Promise<void> {
-  if (!shikimoriStore.loggedIn && !(await shikimoriStore.refreshUser(), shikimoriStore.loggedIn)) {
-    return;
+  if (!shikimoriStore.loggedIn) {
+    await shikimoriStore.refreshUser();
+    if (!shikimoriStore.loggedIn) return;
   }
   loading.value = true;
   error.value = '';

--- a/src/renderer/src/components/ShikimoriView.vue
+++ b/src/renderer/src/components/ShikimoriView.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
+import { storeToRefs } from 'pinia';
 import AnimeCard from './AnimeCard.vue';
 import { useLibraryStore } from '../stores/library';
+import { useShikimoriStore } from '../stores/shikimori';
 
 const libraryStore = useLibraryStore();
+const shikimoriStore = useShikimoriStore();
+const { rates: entries } = storeToRefs(shikimoriStore);
 
-const entries = ref<ShikiAnimeRateEntry[]>([]);
 const loading = ref(false);
 const error = ref('');
 const statusFilter = ref<string>('to_watch');
@@ -46,22 +49,26 @@ const statusCounts = computed(() => {
   return counts;
 });
 
+async function refreshStarredFromEntries(list: ShikiAnimeRateEntry[]): Promise<void> {
+  const ids = list.filter((e) => e.smotretAnime).map((e) => e.smotretAnime!.id);
+  if (ids.length === 0) return;
+  const statuses = await window.api.libraryGetStatus(ids);
+  const starred = new Set<number>();
+  for (const [id, s] of Object.entries(statuses)) {
+    if (s.starred) starred.add(Number(id));
+  }
+  starredIds.value = starred;
+}
+
 async function loadRates(): Promise<void> {
-  const user = await window.api.shikimoriGetUser();
-  if (!user) return;
+  if (!shikimoriStore.loggedIn && !(await shikimoriStore.refreshUser(), shikimoriStore.loggedIn)) {
+    return;
+  }
   loading.value = true;
   error.value = '';
   try {
-    entries.value = await window.api.shikimoriGetAnimeRates();
-    const ids = entries.value.filter((e) => e.smotretAnime).map((e) => e.smotretAnime!.id);
-    if (ids.length > 0) {
-      const statuses = await window.api.libraryGetStatus(ids);
-      const starred = new Set<number>();
-      for (const [id, s] of Object.entries(statuses)) {
-        if (s.starred) starred.add(Number(id));
-      }
-      starredIds.value = starred;
-    }
+    await shikimoriStore.refreshRates();
+    await refreshStarredFromEntries(entries.value);
     if (entries.value.length > 0) refreshing.value = true;
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load anime list';
@@ -103,38 +110,19 @@ function shikiTitle(entry: ShikiAnimeRateEntry): string {
   return entry.shikiAnime.russian || entry.shikiAnime.name;
 }
 
-let unsubRateUpdated: Unsubscribe | null = null;
-let unsubRatesRefreshed: Unsubscribe | null = null;
+// When the store-owned rates broadcast updates, refresh the local
+// starred-anime overlay (re-check libraryGetStatus for newly-added entries).
+watch(
+  () => entries.value,
+  (newEntries) => {
+    refreshing.value = false;
+    void refreshStarredFromEntries(newEntries);
+  },
+  { deep: false }
+);
 
 onMounted(() => {
   loadRates();
-
-  unsubRateUpdated = window.api.onShikimoriRateUpdated((entry) => {
-    const idx = entries.value.findIndex((e) => e.rate.target_id === entry.rate.target_id);
-    if (idx !== -1) {
-      entries.value[idx] = entry;
-      entries.value = [...entries.value];
-    }
-  });
-
-  unsubRatesRefreshed = window.api.onShikimoriRatesRefreshed(async (newEntries) => {
-    entries.value = newEntries;
-    refreshing.value = false;
-    const ids = newEntries.filter((e) => e.smotretAnime).map((e) => e.smotretAnime!.id);
-    if (ids.length > 0) {
-      const statuses = await window.api.libraryGetStatus(ids);
-      const starred = new Set<number>();
-      for (const [id, s] of Object.entries(statuses)) {
-        if (s.starred) starred.add(Number(id));
-      }
-      starredIds.value = starred;
-    }
-  });
-});
-
-onUnmounted(() => {
-  unsubRateUpdated?.();
-  unsubRatesRefreshed?.();
 });
 </script>
 

--- a/src/renderer/src/stores/downloads.ts
+++ b/src/renderer/src/stores/downloads.ts
@@ -1,0 +1,50 @@
+// Downloads store (Phase 4 slice 4d, #111).
+//
+// Owns the per-episode download queue + scan-merge + fix-metadata broadcast
+// projections that DownloadsView, AnimeDetailView, and SettingsView used to
+// each subscribe to independently. Components now read from the store; only
+// the consumer that triggered an action calls `refreshQueue()` if it needs an
+// immediate non-broadcast read.
+//
+// Three broadcasts move into the store:
+//   onDownloadProgress     — replaces `groups` (full queue snapshot)
+//   onScanMergeProgress    — sets `scanMergeProgress`
+//   onFixMetadataProgress  — sets `fixMetadataProgress`
+//
+// Lifetime-scoped subscriptions (Pinia singleton). Disposers discarded.
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type FixMetadataProgress = {
+  current: number
+  total: number
+  file: string
+}
+
+export const useDownloadsStore = defineStore('downloads', () => {
+  const groups = ref<EpisodeGroup[]>([])
+  const scanMergeProgress = ref<ScanMergeProgress | null>(null)
+  const fixMetadataProgress = ref<FixMetadataProgress | null>(null)
+
+  async function refreshQueue(): Promise<void> {
+    groups.value = await window.api.downloadGetQueue()
+  }
+
+  void window.api.onDownloadProgress((data) => {
+    groups.value = data
+  })
+  void window.api.onScanMergeProgress((data) => {
+    scanMergeProgress.value = data
+  })
+  void window.api.onFixMetadataProgress((data) => {
+    fixMetadataProgress.value = data
+  })
+
+  return {
+    groups,
+    scanMergeProgress,
+    fixMetadataProgress,
+    refreshQueue
+  }
+})

--- a/src/renderer/src/stores/shikimori.ts
+++ b/src/renderer/src/stores/shikimori.ts
@@ -1,0 +1,115 @@
+// Shikimori store (Phase 4 slice 4d, #111).
+//
+// Centralizes the Shikimori-related cross-view state that App.vue and three
+// components used to mirror independently: login status, the rates list,
+// per-anime details cache, sync-state, and offline-queue length.
+//
+// Five broadcasts move from ad-hoc per-component subscriptions to the store:
+//   onShikimoriRateUpdated         — upserts an entry into `rates`
+//   onShikimoriRatesRefreshed      — replaces `rates` wholesale
+//   onShikimoriAnimeDetailsUpdated — upserts into `animeDetails`
+//   onShikimoriOfflineQueueChanged — updates `offlineQueueLength`
+//   onShikimoriSyncStatus          — replaces `syncStatus`
+//
+// Subscriptions are eager, lifetime-scoped (Pinia singleton). Disposers are
+// intentionally discarded — the listeners die with the renderer process.
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export type ShikimoriSyncStatusSnapshot = {
+  state: 'idle' | 'syncing'
+  queueLength: number
+  lastSyncAt: number
+  lastSyncError: string | null
+}
+
+const EMPTY_SYNC_STATUS: ShikimoriSyncStatusSnapshot = {
+  state: 'idle',
+  queueLength: 0,
+  lastSyncAt: 0,
+  lastSyncError: null
+}
+
+export const useShikimoriStore = defineStore('shikimori', () => {
+  const user = ref<ShikiUser | null>(null)
+  const rates = ref<ShikiAnimeRateEntry[]>([])
+  const animeDetails = ref<Record<number, ShikiAnimeDetails>>({})
+  const syncStatus = ref<ShikimoriSyncStatusSnapshot>({ ...EMPTY_SYNC_STATUS })
+  const offlineQueueLength = ref(0)
+
+  const loggedIn = computed(() => user.value !== null)
+
+  function rateByMalId(malId: number): ShikiAnimeRateEntry | null {
+    if (!malId) return null
+    return rates.value.find((r) => r.rate.target_id === malId) ?? null
+  }
+
+  function animeDetailsByMalId(malId: number): ShikiAnimeDetails | null {
+    if (!malId) return null
+    return animeDetails.value[malId] ?? null
+  }
+
+  async function refreshUser(): Promise<void> {
+    user.value = await window.api.shikimoriGetUser()
+  }
+
+  async function refreshRates(status?: string): Promise<void> {
+    rates.value = await window.api.shikimoriGetAnimeRates(status)
+  }
+
+  async function refreshSyncStatus(): Promise<void> {
+    const next = await window.api.shikimoriGetSyncStatus()
+    syncStatus.value = next
+    offlineQueueLength.value = next.queueLength
+  }
+
+  async function refreshOfflineQueueLength(): Promise<void> {
+    offlineQueueLength.value = await window.api.shikimoriGetOfflineQueueLength()
+  }
+
+  async function triggerSync(): Promise<void> {
+    await window.api.shikimoriTriggerSync()
+  }
+
+  // Eager subscriptions; live for the renderer's lifetime. See module header.
+  void window.api.onShikimoriRateUpdated((entry) => {
+    const idx = rates.value.findIndex((r) => r.rate.target_id === entry.rate.target_id)
+    if (idx >= 0) {
+      const next = rates.value.slice()
+      next[idx] = entry
+      rates.value = next
+    } else {
+      rates.value = [...rates.value, entry]
+    }
+  })
+  void window.api.onShikimoriRatesRefreshed((entries) => {
+    rates.value = entries
+  })
+  void window.api.onShikimoriAnimeDetailsUpdated(({ malId, details }) => {
+    animeDetails.value = { ...animeDetails.value, [malId]: details }
+  })
+  void window.api.onShikimoriOfflineQueueChanged((data) => {
+    offlineQueueLength.value = data.length
+  })
+  void window.api.onShikimoriSyncStatus((data) => {
+    syncStatus.value = data
+    offlineQueueLength.value = data.queueLength
+  })
+
+  return {
+    user,
+    rates,
+    animeDetails,
+    syncStatus,
+    offlineQueueLength,
+    loggedIn,
+    rateByMalId,
+    animeDetailsByMalId,
+    refreshUser,
+    refreshRates,
+    refreshSyncStatus,
+    refreshOfflineQueueLength,
+    triggerSync
+  }
+})


### PR DESCRIPTION
> Stacked on slice 4c (#115). Base = \`phase4-slice-4c-player-settings-stores\`. Retarget to \`main\` (or to the next surviving slice base) when #112/#114/#115 land.

## Summary

Centralize the last two cross-view broadcast surfaces — Shikimori rate/sync state and the download queue — into Pinia stores. Every per-component subscription on these channels is gone; consumers read store state or watch reactive projections. With this slice, the only IPC subscriptions remaining in the renderer are the ones that depend on a *specific currently-mounted anime / view* (`onFileEpisodesChanged`, `onSkipDetectorProgress`, `onSkipDetectorSignatureUpdated`, `onChapterInjectProgress`, `onAutoDlTickResult`, `onStorageMoveToColdProgress`, `onStorageUsageProgress`, `onStorageCleanupPending`, `onStorageCleanupFinished`, `onCleanupPrompt`, `onSyncplay*`, `onPlayerStream*`). Everything global lives in a store.

## Changes

**New stores:**

- \`src/renderer/src/stores/shikimori.ts\` (\`useShikimoriStore\`):
  - State: \`user\` (+ \`loggedIn\` computed), \`rates\`, \`animeDetails\` (Record<malId, ShikiAnimeDetails>), \`syncStatus\`, \`offlineQueueLength\`.
  - Getters: \`rateByMalId(malId)\`, \`animeDetailsByMalId(malId)\`.
  - Actions: \`refreshUser\`, \`refreshRates\`, \`refreshSyncStatus\`, \`refreshOfflineQueueLength\`, \`triggerSync\`.
  - Owns 5 lifetime-scoped subscriptions: \`onShikimoriRateUpdated\` (upsert), \`onShikimoriRatesRefreshed\` (replace), \`onShikimoriAnimeDetailsUpdated\` (upsert into Map), \`onShikimoriOfflineQueueChanged\`, \`onShikimoriSyncStatus\`.

- \`src/renderer/src/stores/downloads.ts\` (\`useDownloadsStore\`):
  - State: \`groups\` (\`EpisodeGroup[]\`), \`scanMergeProgress\`, \`fixMetadataProgress\`.
  - Action: \`refreshQueue()\`.
  - Owns 3 lifetime-scoped subscriptions: \`onDownloadProgress\`, \`onScanMergeProgress\`, \`onFixMetadataProgress\`.

**\`App.vue\`:**
- Drops local \`shikimoriLoggedIn\` ref + onMounted \`shikimoriGetUser\` probe; reads \`loggedIn\` from \`shikimoriStore\` and calls \`refreshUser()\` on mount.

**\`HomeView.vue\`:**
- Drops \`onShikimoriRateUpdated\` + \`onShikimoriRatesRefreshed\` component subscriptions.
- \`watch(shikimoriStore.rates, refresh)\` re-fetches continue-watching on any rate change (same trigger as before, store-driven).

**\`ShikimoriView.vue\`:**
- Local \`entries\` ref replaced with \`storeToRefs(shikimoriStore).rates\`.
- \`loadRates()\` now calls \`shikimoriStore.refreshRates()\`.
- Drops both Shikimori subscriptions. A \`watch(entries, …)\` keeps the starred-anime overlay (\`libraryGetStatus\`) in sync.

**\`AnimeDetailView.vue\`:**
- Drops 5 Shikimori subscriptions + the \`onDownloadProgress\` subscription. Component-local subscriptions kept where they're keyed to the current anime (\`onFileEpisodesChanged\`, skip-detector \`Progress\`/\`SignatureUpdated\`, \`onChapterInjectProgress\`).
- Local \`offlineQueueLength\` / \`syncState\` / \`lastSyncError\` refs replaced with \`storeToRefs(shikimoriStore).offlineQueueLength\` + computed projections over \`syncStatus\`.
- \`watch(() => shikimoriStore.rateByMalId(malId), …)\` syncs the editable \`shikiRate\`/\`shikiStatus\`/\`shikiEpisodes\`/\`shikiScore\`/\`shikiRewatches\` refs whenever the store sees a rate broadcast.
- \`watch(() => shikimoriStore.animeDetailsByMalId(malId), …)\` syncs \`shikiDetails\`.
- \`watch(downloadsStore.groups, updateDownloadGroups)\` keeps per-episode UI state current.
- \`onMounted\` seeds \`refreshOfflineQueueLength()\` + \`refreshSyncStatus()\`.
- \`triggerSyncNow()\` → \`shikimoriStore.triggerSync()\`.

**\`DownloadsView.vue\`:**
- Drops local \`groups\` ref + \`onDownloadProgress\` subscription; reads from \`downloadsStore\` (\`storeToRefs\`). \`refreshQueue()\` runs on mount.

**\`SettingsView.vue\`:**
- Drops local \`scanProgress\` + \`fixProgress\` refs and their two subscriptions; reads both from \`downloadsStore\` (\`storeToRefs\`). Existing setter writes (\`scanProgress.value = null\` etc.) now write through to the store.

**Docs:**
- \`DESIGN.md\` "Navigation State" grows a slice-4d addendum describing both stores.

## What's still in App.vue (slice 4e)

- The \`onCleanupPrompt\` subscription + cleanup-toast UI + \`handleCleanupPrompt\` flow stays in App.vue because it's a global toast.
- App.vue's remaining responsibilities: routing/layout + keyboard handler + cleanup toast UI + ffmpeg overlay UI + cleanup-modal UI.
- Final shrink to layout-only + CI grep gate forbidding \`window.api.off\` / \`removeAllListeners\` — slice 4e.

## Behavior

No user-visible change. Shikimori rate updates still propagate to HomeView (continue-watching refresh), ShikimoriView (entries list), and AnimeDetailView (inline shiki form). Sync-status banner, offline-queue chip, download queue progress, scan-merge / fix-metadata banners — all behave identically; their broadcast plumbing just lives in two singleton stores now.

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — 0 errors, 8 pre-existing warnings unchanged
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — 111/111 (existing suites all pass; no new store tests in this slice — Shikimori/downloads stores require global \`window.api\` mocks that are more naturally added in Phase 7's dedicated coverage slice, same reasoning that left \`useSettingsStore\` untested in 4c)
- [x] \`npm run build\` — green
- [ ] Manual: edit Shikimori rate inline on AnimeDetailView → HomeView "Continue Watching" refreshes; offline edit → queue chip + sync banner; open Downloads view while a download is in flight → progress updates; trigger Scan/Merge in Settings → progress banner; navigate views and check no double-broadcast issues

## Out of scope (slice 4e of #111)

- App.vue final shrink (routing/layout-only).
- CI grep gate forbidding \`window.api.off\` / \`removeAllListeners\` survival.

Part of #111. Epic: #84. Stacked on #115.