### PR TITLE
refactor: Phase 4 slice 4e — App.vue shrink + CI grep gate (#111)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -158,6 +158,8 @@ jobs:
 
       - run: npm run format:check
 
+      - run: npm run check:subscription-contract
+
       - run: npm run test
 
       # The Playwright smoke test drives the built app.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -374,9 +374,29 @@ LibraryView shows both with indicators:
 `EventSubscriber<T> = (listener) => Unsubscribe` (see `src/shared/ipc/channels.ts`).
 Each call registers a dedicated listener and returns a disposer that removes only
 that listener — never `ipcRenderer.removeAllListeners`, which would clobber every
-other subscriber on the channel. Renderer callers capture the returned `Unsubscribe`
-and invoke it in `onBeforeUnmount`/`onUnmounted` (or store disposal in Phase 4b+).
-There are no `off*` methods on `window.api`.
+other subscriber on the channel. There are no `off*` methods on `window.api`.
+
+**Ownership rule (Phase 4 slices 4b–4d):**
+
+| Subscription kind | Owner | Disposal |
+|---|---|---|
+| Cross-view (download/scan-merge/fix-metadata progress, Shikimori rate/refresh/sync/details/offline-queue, ffmpeg/fpcalc/update status) | Pinia store (`useDownloadsStore`, `useShikimoriStore`, `useSettingsStore`) | Lifetime-scoped — singleton, never disposed |
+| Anime-specific (file-episodes-changed, skip-detector progress/signature, chapter-inject progress, cleanup-prompt toast) | The consuming component | `onBeforeUnmount` / `onUnmounted` |
+| Player-instance (player-stream chunks/end/error/progress/subtitles, syncplay session) | `PlayerView.vue` | `onBeforeUnmount` |
+
+The CI step `npm run check:subscription-contract` greps `src/preload/` and
+`src/renderer/` for `removeAllListeners(` or `window.api.off*(` calls and fails
+the build if any survive (Phase 4 slice 4e).
+
+**Composables (Phase 4 slice 4e):**
+
+Global app glue that doesn't belong on a Pinia store goes into
+`src/renderer/src/composables/`. The first inhabitant is
+`useKeyboardShortcuts({ bindings, suppressWhen, onAction })`, which binds a
+window-level keydown listener against the settings store's resolved bindings
+and dispatches the small set of app-wide actions (`back` / `focusSearch` /
+`goDownloads`). App.vue invokes it once at setup; the composable owns the
+event-listener lifecycle.
 
 | Channel | Direction | Purpose |
 |---------|-----------|---------|

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "check:subscription-contract": "bash scripts/check-subscription-contract.sh",
     "screenshot": "node scripts/screenshot.js"
   },
   "build": {

--- a/scripts/check-subscription-contract.sh
+++ b/scripts/check-subscription-contract.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Phase 4 slice 4e (#111) — fail CI if any forbidden subscription pattern
+# survives in preload or renderer source. After slice 4a, every broadcast
+# subscription on `window.api` returns an `Unsubscribe` disposer; there are
+# no `off*` methods and no `ipcRenderer.removeAllListeners(…)` calls.
+#
+# Regex requires the open paren so the contract-doc comment in
+# `src/preload/subscribe.ts` (which mentions the names without calling them)
+# stays allowed.
+
+set -euo pipefail
+
+PATTERN='removeAllListeners\(|window\.api\.off[A-Z][A-Za-z0-9_]*\('
+
+# Use --include to be explicit about file types; --exclude-dir to skip build
+# outputs that grep would otherwise scan if invoked at the repo root.
+MATCHES="$(grep -rEn \
+  --include='*.ts' --include='*.vue' --include='*.tsx' --include='*.js' \
+  --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=out \
+  "$PATTERN" \
+  src/preload/ src/renderer/ \
+  || true)"
+
+if [ -n "$MATCHES" ]; then
+  echo "Subscription-contract violation — forbidden patterns survived:"
+  echo
+  echo "$MATCHES"
+  echo
+  echo "After #111 slice 4a, every broadcast subscription on \`window.api\`"
+  echo "returns an \`Unsubscribe\` disposer. \`removeAllListeners()\` and"
+  echo "\`window.api.off*()\` are not part of the contract. Capture the"
+  echo "returned disposer and call it in \`onBeforeUnmount\`/\`onUnmounted\`"
+  echo "(or in a Pinia store's setup, for lifetime-scoped subscriptions)."
+  exit 1
+fi

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -5,6 +5,7 @@ import { useLibraryStore } from './stores/library';
 import { usePlayerStore } from './stores/player';
 import { useSettingsStore } from './stores/settings';
 import { useShikimoriStore } from './stores/shikimori';
+import { useKeyboardShortcuts, type ShortcutAction } from './composables/keyboard-shortcuts';
 import Sidebar from './components/Sidebar.vue';
 import SearchView from './components/SearchView.vue';
 import LibraryView from './components/LibraryView.vue';
@@ -35,63 +36,25 @@ watch(currentView, (next, prev) => {
   if (prev === 'settings' && next !== 'settings') void settingsStore.loadShortcuts();
 });
 
-const isMac = navigator.platform.toUpperCase().includes('MAC');
-
-function matchesBinding(e: KeyboardEvent, binding: string): boolean {
-  const parts = binding.split('+');
-  const key = parts[parts.length - 1];
-  const mods = parts.slice(0, -1).map((m) => m.toLowerCase());
-
-  const needCtrl = mods.includes('ctrl');
-  const needMeta = mods.includes('meta');
-  const needCmdOrCtrl = mods.includes('cmdorctrl');
-  const needShift = mods.includes('shift');
-  const needAlt = mods.includes('alt');
-
-  const wantCtrl = needCtrl || (needCmdOrCtrl && !isMac);
-  const wantMeta = needMeta || (needCmdOrCtrl && isMac);
-
-  if (e.ctrlKey !== wantCtrl) return false;
-  if (e.metaKey !== wantMeta) return false;
-  if (e.shiftKey !== needShift) return false;
-  if (e.altKey !== needAlt) return false;
-
-  return e.key.toLowerCase() === key.toLowerCase();
-}
-
-function executeAction(action: string): void {
-  switch (action) {
-    case 'back':
-      if (activeAnimeId.value) libraryStore.closeAnime();
-      break;
-    case 'focusSearch':
-      libraryStore.navigate('search');
-      libraryStore.animeByView.search = null;
-      nextTick(() => searchViewRef.value?.focusInput());
-      break;
-    case 'goDownloads':
-      libraryStore.navigate('downloads');
-      break;
-  }
-}
-
-function handleKeydown(e: KeyboardEvent): void {
-  // Don't intercept shortcuts when the player overlay is active
-  if (playerState.value) return;
-
-  const tag = (e.target as HTMLElement).tagName;
-  const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-
-  for (const [action, binding] of Object.entries(shortcuts.value)) {
-    if (!binding) continue;
-    if (matchesBinding(e, binding)) {
-      if (action === 'back' && isInput) continue;
-      e.preventDefault();
-      executeAction(action);
-      return;
+useKeyboardShortcuts({
+  bindings: shortcuts,
+  suppressWhen: playerState,
+  onAction: (action: ShortcutAction) => {
+    switch (action) {
+      case 'back':
+        if (activeAnimeId.value) libraryStore.closeAnime();
+        break;
+      case 'focusSearch':
+        libraryStore.navigate('search');
+        libraryStore.animeByView.search = null;
+        nextTick(() => searchViewRef.value?.focusInput());
+        break;
+      case 'goDownloads':
+        libraryStore.navigate('downloads');
+        break;
     }
   }
-}
+});
 
 // Cleanup prompt (Shikimori "completed" transition)
 const cleanupToast = ref<{
@@ -169,7 +132,6 @@ let unsubCleanupPrompt: Unsubscribe | null = null;
 onMounted(async () => {
   await settingsStore.loadShortcuts();
   await shikimoriStore.refreshUser();
-  window.addEventListener('keydown', handleKeydown);
   unsubCleanupPrompt = window.api.onCleanupPrompt(handleCleanupPrompt);
   // Expose test hook for Playwright screenshot script
   (window as any).__openTestPlayer = (payload: Parameters<typeof playerStore.openPlayer>[0]) =>
@@ -177,7 +139,6 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  window.removeEventListener('keydown', handleKeydown);
   unsubCleanupPrompt?.();
   if (cleanupToastTimer) clearTimeout(cleanupToastTimer);
 });

--- a/src/renderer/src/composables/keyboard-shortcuts.ts
+++ b/src/renderer/src/composables/keyboard-shortcuts.ts
@@ -1,0 +1,73 @@
+// Global keyboard-shortcut composable (Phase 4 slice 4e, #111).
+//
+// Subscribes a window-level keydown listener that matches `settingsStore.shortcuts`
+// (resolved bindings from the user's preferences) and dispatches a small set of
+// app-wide actions: "back" (close the open AnimeDetailView), "focusSearch"
+// (navigate to search + focus its input), "goDownloads".
+//
+// Lives outside App.vue so the routing root can stay short. The caller passes
+// the actions object so the composable doesn't have to reach into stores
+// directly — keeping the composable independently testable.
+
+import { onBeforeUnmount, onMounted } from 'vue'
+import type { Ref } from 'vue'
+
+const isMac = navigator.platform.toUpperCase().includes('MAC')
+
+function matchesBinding(e: KeyboardEvent, binding: string): boolean {
+  const parts = binding.split('+')
+  const key = parts[parts.length - 1]
+  const mods = parts.slice(0, -1).map((m) => m.toLowerCase())
+
+  const needCtrl = mods.includes('ctrl')
+  const needMeta = mods.includes('meta')
+  const needCmdOrCtrl = mods.includes('cmdorctrl')
+  const needShift = mods.includes('shift')
+  const needAlt = mods.includes('alt')
+
+  const wantCtrl = needCtrl || (needCmdOrCtrl && !isMac)
+  const wantMeta = needMeta || (needCmdOrCtrl && isMac)
+
+  if (e.ctrlKey !== wantCtrl) return false
+  if (e.metaKey !== wantMeta) return false
+  if (e.shiftKey !== needShift) return false
+  if (e.altKey !== needAlt) return false
+
+  return e.key.toLowerCase() === key.toLowerCase()
+}
+
+export type ShortcutAction = 'back' | 'focusSearch' | 'goDownloads'
+
+export type ShortcutContext = {
+  /** Resolved binding map from settings (action name → "Ctrl+Shift+K" form). */
+  bindings: Ref<Record<string, string>>
+  /** When non-null, the keyboard handler is bypassed entirely (e.g. player overlay). */
+  suppressWhen: Ref<unknown>
+  /** Action dispatcher — `back` is suppressed inside <input>/<textarea>/<select>. */
+  onAction: (action: ShortcutAction) => void
+}
+
+export function useKeyboardShortcuts({ bindings, suppressWhen, onAction }: ShortcutContext): void {
+  function handleKeydown(e: KeyboardEvent): void {
+    if (suppressWhen.value) return
+
+    const tag = (e.target as HTMLElement).tagName
+    const isInput = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+
+    for (const [action, binding] of Object.entries(bindings.value)) {
+      if (!binding) continue
+      if (!matchesBinding(e, binding)) continue
+      if (action === 'back' && isInput) continue
+      e.preventDefault()
+      onAction(action as ShortcutAction)
+      return
+    }
+  }
+
+  onMounted(() => {
+    window.addEventListener('keydown', handleKeydown)
+  })
+  onBeforeUnmount(() => {
+    window.removeEventListener('keydown', handleKeydown)
+  })
+}


### PR DESCRIPTION
> Final slice of Phase 4. Stacked on slice 4d (#116). Base = \`phase4-slice-4d-shikimori-downloads-stores\`. Retarget to \`main\` (or the next surviving slice base) when the slice 4a–4d PRs land.

## Summary

Closes out Phase 4 of the structure-refactor epic (#84). Two complementary changes:

1. **App.vue shrink** — extracts the global keyboard-shortcut handler into a new composable (`src/renderer/src/composables/keyboard-shortcuts.ts`). App.vue's responsibilities collapse to routing, layout, store boot probes, the \`onCleanupPrompt\` subscription, the cleanup-toast UI, and the player-overlay test hook.
2. **CI grep gate** — locks the subscription contract into CI. \`scripts/check-subscription-contract.sh\` fails the build if any \`removeAllListeners(\` or \`window.api.off*(\` call survives in \`src/preload/\` or \`src/renderer/\`. So future code can't drift back to the pre-Phase-4 pattern.

## Changes

**Renderer (\`src/renderer/\`):**

- **New** \`src/renderer/src/composables/keyboard-shortcuts.ts\` exports \`useKeyboardShortcuts({ bindings, suppressWhen, onAction })\`:
  - \`bindings\` — \`Ref<Record<string, string>>\` from \`settingsStore.shortcuts\`.
  - \`suppressWhen\` — \`Ref<unknown>\`; non-null bypasses the handler (App.vue passes \`playerState\` so the player overlay swallows app shortcuts).
  - \`onAction\` — typed dispatcher for \`back\` / \`focusSearch\` / \`goDownloads\`.
  - Owns the \`window.addEventListener('keydown', …)\` + remove-listener lifecycle via \`onMounted\`/\`onBeforeUnmount\`.

- **\`App.vue\`:**
  - Drops \`matchesBinding\`, \`executeAction\`, \`handleKeydown\`, the local \`isMac\` constant, and the window keydown add/remove (~55 lines from the script section).
  - Invokes \`useKeyboardShortcuts(...)\` once at setup; passes action implementations that talk to \`libraryStore\` and \`searchViewRef\` directly.
  - Remaining responsibilities: routing/layout, store boot probes (\`loadShortcuts\` + \`refreshUser\`), \`onCleanupPrompt\` subscription + cleanup-toast UI, ffmpeg overlay UI, the Playwright test hook.

**CI:**

- **New** \`scripts/check-subscription-contract.sh\` greps \`src/preload/\` and \`src/renderer/\` for forbidden patterns. The regex requires an open paren so the contract-doc comment in \`src/preload/subscribe.ts\` (which mentions the names without calling them) stays allowed.

- **\`package.json\`:** adds \`"check:subscription-contract": "bash scripts/check-subscription-contract.sh"\`.

- **\`.github/workflows/check.yml\`:** runs the new script in the quality job between \`format:check\` and \`test\`.

**Docs:**

- \`DESIGN.md\` broadcast-subscription contract section grows two sub-sections:
  - **Ownership rule** table — cross-view subs live in Pinia stores (lifetime-scoped), anime-specific subs live in the consuming component, player-instance subs live in PlayerView.
  - **Composables** — documents \`useKeyboardShortcuts\` as the first inhabitant of \`composables/\`.

## What's done with Phase 4

After this slice, the renderer state-layer epic is complete:

| Slice | Landed | Description |
|---|---|---|
| 4a | #112 | Preload subscribe-returns-disposer; renderer call-site migration |
| 4b | #114 | Pinia + \`useLibraryStore\`; per-view navigation/anime stacks |
| 4c | #115 | \`usePlayerStore\` + \`useSettingsStore\` |
| 4d | #116 | \`useShikimoriStore\` + \`useDownloadsStore\` |
| 4e | _this PR_ | App.vue shrink + CI grep gate |

App.vue final script-section size: ~145 lines (was ~580 before Phase 4, ~180 after 4d). All cross-view broadcast subscriptions live in Pinia stores; component-local ones bind to lifecycle hooks; the CI gate prevents regression.

**Next executable**: Phase 5 (renderer component decomposition: \`SettingsView\` / \`AnimeDetailView\` / \`PlayerView\` + headless \`useMsePlayer\`).

## Behavior

No user-visible change. Keyboard shortcuts (back / focus search / go to downloads) behave identically; their handler just lives in a composable now. The cleanup toast, ffmpeg overlay, player overlay, and all six view mounts render unchanged.

## Test plan

- [x] \`npm run typecheck\` — green
- [x] \`npm run lint\` — 0 errors, 8 pre-existing warnings unchanged
- [x] \`npm run format:check\` — clean
- [x] \`npm run test\` — 111/111
- [x] \`npm run check:subscription-contract\` — clean (no forbidden patterns)
- [x] \`npm run build\` — green
- [ ] Manual: bound shortcuts still fire from any view; \`back\` still no-ops inside text inputs; opening the built-in player overlay suppresses app shortcuts; navigating between Home/Search/Library/etc. via the Sidebar works as before; cleanup toast still triggers on Shikimori "completed" transitions

Part of #111. Closes Phase 4 of #84. Stacked on #116.