### PR TITLE
refactor: Phase 5 slice 5b.1 — AnimeDetailView composable extraction (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -388,15 +388,39 @@ The CI step `npm run check:subscription-contract` greps `src/preload/` and
 `src/renderer/` for `removeAllListeners(` or `window.api.off*(` calls and fails
 the build if any survive (Phase 4 slice 4e).
 
-**Composables (Phase 4 slice 4e):**
+**Composables (Phase 4 slice 4e + Phase 5 slice 5b.1):**
 
 Global app glue that doesn't belong on a Pinia store goes into
-`src/renderer/src/composables/`. The first inhabitant is
-`useKeyboardShortcuts({ bindings, suppressWhen, onAction })`, which binds a
-window-level keydown listener against the settings store's resolved bindings
-and dispatches the small set of app-wide actions (`back` / `focusSearch` /
-`goDownloads`). App.vue invokes it once at setup; the composable owns the
-event-listener lifecycle.
+`src/renderer/src/composables/`.
+
+- `useKeyboardShortcuts({ bindings, suppressWhen, onAction })` — binds a
+  window-level keydown listener against the settings store's resolved bindings
+  and dispatches the small set of app-wide actions (`back` / `focusSearch` /
+  `goDownloads`). App.vue invokes it once at setup; the composable owns the
+  event-listener lifecycle. (Phase 4 slice 4e)
+- `useChronology()` — Shikimori chronology panel state (related list, loading,
+  collapsed) + `loadRelated(malId)` IPC action for the AnimeDetailView
+  chronology section. (Phase 5 slice 5b.1)
+- `useAnimeDetailPrefs()` — per-anime translation type + selected author refs
+  plus `applyDownloadedTranslationDefault(snapshot)` (picks the most-frequent
+  downloaded type+author combo) and `loadInitialTranslationType(initialPrefs)`.
+  The component wires a `watch` that persists changes to
+  `usePlayerStore.saveAnimePrefs`. (Phase 5 slice 5b.1)
+- `useEpisodeList({ anime, episodeMeta, fileStatus, downloadGroups, watchProgress, … })`
+  — the heart of AnimeDetailView's reactivity surface. Owns the episodes Map,
+  current page, probed `realQuality` cache, episodeOverrides, and focusApplied.
+  Exposes `filteredEpisodes`, `pagedEpisodes`, `episodeRows` (the 5-priority
+  selection: queued ↦ override ↦ remembered ↦ downloaded ↦ default), helper
+  computeds (`translationTypeCounts`, `availableAuthors`), helpers
+  (`bestPerAuthor`, `getRealHeight`, `qualityLabel`), and actions
+  (`loadPageEpisodes`, `goToPage`, `probeSelectedQualities`,
+  `onEpisodeTranslationChange`, `applyFocusEpisode`, `resetEpisodeOverrides`).
+  Lifecycle hooks are *not* registered here — the consumer wires `onMounted` /
+  watchers — which keeps the composable callable from Vitest. (Phase 5 slice 5b.1)
+
+Composables that own broadcast subscriptions or DOM listeners (like
+`useKeyboardShortcuts`) bind those inside themselves; pure-logic composables
+(the three 5b.1 additions) defer lifecycle to the caller.
 
 | Channel | Direction | Purpose |
 |---------|-----------|---------|

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -13,6 +13,9 @@ import { usePlayerStore } from '../stores/player';
 import { useShikimoriStore } from '../stores/shikimori';
 import { useDownloadsStore } from '../stores/downloads';
 import { storeToRefs } from 'pinia';
+import { useAnimeDetailPrefs } from '../composables/use-anime-detail-prefs';
+import { useChronology } from '../composables/use-chronology';
+import { useEpisodeList, PAGE_SIZE, type EpisodeRow } from '../composables/use-episode-list';
 
 const props = defineProps<{
   animeId: number;
@@ -27,11 +30,13 @@ const downloadsStore = useDownloadsStore();
 const { syncStatus, offlineQueueLength } = storeToRefs(shikimoriStore);
 
 const anime = ref<AnimeDetail | null>(null);
-const episodes = ref<Map<number, EpisodeDetail>>(new Map());
 const loading = ref(true);
-const loadingEpisodes = ref(false);
-const translationType = ref('subRu');
-const selectedAuthor = ref('');
+
+const prefs = useAnimeDetailPrefs();
+const { translationType, selectedAuthor } = prefs;
+
+const chronology = useChronology();
+const { shikiRelated, relatedLoading, relatedCollapsed } = chronology;
 
 const dataSource = ref<'api' | 'cache' | null>(null);
 const isOffline = computed(() => dataSource.value === 'cache');
@@ -50,8 +55,50 @@ const autoDlSaving = ref(false);
 const isDownloaded = ref(false);
 const cleanupModalOpen = ref(false);
 
-const episodeOverrides = ref<Map<number, number>>(new Map()); // episodeId -> translationId
-const realQuality = ref<Map<number, number>>(new Map()); // translationId -> actual height from embed
+const episodeMeta = ref<Record<string, EpisodeMeta[]>>({});
+const fileStatus = ref<
+  Record<
+    string,
+    { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
+  >
+>({});
+const downloadGroups = ref<Map<string, EpisodeGroup>>(new Map());
+const watchProgress = ref<Record<string, WatchProgressEntry>>({});
+
+const episodeList = useEpisodeList({
+  anime,
+  getAnimeId: () => props.animeId,
+  getInitialAuthor: () => props.initialPrefs?.author,
+  translationType,
+  selectedAuthor,
+  episodeMeta,
+  fileStatus,
+  downloadGroups,
+  watchProgress,
+  libraryStore,
+  checkFileStatus: () => checkFileStatus()
+});
+
+const {
+  episodes,
+  currentPage,
+  focusApplied,
+  loadingEpisodes,
+  filteredEpisodes,
+  episodeRows,
+  totalPages,
+  isPaginated,
+  translationTypeCounts,
+  availableAuthors,
+  getRealHeight,
+  qualityLabel,
+  goToPage,
+  loadPageEpisodes,
+  probeSelectedQualities,
+  onEpisodeTranslationChange,
+  applyFocusEpisode,
+  resetEpisodeOverrides
+} = episodeList;
 
 // Shikimori state
 const shikiUser = ref<ShikiUser | null>(null);
@@ -76,11 +123,6 @@ const shikiUserChecked = ref(false);
 // Shikimori detailed info (description / genres) — cached in main process
 const shikiDetails = ref<ShikiAnimeDetails | null>(null);
 const descExpanded = ref(false);
-
-// Shikimori chronology (related anime in the franchise)
-const shikiRelated = ref<ShikiRelatedEntry[]>([]);
-const relatedLoading = ref(false);
-const relatedCollapsed = ref(true);
 
 // Skip detection (Chromaprint local fingerprinting — debug panel only for now)
 const skipPanelCollapsed = ref(true);
@@ -181,203 +223,6 @@ const TRANSLATION_TYPES = [
   { value: 'raw', label: 'RAW', short: 'RAW', color: '#6a6a8a' }
 ];
 
-const filteredEpisodes = computed(() => {
-  if (!anime.value) return [];
-
-  const allActive = anime.value.episodes.filter(
-    (ep) => ep.isActive === 1 && ep.episodeType !== 'preview'
-  );
-
-  if (!anime.value.type) return allActive;
-
-  const matchedEpisodes = anime.value.episodes.filter(
-    (ep) => ep.isActive === 1 && ep.episodeType === anime.value!.type
-  );
-
-  if (matchedEpisodes.length === 0) return allActive;
-  if (anime.value.numberOfEpisodes && matchedEpisodes.length !== anime.value.numberOfEpisodes)
-    return allActive;
-
-  return matchedEpisodes;
-});
-
-const PAGE_SIZE = 30;
-const currentPage = ref(0);
-const totalPages = computed(() =>
-  Math.max(1, Math.ceil(filteredEpisodes.value.length / PAGE_SIZE))
-);
-const isPaginated = computed(() => filteredEpisodes.value.length > PAGE_SIZE);
-const pagedEpisodes = computed(() => {
-  if (!isPaginated.value) return filteredEpisodes.value;
-  const start = currentPage.value * PAGE_SIZE;
-  return filteredEpisodes.value.slice(start, start + PAGE_SIZE);
-});
-
-// Count unique episodes per translation type
-const translationTypeCounts = computed(() => {
-  const counts = new Map<string, number>();
-  for (const ep of episodes.value.values()) {
-    const typesInEp = new Set<string>();
-    for (const tr of ep.translations) {
-      if (tr.isActive === 1) typesInEp.add(tr.type);
-    }
-    for (const t of typesInEp) {
-      counts.set(t, (counts.get(t) || 0) + 1);
-    }
-  }
-  return counts;
-});
-
-const availableAuthors = computed(() => {
-  const counts = new Map<string, number>();
-  for (const ep of episodes.value.values()) {
-    // Track unique authors per episode (count each author once per episode)
-    const seen = new Set<string>();
-    for (const tr of ep.translations) {
-      if (tr.type === translationType.value && tr.isActive === 1 && !seen.has(tr.authorsSummary)) {
-        seen.add(tr.authorsSummary);
-        counts.set(tr.authorsSummary, (counts.get(tr.authorsSummary) || 0) + 1);
-      }
-    }
-  }
-  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
-});
-
-interface EpisodeRow {
-  episode: EpisodeSummary;
-  allTranslations: Translation[];
-  selectedTr: Translation | null;
-  isLocked: boolean;
-  lockSource: 'downloaded' | 'queued' | null;
-  downloadedTrIds: Set<number>;
-}
-
-// For each author+type combo, keep only the best quality translation
-function bestPerAuthor(translations: Translation[]): Translation[] {
-  const best = new Map<string, Translation>();
-  for (const tr of translations) {
-    const key = `${tr.type}:${tr.authorsSummary}`;
-    const existing = best.get(key);
-    if (!existing || getRealHeight(tr) > getRealHeight(existing)) {
-      best.set(key, tr);
-    }
-  }
-  return [...best.values()];
-}
-
-const episodeRows = computed((): EpisodeRow[] => {
-  return pagedEpisodes.value.map((ep) => {
-    const detail = episodes.value.get(ep.id);
-    const rawTranslations = detail ? detail.translations.filter((tr) => tr.isActive === 1) : [];
-    const allTranslations = bestPerAuthor(rawTranslations);
-
-    // Sort: global type first, then by quality desc, then by type order
-    const sorted = [...allTranslations].sort((a, b) => {
-      const aMatch = a.type === translationType.value ? 0 : 1;
-      const bMatch = b.type === translationType.value ? 0 : 1;
-      if (aMatch !== bMatch) return aMatch - bMatch;
-      const aH = getRealHeight(a),
-        bH = getRealHeight(b);
-      if (aH !== bH) return bH - aH;
-      const typeOrder = TRANSLATION_TYPES.map((t) => t.value);
-      return typeOrder.indexOf(a.type) - typeOrder.indexOf(b.type);
-    });
-
-    const metas = episodeMeta.value[ep.episodeInt] || [];
-    const group = downloadGroups.value.get(ep.episodeFull);
-
-    // Build set of downloaded translation IDs from metadata + files on disk
-    const downloadedTrIds = new Set<number>();
-    for (const m of metas) {
-      if (m.translationId) downloadedTrIds.add(m.translationId);
-    }
-
-    let selectedTr: Translation | null = null;
-    let isLocked = false;
-    let lockSource: 'downloaded' | 'queued' | null = null;
-
-    // Priority 1: In download queue (active) — lock the row
-    if (
-      group &&
-      group.video &&
-      !['completed', 'cancelled', 'failed'].includes(group.video.status)
-    ) {
-      selectedTr = sorted.find((tr) => tr.id === group.translationId) || null;
-      if (selectedTr) {
-        isLocked = true;
-        lockSource = 'queued';
-      }
-    }
-
-    // Priority 2: User per-episode override (in-session, sync; gives instant feedback
-    // after a dropdown click before the persisted watchProgress update lands)
-    if (!isLocked && episodeOverrides.value.has(ep.id)) {
-      selectedTr = sorted.find((tr) => tr.id === episodeOverrides.value.get(ep.id)) || null;
-    }
-
-    // Priority 3: Last-used translation for this episode (persisted in watchProgress).
-    // Sits ABOVE downloaded so an explicit user choice — even a stream — wins over
-    // a downloaded file. Falls through if the remembered id is no longer available.
-    if (!isLocked && !selectedTr) {
-      const remembered = watchProgress.value[ep.episodeInt]?.translationId;
-      if (remembered != null) {
-        selectedTr = sorted.find((tr) => tr.id === remembered) || null;
-      }
-    }
-
-    // Priority 4: Prefer any downloaded translation on this episode — avoids silent fallback to
-    // streaming when the global default (type+author) doesn't match what's on disk.
-    // Within same-type downloads, honor the user's author preference before picking highest quality.
-    if (!isLocked && !selectedTr && downloadedTrIds.size > 0) {
-      const downloaded = sorted.filter((tr) => downloadedTrIds.has(tr.id));
-      const sameType = downloaded.filter((tr) => tr.type === translationType.value);
-      const sameAuthor = sameType.find((tr) => tr.authorsSummary === selectedAuthor.value);
-      const bestSameType = [...sameType].sort((a, b) => getRealHeight(b) - getRealHeight(a))[0];
-      selectedTr = sameAuthor || bestSameType || downloaded[0] || null;
-    }
-
-    // Priority 5: Global default (same type + author)
-    if (!isLocked && !selectedTr) {
-      const typeFiltered = sorted.filter((tr) => tr.type === translationType.value);
-      selectedTr =
-        typeFiltered.find((tr) => tr.authorsSummary === selectedAuthor.value) ||
-        typeFiltered[0] ||
-        null;
-    }
-
-    return {
-      episode: ep,
-      allTranslations: sorted,
-      selectedTr,
-      isLocked,
-      lockSource,
-      downloadedTrIds
-    };
-  });
-});
-
-function onEpisodeTranslationChange(
-  episodeId: number,
-  episodeInt: string,
-  translationId: number
-): void {
-  episodeOverrides.value = new Map(episodeOverrides.value.set(episodeId, translationId));
-  // Persist so the choice survives page reloads and feeds back into Priority 3
-  // resolution. Reuse any existing playback position/duration so we don't clobber
-  // partial-watch progress when the user just changes translation.
-  const prev = watchProgress.value[episodeInt];
-  window.api
-    .watchProgressSave(
-      props.animeId,
-      episodeInt,
-      prev?.position ?? 0,
-      prev?.duration ?? 0,
-      prev?.watched,
-      translationId
-    )
-    .catch((err) => console.warn('[anime-detail] failed to persist translation choice:', err));
-}
-
 function onMouseBack(e: MouseEvent): void {
   if (e.button === 3) {
     e.preventDefault();
@@ -395,16 +240,7 @@ async function loadShikimoriData(): Promise<void> {
   }
   if (!anime.value?.myAnimeListId) return;
 
-  relatedLoading.value = true;
-  const relatedPromise = window.api
-    .shikimoriGetRelated(anime.value.myAnimeListId)
-    .then((related) => {
-      shikiRelated.value = related;
-    })
-    .catch((err) => console.error('Failed to load Shikimori related:', err))
-    .finally(() => {
-      relatedLoading.value = false;
-    });
+  const relatedPromise = chronology.loadRelated(anime.value.myAnimeListId);
 
   if (!shikiUser.value) {
     await relatedPromise;
@@ -607,11 +443,7 @@ onMounted(async () => {
   window.addEventListener('mouseup', onMouseBack);
   playerMode.value =
     ((await window.api.getSetting('playerMode')) as string as typeof playerMode.value) || 'system';
-  if (props.initialPrefs?.translationType) {
-    translationType.value = props.initialPrefs.translationType;
-  } else {
-    translationType.value = ((await window.api.getSetting('translationType')) as string) || 'subRu';
-  }
+  await prefs.loadInitialTranslationType(props.initialPrefs?.translationType);
 
   window.api
     .libraryHas(props.animeId)
@@ -823,183 +655,13 @@ async function shikiSave(): Promise<void> {
   }
 }
 
+// Wraps the prefs composable's helper so call sites stay terse.
 function applyDownloadedTranslationDefault(): void {
-  const counts = new Map<string, { type: string; author: string; count: number }>();
-  for (const metaArr of Object.values(episodeMeta.value)) {
-    for (const m of metaArr) {
-      const key = `${m.translationType}|${m.author}`;
-      const existing = counts.get(key);
-      if (existing) existing.count++;
-      else counts.set(key, { type: m.translationType, author: m.author, count: 1 });
-    }
-  }
-  if (counts.size === 0) return;
-  let best: { type: string; author: string; count: number } | null = null;
-  for (const entry of counts.values()) {
-    if (!best || entry.count > best.count) best = entry;
-  }
-  if (!best) return;
-  translationType.value = best.type;
-  if (best.author && availableAuthors.value.some(([a]) => a === best!.author)) {
-    selectedAuthor.value = best.author;
-  }
+  prefs.applyDownloadedTranslationDefault({
+    episodeMeta: episodeMeta.value,
+    availableAuthors: availableAuthors.value
+  });
 }
-
-async function loadPageEpisodes(): Promise<void> {
-  if (!anime.value || pagedEpisodes.value.length === 0) return;
-  loadingEpisodes.value = true;
-
-  const batch = 5;
-  const toLoad = pagedEpisodes.value.filter((ep) => !episodes.value.has(ep.id));
-
-  for (let i = 0; i < toLoad.length; i += batch) {
-    const chunk = toLoad.slice(i, i + batch);
-    const fetched = await Promise.all(
-      chunk.map((ep) => window.api.getEpisode(ep.id, props.animeId).then((r) => r.data))
-    );
-    const updated = new Map(episodes.value);
-    for (const ep of fetched) {
-      updated.set(ep.id, ep);
-    }
-    episodes.value = updated;
-  }
-
-  if (availableAuthors.value.length > 0 && !selectedAuthor.value) {
-    if (
-      props.initialPrefs?.author &&
-      availableAuthors.value.some(([a]) => a === props.initialPrefs!.author)
-    ) {
-      selectedAuthor.value = props.initialPrefs.author;
-    } else {
-      selectedAuthor.value = availableAuthors.value[0][0];
-    }
-  }
-
-  loadingEpisodes.value = false;
-  probeSelectedQualities();
-}
-
-async function goToPage(page: number): Promise<void> {
-  currentPage.value = page;
-  await loadPageEpisodes();
-  await checkFileStatus();
-}
-
-let probeGeneration = 0;
-
-async function probeSelectedQualities(): Promise<void> {
-  const gen = ++probeGeneration;
-
-  // Build translation metadata lookup
-  const trMeta = new Map<number, Translation>();
-  for (const row of episodeRows.value) {
-    for (const tr of row.allTranslations) {
-      trMeta.set(tr.id, tr);
-    }
-  }
-
-  // Phase 1: probe only currently selected translations
-  const selectedIds: number[] = [];
-  for (const row of episodeRows.value) {
-    if (row.selectedTr && !realQuality.value.has(row.selectedTr.id)) {
-      selectedIds.push(row.selectedTr.id);
-    }
-  }
-
-  if (selectedIds.length > 0) {
-    const updated = await probeIds(selectedIds, trMeta, gen);
-    if (updated) realQuality.value = updated;
-  }
-
-  if (gen !== probeGeneration) return;
-
-  // Phase 2: full scan only if enabled in settings and needed
-  const bgProbeEnabled = (await window.api.getSetting('backgroundQualityProbe')) as boolean;
-  if (!bgProbeEnabled) return;
-
-  const episodeCount = filteredEpisodes.value.length;
-  const needsFullScan = await window.api.probeFullScanNeeded(props.animeId, episodeCount);
-  if (!needsFullScan || gen !== probeGeneration) return;
-
-  const remainingIds: number[] = [];
-  for (const id of trMeta.keys()) {
-    if (!realQuality.value.has(id)) {
-      remainingIds.push(id);
-    }
-  }
-
-  if (remainingIds.length > 0) {
-    const updated = await probeIds(remainingIds, trMeta, gen, true);
-    if (updated) realQuality.value = updated;
-  }
-
-  if (gen === probeGeneration) {
-    window.api.probeFullScanDone(props.animeId, episodeCount);
-  }
-}
-
-async function probeIds(
-  ids: number[],
-  trMeta: Map<number, Translation>,
-  gen: number,
-  throttle = false
-): Promise<Map<number, number> | null> {
-  const batchSize = throttle ? 2 : 5;
-  const collected = new Map<number, number>();
-  for (let i = 0; i < ids.length; i += batchSize) {
-    if (gen !== probeGeneration) return null;
-    if (throttle) await new Promise((r) => setTimeout(r, 100));
-    const batch = ids.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map((id) =>
-        window.api.probeEmbedQuality(id, props.animeId).then((h) => ({ id, height: h }))
-      )
-    );
-    for (const r of results) {
-      if (r.height !== null) {
-        collected.set(r.id, r.height);
-        const tr = trMeta.get(r.id);
-        if (tr && tr.height !== r.height) {
-          console.warn(
-            `[quality-mismatch] Translation ${r.id} (${tr.authorsSummary}, ${tr.type}): reported=${tr.height}p, actual=${r.height}p`
-          );
-          window.api.reportQualityMismatch({
-            translationId: r.id,
-            author: tr.authorsSummary,
-            type: tr.type,
-            reported: tr.height,
-            actual: r.height
-          });
-        }
-      }
-    }
-  }
-  if (gen !== probeGeneration) return null;
-  const merged = new Map(realQuality.value);
-  for (const [id, h] of collected) {
-    merged.set(id, h);
-  }
-  return merged;
-}
-
-function getRealHeight(tr: Translation): number {
-  return realQuality.value.get(tr.id) ?? tr.height;
-}
-
-function qualityLabel(height: number): string {
-  if (height >= 1080) return '1080p';
-  if (height >= 720) return '720p';
-  if (height >= 480) return '480p';
-  return `${height}p`;
-}
-
-const fileStatus = ref<
-  Record<
-    string,
-    { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
-  >
->({});
-const watchProgress = ref<Record<string, WatchProgressEntry>>({});
 
 async function loadWatchProgress(): Promise<void> {
   try {
@@ -1173,34 +835,8 @@ async function onCleanupDeleted(): Promise<void> {
   await checkFileStatus();
 }
 
-const episodeMeta = ref<Record<string, EpisodeMeta[]>>({});
-const downloadGroups = ref<Map<string, EpisodeGroup>>(new Map());
 const downloading = ref(false);
 const errorMessage = ref('');
-
-const focusApplied = ref(false);
-async function applyFocusEpisode(target: string): Promise<void> {
-  if (focusApplied.value) return;
-  const eps = filteredEpisodes.value;
-  if (eps.length === 0) return;
-  const targetIdx = eps.findIndex((e) => e.episodeInt === target);
-  if (targetIdx < 0) {
-    focusApplied.value = true;
-    libraryStore.clearFocusEpisode(props.animeId);
-    return;
-  }
-  const targetPage = isPaginated.value ? Math.floor(targetIdx / PAGE_SIZE) : 0;
-  if (targetPage !== currentPage.value) {
-    await goToPage(targetPage);
-  }
-  await nextTick();
-  const el = document.querySelector(
-    `.episode-row[data-ep-int="${CSS.escape(target)}"]`
-  ) as HTMLElement | null;
-  if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  focusApplied.value = true;
-  libraryStore.clearFocusEpisode(props.animeId);
-}
 
 watch(
   [() => props.focusEpisodeInt, filteredEpisodes, loadingEpisodes],
@@ -1335,9 +971,9 @@ function getGroup(episodeFull: string): EpisodeGroup | undefined {
 }
 
 watch([translationType, selectedAuthor], () => {
-  episodeOverrides.value = new Map();
+  resetEpisodeOverrides();
   playerStore.saveAnimePrefs(props.animeId, translationType.value, selectedAuthor.value);
-  probeSelectedQualities();
+  void probeSelectedQualities();
 });
 
 const posterSrc = ref('');

--- a/src/renderer/src/composables/use-anime-detail-prefs.ts
+++ b/src/renderer/src/composables/use-anime-detail-prefs.ts
@@ -1,0 +1,64 @@
+// Per-anime translation type + author selection for AnimeDetailView.
+// Phase 5 slice 5b.1 (#118).
+//
+// Owns translationType + selectedAuthor refs and the
+// applyDownloadedTranslationDefault heuristic that picks the most
+// frequently-downloaded type+author combo on first load. The dep snapshot
+// (episodeMeta + availableAuthors) is passed as a parameter to the helper,
+// not held as a reactive input — this avoids a circular construction with
+// useEpisodeList, which derives availableAuthors from translationType.
+
+import { ref, type Ref } from 'vue'
+
+export function useAnimeDetailPrefs(): {
+  translationType: Ref<string>
+  selectedAuthor: Ref<string>
+  applyDownloadedTranslationDefault: (snapshot: {
+    episodeMeta: Record<string, EpisodeMeta[]>
+    availableAuthors: [string, number][]
+  }) => void
+  loadInitialTranslationType: (initialPrefsValue?: string) => Promise<void>
+} {
+  const translationType = ref('subRu')
+  const selectedAuthor = ref('')
+
+  async function loadInitialTranslationType(initialPrefsValue?: string): Promise<void> {
+    if (initialPrefsValue) {
+      translationType.value = initialPrefsValue
+      return
+    }
+    translationType.value = ((await window.api.getSetting('translationType')) as string) || 'subRu'
+  }
+
+  function applyDownloadedTranslationDefault(snapshot: {
+    episodeMeta: Record<string, EpisodeMeta[]>
+    availableAuthors: [string, number][]
+  }): void {
+    const counts = new Map<string, { type: string; author: string; count: number }>()
+    for (const metaArr of Object.values(snapshot.episodeMeta)) {
+      for (const m of metaArr) {
+        const key = `${m.translationType}|${m.author}`
+        const existing = counts.get(key)
+        if (existing) existing.count++
+        else counts.set(key, { type: m.translationType, author: m.author, count: 1 })
+      }
+    }
+    if (counts.size === 0) return
+    let best: { type: string; author: string; count: number } | null = null
+    for (const entry of counts.values()) {
+      if (!best || entry.count > best.count) best = entry
+    }
+    if (!best) return
+    translationType.value = best.type
+    if (best.author && snapshot.availableAuthors.some(([a]) => a === best!.author)) {
+      selectedAuthor.value = best.author
+    }
+  }
+
+  return {
+    translationType,
+    selectedAuthor,
+    applyDownloadedTranslationDefault,
+    loadInitialTranslationType
+  }
+}

--- a/src/renderer/src/composables/use-chronology.ts
+++ b/src/renderer/src/composables/use-chronology.ts
@@ -1,0 +1,35 @@
+// Shikimori chronology (related anime in the franchise) for the
+// AnimeDetailView panel. Phase 5 slice 5b.1 (#118).
+//
+// Self-contained: holds the related list + loading + collapsed UI state,
+// exposes a `loadRelated(malId)` action. The caller (AnimeDetailView) decides
+// when to fetch — typically on mount once `anime.value?.myAnimeListId` is
+// known. Lifecycle hooks intentionally NOT registered here so the composable
+// stays usable from Vitest without a component context.
+
+import { ref, type Ref } from 'vue'
+
+export function useChronology(): {
+  shikiRelated: Ref<ShikiRelatedEntry[]>
+  relatedLoading: Ref<boolean>
+  relatedCollapsed: Ref<boolean>
+  loadRelated: (malId: number) => Promise<void>
+} {
+  const shikiRelated = ref<ShikiRelatedEntry[]>([])
+  const relatedLoading = ref(false)
+  const relatedCollapsed = ref(true)
+
+  async function loadRelated(malId: number): Promise<void> {
+    if (!malId) return
+    relatedLoading.value = true
+    try {
+      shikiRelated.value = await window.api.shikimoriGetRelated(malId)
+    } catch (err) {
+      console.error('Failed to load Shikimori related:', err)
+    } finally {
+      relatedLoading.value = false
+    }
+  }
+
+  return { shikiRelated, relatedLoading, relatedCollapsed, loadRelated }
+}

--- a/src/renderer/src/composables/use-episode-list.ts
+++ b/src/renderer/src/composables/use-episode-list.ts
@@ -1,0 +1,452 @@
+// Episode list / paging / projection for AnimeDetailView. Phase 5 slice 5b.1 (#118).
+//
+// Owns: episodes Map, currentPage, realQuality (probed), episodeOverrides,
+// focusApplied, loadingEpisodes.
+//
+// Consumes (as Refs) the per-anime state owned by the component or other
+// composables: anime, animeId (getter), translationType, selectedAuthor,
+// episodeMeta, fileStatus, downloadGroups, watchProgress.
+//
+// Returns:
+// - the page projections (filteredEpisodes, pagedEpisodes, episodeRows),
+// - paging + load + focus actions,
+// - quality probing,
+// - the 5-priority episode-row selection algorithm (the central piece of
+//   AnimeDetailView's reactivity surface).
+//
+// Lifecycle hooks are NOT registered here — the component is responsible for
+// wiring up onMounted/onUnmounted timing of loadPageEpisodes etc. This keeps
+// the composable callable from Vitest.
+
+import { ref, computed, nextTick, type Ref, type ComputedRef } from 'vue'
+import type { useLibraryStore } from '../stores/library'
+
+export interface EpisodeRow {
+  episode: EpisodeSummary
+  allTranslations: Translation[]
+  selectedTr: Translation | null
+  isLocked: boolean
+  lockSource: 'downloaded' | 'queued' | null
+  downloadedTrIds: Set<number>
+}
+
+export const PAGE_SIZE = 30
+
+const TRANSLATION_TYPE_ORDER: readonly string[] = ['subRu', 'subEn', 'voiceRu', 'voiceEn', 'raw']
+
+export function useEpisodeList(deps: {
+  anime: Ref<AnimeDetail | null>
+  getAnimeId: () => number
+  getInitialAuthor: () => string | undefined
+  translationType: Ref<string>
+  selectedAuthor: Ref<string>
+  episodeMeta: Ref<Record<string, EpisodeMeta[]>>
+  fileStatus: Ref<
+    Record<
+      string,
+      { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
+    >
+  >
+  downloadGroups: Ref<Map<string, EpisodeGroup>>
+  watchProgress: Ref<Record<string, WatchProgressEntry>>
+  libraryStore: ReturnType<typeof useLibraryStore>
+  checkFileStatus: () => Promise<void>
+}): {
+  episodes: Ref<Map<number, EpisodeDetail>>
+  currentPage: Ref<number>
+  realQuality: Ref<Map<number, number>>
+  episodeOverrides: Ref<Map<number, number>>
+  focusApplied: Ref<boolean>
+  loadingEpisodes: Ref<boolean>
+  filteredEpisodes: ComputedRef<EpisodeSummary[]>
+  pagedEpisodes: ComputedRef<EpisodeSummary[]>
+  episodeRows: ComputedRef<EpisodeRow[]>
+  totalPages: ComputedRef<number>
+  isPaginated: ComputedRef<boolean>
+  translationTypeCounts: ComputedRef<Map<string, number>>
+  availableAuthors: ComputedRef<[string, number][]>
+  PAGE_SIZE: number
+  getRealHeight: (tr: Translation) => number
+  qualityLabel: (height: number) => string
+  bestPerAuthor: (translations: Translation[]) => Translation[]
+  goToPage: (page: number) => Promise<void>
+  loadPageEpisodes: () => Promise<void>
+  probeSelectedQualities: () => Promise<void>
+  onEpisodeTranslationChange: (episodeId: number, episodeInt: string, translationId: number) => void
+  applyFocusEpisode: (target: string) => Promise<void>
+  resetEpisodeOverrides: () => void
+} {
+  const episodes = ref<Map<number, EpisodeDetail>>(new Map())
+  const currentPage = ref(0)
+  const realQuality = ref<Map<number, number>>(new Map())
+  const episodeOverrides = ref<Map<number, number>>(new Map())
+  const focusApplied = ref(false)
+  const loadingEpisodes = ref(false)
+
+  let probeGeneration = 0
+
+  function getRealHeight(tr: Translation): number {
+    return realQuality.value.get(tr.id) ?? tr.height
+  }
+
+  function qualityLabel(height: number): string {
+    if (height >= 1080) return '1080p'
+    if (height >= 720) return '720p'
+    if (height >= 480) return '480p'
+    return `${height}p`
+  }
+
+  function bestPerAuthor(translations: Translation[]): Translation[] {
+    const best = new Map<string, Translation>()
+    for (const tr of translations) {
+      const key = `${tr.type}:${tr.authorsSummary}`
+      const existing = best.get(key)
+      if (!existing || getRealHeight(tr) > getRealHeight(existing)) {
+        best.set(key, tr)
+      }
+    }
+    return [...best.values()]
+  }
+
+  const filteredEpisodes = computed(() => {
+    if (!deps.anime.value) return []
+    const allActive = deps.anime.value.episodes.filter(
+      (ep) => ep.isActive === 1 && ep.episodeType !== 'preview'
+    )
+    if (!deps.anime.value.type) return allActive
+    const matched = deps.anime.value.episodes.filter(
+      (ep) => ep.isActive === 1 && ep.episodeType === deps.anime.value!.type
+    )
+    if (matched.length === 0) return allActive
+    if (deps.anime.value.numberOfEpisodes && matched.length !== deps.anime.value.numberOfEpisodes)
+      return allActive
+    return matched
+  })
+
+  const totalPages = computed(() =>
+    Math.max(1, Math.ceil(filteredEpisodes.value.length / PAGE_SIZE))
+  )
+  const isPaginated = computed(() => filteredEpisodes.value.length > PAGE_SIZE)
+  const pagedEpisodes = computed(() => {
+    if (!isPaginated.value) return filteredEpisodes.value
+    const start = currentPage.value * PAGE_SIZE
+    return filteredEpisodes.value.slice(start, start + PAGE_SIZE)
+  })
+
+  const translationTypeCounts = computed(() => {
+    const counts = new Map<string, number>()
+    for (const ep of episodes.value.values()) {
+      const seen = new Set<string>()
+      for (const tr of ep.translations) {
+        if (tr.isActive === 1) seen.add(tr.type)
+      }
+      for (const t of seen) counts.set(t, (counts.get(t) || 0) + 1)
+    }
+    return counts
+  })
+
+  const availableAuthors = computed(() => {
+    const counts = new Map<string, number>()
+    for (const ep of episodes.value.values()) {
+      const seen = new Set<string>()
+      for (const tr of ep.translations) {
+        if (
+          tr.type === deps.translationType.value &&
+          tr.isActive === 1 &&
+          !seen.has(tr.authorsSummary)
+        ) {
+          seen.add(tr.authorsSummary)
+          counts.set(tr.authorsSummary, (counts.get(tr.authorsSummary) || 0) + 1)
+        }
+      }
+    }
+    return [...counts.entries()].sort((a, b) => b[1] - a[1])
+  })
+
+  const episodeRows = computed<EpisodeRow[]>(() => {
+    return pagedEpisodes.value.map((ep) => {
+      const detail = episodes.value.get(ep.id)
+      const rawTranslations = detail ? detail.translations.filter((tr) => tr.isActive === 1) : []
+      const allTranslations = bestPerAuthor(rawTranslations)
+
+      const sorted = [...allTranslations].sort((a, b) => {
+        const aMatch = a.type === deps.translationType.value ? 0 : 1
+        const bMatch = b.type === deps.translationType.value ? 0 : 1
+        if (aMatch !== bMatch) return aMatch - bMatch
+        const aH = getRealHeight(a)
+        const bH = getRealHeight(b)
+        if (aH !== bH) return bH - aH
+        return TRANSLATION_TYPE_ORDER.indexOf(a.type) - TRANSLATION_TYPE_ORDER.indexOf(b.type)
+      })
+
+      const metas = deps.episodeMeta.value[ep.episodeInt] || []
+      const group = deps.downloadGroups.value.get(ep.episodeFull)
+
+      const downloadedTrIds = new Set<number>()
+      for (const m of metas) {
+        if (m.translationId) downloadedTrIds.add(m.translationId)
+      }
+
+      let selectedTr: Translation | null = null
+      let isLocked = false
+      let lockSource: 'downloaded' | 'queued' | null = null
+
+      // Priority 1: queued/active download — lock the row
+      if (
+        group &&
+        group.video &&
+        !['completed', 'cancelled', 'failed'].includes(group.video.status)
+      ) {
+        selectedTr = sorted.find((tr) => tr.id === group.translationId) || null
+        if (selectedTr) {
+          isLocked = true
+          lockSource = 'queued'
+        }
+      }
+
+      // Priority 2: in-session user override (sync, gives instant dropdown feedback
+      // before the persisted watchProgress update lands)
+      if (!isLocked && episodeOverrides.value.has(ep.id)) {
+        selectedTr = sorted.find((tr) => tr.id === episodeOverrides.value.get(ep.id)) || null
+      }
+
+      // Priority 3: last-used translation persisted in watchProgress. Ranked above
+      // downloaded so an explicit user choice — even a stream — wins over a file.
+      if (!isLocked && !selectedTr) {
+        const remembered = deps.watchProgress.value[ep.episodeInt]?.translationId
+        if (remembered != null) {
+          selectedTr = sorted.find((tr) => tr.id === remembered) || null
+        }
+      }
+
+      // Priority 4: any downloaded translation — avoids silent fallback to streaming
+      // when the global default doesn't match what's on disk. Within same-type
+      // downloads, honor the user's author preference before falling back to highest.
+      if (!isLocked && !selectedTr && downloadedTrIds.size > 0) {
+        const downloaded = sorted.filter((tr) => downloadedTrIds.has(tr.id))
+        const sameType = downloaded.filter((tr) => tr.type === deps.translationType.value)
+        const sameAuthor = sameType.find((tr) => tr.authorsSummary === deps.selectedAuthor.value)
+        const bestSameType = [...sameType].sort((a, b) => getRealHeight(b) - getRealHeight(a))[0]
+        selectedTr = sameAuthor || bestSameType || downloaded[0] || null
+      }
+
+      // Priority 5: global default (translation type + author)
+      if (!isLocked && !selectedTr) {
+        const typeFiltered = sorted.filter((tr) => tr.type === deps.translationType.value)
+        selectedTr =
+          typeFiltered.find((tr) => tr.authorsSummary === deps.selectedAuthor.value) ||
+          typeFiltered[0] ||
+          null
+      }
+
+      return {
+        episode: ep,
+        allTranslations: sorted,
+        selectedTr,
+        isLocked,
+        lockSource,
+        downloadedTrIds
+      }
+    })
+  })
+
+  function onEpisodeTranslationChange(
+    episodeId: number,
+    episodeInt: string,
+    translationId: number
+  ): void {
+    episodeOverrides.value = new Map(episodeOverrides.value.set(episodeId, translationId))
+    const prev = deps.watchProgress.value[episodeInt]
+    window.api
+      .watchProgressSave(
+        deps.getAnimeId(),
+        episodeInt,
+        prev?.position ?? 0,
+        prev?.duration ?? 0,
+        prev?.watched,
+        translationId
+      )
+      .catch((err) => console.warn('[anime-detail] failed to persist translation choice:', err))
+  }
+
+  function resetEpisodeOverrides(): void {
+    episodeOverrides.value = new Map()
+  }
+
+  async function loadPageEpisodes(): Promise<void> {
+    if (!deps.anime.value || pagedEpisodes.value.length === 0) return
+    loadingEpisodes.value = true
+
+    const batch = 5
+    const toLoad = pagedEpisodes.value.filter((ep) => !episodes.value.has(ep.id))
+
+    for (let i = 0; i < toLoad.length; i += batch) {
+      const chunk = toLoad.slice(i, i + batch)
+      const fetched = await Promise.all(
+        chunk.map((ep) => window.api.getEpisode(ep.id, deps.getAnimeId()).then((r) => r.data))
+      )
+      const updated = new Map(episodes.value)
+      for (const ep of fetched) {
+        updated.set(ep.id, ep)
+      }
+      episodes.value = updated
+    }
+
+    if (availableAuthors.value.length > 0 && !deps.selectedAuthor.value) {
+      const initial = deps.getInitialAuthor()
+      if (initial && availableAuthors.value.some(([a]) => a === initial)) {
+        deps.selectedAuthor.value = initial
+      } else {
+        deps.selectedAuthor.value = availableAuthors.value[0][0]
+      }
+    }
+
+    loadingEpisodes.value = false
+    void probeSelectedQualities()
+  }
+
+  async function goToPage(page: number): Promise<void> {
+    currentPage.value = page
+    await loadPageEpisodes()
+    await deps.checkFileStatus()
+  }
+
+  async function probeSelectedQualities(): Promise<void> {
+    const gen = ++probeGeneration
+
+    const trMeta = new Map<number, Translation>()
+    for (const row of episodeRows.value) {
+      for (const tr of row.allTranslations) {
+        trMeta.set(tr.id, tr)
+      }
+    }
+
+    const selectedIds: number[] = []
+    for (const row of episodeRows.value) {
+      if (row.selectedTr && !realQuality.value.has(row.selectedTr.id)) {
+        selectedIds.push(row.selectedTr.id)
+      }
+    }
+
+    if (selectedIds.length > 0) {
+      const updated = await probeIds(selectedIds, trMeta, gen)
+      if (updated) realQuality.value = updated
+    }
+
+    if (gen !== probeGeneration) return
+
+    const bgProbeEnabled = (await window.api.getSetting('backgroundQualityProbe')) as boolean
+    if (!bgProbeEnabled) return
+
+    const episodeCount = filteredEpisodes.value.length
+    const needsFullScan = await window.api.probeFullScanNeeded(deps.getAnimeId(), episodeCount)
+    if (!needsFullScan || gen !== probeGeneration) return
+
+    const remainingIds: number[] = []
+    for (const id of trMeta.keys()) {
+      if (!realQuality.value.has(id)) remainingIds.push(id)
+    }
+
+    if (remainingIds.length > 0) {
+      const updated = await probeIds(remainingIds, trMeta, gen, true)
+      if (updated) realQuality.value = updated
+    }
+
+    if (gen === probeGeneration) {
+      void window.api.probeFullScanDone(deps.getAnimeId(), episodeCount)
+    }
+  }
+
+  async function probeIds(
+    ids: number[],
+    trMeta: Map<number, Translation>,
+    gen: number,
+    throttle = false
+  ): Promise<Map<number, number> | null> {
+    const batchSize = throttle ? 2 : 5
+    const collected = new Map<number, number>()
+    for (let i = 0; i < ids.length; i += batchSize) {
+      if (gen !== probeGeneration) return null
+      if (throttle) await new Promise((r) => setTimeout(r, 100))
+      const batch = ids.slice(i, i + batchSize)
+      const results = await Promise.all(
+        batch.map((id) =>
+          window.api.probeEmbedQuality(id, deps.getAnimeId()).then((h) => ({ id, height: h }))
+        )
+      )
+      for (const r of results) {
+        if (r.height !== null) {
+          collected.set(r.id, r.height)
+          const tr = trMeta.get(r.id)
+          if (tr && tr.height !== r.height) {
+            console.warn(
+              `[quality-mismatch] Translation ${r.id} (${tr.authorsSummary}, ${tr.type}): reported=${tr.height}p, actual=${r.height}p`
+            )
+            void window.api.reportQualityMismatch({
+              translationId: r.id,
+              author: tr.authorsSummary,
+              type: tr.type,
+              reported: tr.height,
+              actual: r.height
+            })
+          }
+        }
+      }
+    }
+    if (gen !== probeGeneration) return null
+    const merged = new Map(realQuality.value)
+    for (const [id, h] of collected) {
+      merged.set(id, h)
+    }
+    return merged
+  }
+
+  async function applyFocusEpisode(target: string): Promise<void> {
+    if (focusApplied.value) return
+    const eps = filteredEpisodes.value
+    if (eps.length === 0) return
+    const targetIdx = eps.findIndex((e) => e.episodeInt === target)
+    if (targetIdx < 0) {
+      focusApplied.value = true
+      deps.libraryStore.clearFocusEpisode(deps.getAnimeId())
+      return
+    }
+    const targetPage = isPaginated.value ? Math.floor(targetIdx / PAGE_SIZE) : 0
+    if (targetPage !== currentPage.value) {
+      await goToPage(targetPage)
+    }
+    await nextTick()
+    const el = document.querySelector(
+      `.episode-row[data-ep-int="${CSS.escape(target)}"]`
+    ) as HTMLElement | null
+    if (el) el.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    focusApplied.value = true
+    deps.libraryStore.clearFocusEpisode(deps.getAnimeId())
+  }
+
+  return {
+    episodes,
+    currentPage,
+    realQuality,
+    episodeOverrides,
+    focusApplied,
+    loadingEpisodes,
+    filteredEpisodes,
+    pagedEpisodes,
+    episodeRows,
+    totalPages,
+    isPaginated,
+    translationTypeCounts,
+    availableAuthors,
+    PAGE_SIZE,
+    getRealHeight,
+    qualityLabel,
+    bestPerAuthor,
+    goToPage,
+    loadPageEpisodes,
+    probeSelectedQualities,
+    onEpisodeTranslationChange,
+    applyFocusEpisode,
+    resetEpisodeOverrides
+  }
+}

--- a/test/renderer/composables/use-anime-detail-prefs.test.ts
+++ b/test/renderer/composables/use-anime-detail-prefs.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAnimeDetailPrefs } from '../../../src/renderer/src/composables/use-anime-detail-prefs'
+
+type Api = { getSetting: (key: string) => Promise<unknown> }
+
+function setApi(api: Partial<Api>): void {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api }
+}
+
+function makeMeta(episodeInt: string, translationType: string, author: string): EpisodeMeta {
+  return {
+    episodeInt,
+    translationId: 1,
+    translationType,
+    author,
+    height: 720
+  } as unknown as EpisodeMeta
+}
+
+beforeEach(() => {
+  setApi({})
+})
+
+describe('useAnimeDetailPrefs', () => {
+  it('defaults translationType to subRu and selectedAuthor empty', () => {
+    const { translationType, selectedAuthor } = useAnimeDetailPrefs()
+    expect(translationType.value).toBe('subRu')
+    expect(selectedAuthor.value).toBe('')
+  })
+
+  it('loadInitialTranslationType uses initialPrefs over storage', async () => {
+    const getSetting = vi.fn().mockResolvedValue('subEn')
+    setApi({ getSetting })
+    const prefs = useAnimeDetailPrefs()
+    await prefs.loadInitialTranslationType('voiceRu')
+    expect(prefs.translationType.value).toBe('voiceRu')
+    expect(getSetting).not.toHaveBeenCalled()
+  })
+
+  it('loadInitialTranslationType falls back to storage and subRu default', async () => {
+    setApi({ getSetting: vi.fn().mockResolvedValue(null) })
+    const prefs = useAnimeDetailPrefs()
+    await prefs.loadInitialTranslationType()
+    expect(prefs.translationType.value).toBe('subRu')
+  })
+
+  it('applyDownloadedTranslationDefault picks the highest-frequency combo', () => {
+    const prefs = useAnimeDetailPrefs()
+    prefs.applyDownloadedTranslationDefault({
+      episodeMeta: {
+        '1': [makeMeta('1', 'voiceRu', 'AniLibria')],
+        '2': [makeMeta('2', 'voiceRu', 'AniLibria')],
+        '3': [makeMeta('3', 'subRu', 'Anidub')]
+      },
+      availableAuthors: [
+        ['AniLibria', 2],
+        ['Anidub', 1]
+      ]
+    })
+    expect(prefs.translationType.value).toBe('voiceRu')
+    expect(prefs.selectedAuthor.value).toBe('AniLibria')
+  })
+
+  it('applyDownloadedTranslationDefault only sets author if present in availableAuthors', () => {
+    const prefs = useAnimeDetailPrefs()
+    prefs.applyDownloadedTranslationDefault({
+      episodeMeta: { '1': [makeMeta('1', 'subRu', 'GhostStudio')] },
+      // GhostStudio is the most-downloaded but the dropdown doesn't expose it.
+      availableAuthors: [['Anidub', 1]]
+    })
+    expect(prefs.translationType.value).toBe('subRu')
+    expect(prefs.selectedAuthor.value).toBe('')
+  })
+
+  it('applyDownloadedTranslationDefault is a no-op with empty episodeMeta', () => {
+    const prefs = useAnimeDetailPrefs()
+    prefs.applyDownloadedTranslationDefault({ episodeMeta: {}, availableAuthors: [] })
+    expect(prefs.translationType.value).toBe('subRu')
+    expect(prefs.selectedAuthor.value).toBe('')
+  })
+})

--- a/test/renderer/composables/use-chronology.test.ts
+++ b/test/renderer/composables/use-chronology.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useChronology } from '../../../src/renderer/src/composables/use-chronology'
+
+type Api = { shikimoriGetRelated: (malId: number) => Promise<ShikiRelatedEntry[]> }
+
+function setApi(api: Partial<Api>): void {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api }
+}
+
+beforeEach(() => {
+  setApi({})
+})
+
+describe('useChronology', () => {
+  it('starts empty, idle, and collapsed', () => {
+    const { shikiRelated, relatedLoading, relatedCollapsed } = useChronology()
+    expect(shikiRelated.value).toEqual([])
+    expect(relatedLoading.value).toBe(false)
+    expect(relatedCollapsed.value).toBe(true)
+  })
+
+  it('loadRelated fetches via IPC and toggles loading', async () => {
+    const fake: ShikiRelatedEntry[] = [
+      {
+        relation: 'Sequel',
+        anime: { id: 1, name: 'Foo', russian: 'Foo', kind: 'tv', episodes: 12 }
+      } as unknown as ShikiRelatedEntry
+    ]
+    const spy = vi.fn().mockResolvedValue(fake)
+    setApi({ shikimoriGetRelated: spy })
+
+    const { shikiRelated, relatedLoading, loadRelated } = useChronology()
+    const p = loadRelated(123)
+    expect(relatedLoading.value).toBe(true)
+    await p
+    expect(relatedLoading.value).toBe(false)
+    expect(spy).toHaveBeenCalledWith(123)
+    expect(shikiRelated.value).toEqual(fake)
+  })
+
+  it('loadRelated(0) is a no-op', async () => {
+    const spy = vi.fn()
+    setApi({ shikimoriGetRelated: spy })
+    const { loadRelated, relatedLoading } = useChronology()
+    await loadRelated(0)
+    expect(spy).not.toHaveBeenCalled()
+    expect(relatedLoading.value).toBe(false)
+  })
+
+  it('still clears loading on IPC failure', async () => {
+    const err = new Error('boom')
+    setApi({ shikimoriGetRelated: vi.fn().mockRejectedValue(err) })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { loadRelated, relatedLoading, shikiRelated } = useChronology()
+    await loadRelated(7)
+    expect(relatedLoading.value).toBe(false)
+    expect(shikiRelated.value).toEqual([])
+    expect(errSpy).toHaveBeenCalled()
+    errSpy.mockRestore()
+  })
+})

--- a/test/renderer/composables/use-episode-list.test.ts
+++ b/test/renderer/composables/use-episode-list.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useLibraryStore } from '../../../src/renderer/src/stores/library'
+import { useEpisodeList } from '../../../src/renderer/src/composables/use-episode-list'
+
+type Api = {
+  getEpisode: (id: number, animeId: number) => Promise<{ data: EpisodeDetail }>
+  watchProgressSave: (...args: unknown[]) => Promise<void>
+  probeEmbedQuality: (id: number, animeId: number) => Promise<number | null>
+  getSetting: (key: string) => Promise<unknown>
+  probeFullScanNeeded: (animeId: number, count: number) => Promise<boolean>
+  probeFullScanDone: (animeId: number, count: number) => Promise<void>
+  reportQualityMismatch: (data: unknown) => Promise<void>
+}
+
+function setApi(api: Partial<Api>): void {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api }
+}
+
+function mkEpisode(
+  id: number,
+  episodeInt: string,
+  episodeType = 'tv',
+  isActive = 1
+): EpisodeSummary {
+  return {
+    id,
+    episodeInt,
+    episodeFull: `Episode ${episodeInt}`,
+    episodeType,
+    isActive,
+    firstUploadedDateTime: '2025-01-01'
+  } as unknown as EpisodeSummary
+}
+
+function mkTr(id: number, type: string, author: string, height = 720): Translation {
+  return {
+    id,
+    type,
+    height,
+    authorsSummary: author,
+    isActive: 1
+  } as unknown as Translation
+}
+
+function mkAnime(opts: {
+  type?: string | null
+  numberOfEpisodes?: number
+  episodes: EpisodeSummary[]
+}): AnimeDetail {
+  return {
+    id: 1,
+    title: 'Test',
+    titles: { ru: 'Тест', en: 'Test' },
+    type: opts.type ?? null,
+    numberOfEpisodes: opts.numberOfEpisodes ?? 0,
+    episodes: opts.episodes,
+    posterUrl: '',
+    posterUrlSmall: ''
+  } as unknown as AnimeDetail
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof useEpisodeList>[0]> = {}) {
+  setActivePinia(createPinia())
+  const libraryStore = useLibraryStore()
+  return {
+    anime: ref<AnimeDetail | null>(null),
+    getAnimeId: () => 1,
+    getInitialAuthor: () => undefined,
+    translationType: ref('subRu'),
+    selectedAuthor: ref(''),
+    episodeMeta: ref<Record<string, EpisodeMeta[]>>({}),
+    fileStatus: ref({}),
+    downloadGroups: ref(new Map<string, EpisodeGroup>()),
+    watchProgress: ref<Record<string, WatchProgressEntry>>({}),
+    libraryStore,
+    checkFileStatus: vi.fn().mockResolvedValue(undefined),
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  setApi({})
+  // Minimal DOM stubs so applyFocusEpisode (which queries the episode-row by
+  // dataset) can run in the node test environment.
+  ;(globalThis as { document?: { querySelector: () => null } }).document = {
+    querySelector: () => null
+  }
+  ;(globalThis as { CSS?: { escape: (s: string) => string } }).CSS = {
+    escape: (s: string) => s
+  }
+})
+
+describe('useEpisodeList — filtering & paging', () => {
+  it('returns [] before anime is loaded', () => {
+    const list = useEpisodeList(makeDeps())
+    expect(list.filteredEpisodes.value).toEqual([])
+  })
+
+  it('filters to anime.type when matched count equals numberOfEpisodes', () => {
+    const anime = ref<AnimeDetail | null>(
+      mkAnime({
+        type: 'tv',
+        numberOfEpisodes: 2,
+        episodes: [mkEpisode(1, '1', 'tv'), mkEpisode(2, '2', 'tv'), mkEpisode(3, '1.5', 'special')]
+      })
+    )
+    const list = useEpisodeList(makeDeps({ anime }))
+    expect(list.filteredEpisodes.value.map((e) => e.id)).toEqual([1, 2])
+  })
+
+  it('falls back to allActive when type filter does not equal numberOfEpisodes', () => {
+    const anime = ref<AnimeDetail | null>(
+      mkAnime({
+        type: 'tv',
+        numberOfEpisodes: 3,
+        episodes: [mkEpisode(1, '1', 'tv'), mkEpisode(2, '2', 'tv'), mkEpisode(3, '1.5', 'special')]
+      })
+    )
+    const list = useEpisodeList(makeDeps({ anime }))
+    expect(list.filteredEpisodes.value.map((e) => e.id)).toEqual([1, 2, 3])
+  })
+
+  it('preserves fractional episodes (.5) in allActive fallback', () => {
+    const anime = ref<AnimeDetail | null>(
+      mkAnime({
+        type: null,
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '1.5'), mkEpisode(3, '2')]
+      })
+    )
+    const list = useEpisodeList(makeDeps({ anime }))
+    expect(list.filteredEpisodes.value.map((e) => e.episodeInt)).toEqual(['1', '1.5', '2'])
+  })
+
+  it('paginates at PAGE_SIZE=30', () => {
+    const eps: EpisodeSummary[] = []
+    for (let i = 1; i <= 50; i++) eps.push(mkEpisode(i, String(i)))
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const list = useEpisodeList(makeDeps({ anime }))
+    expect(list.isPaginated.value).toBe(true)
+    expect(list.totalPages.value).toBe(2)
+    expect(list.pagedEpisodes.value.length).toBe(30)
+    list.currentPage.value = 1
+    expect(list.pagedEpisodes.value.length).toBe(20)
+  })
+})
+
+describe('useEpisodeList — episodeRows selection priority', () => {
+  function build(opts: {
+    translationType?: string
+    selectedAuthor?: string
+    episodeMeta?: Record<string, EpisodeMeta[]>
+    downloadGroups?: Map<string, EpisodeGroup>
+    watchProgress?: Record<string, WatchProgressEntry>
+    translations: Translation[]
+  }) {
+    const ep = mkEpisode(100, '5', 'tv')
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: [ep] }))
+    const deps = makeDeps({
+      anime,
+      translationType: ref(opts.translationType ?? 'subRu'),
+      selectedAuthor: ref(opts.selectedAuthor ?? ''),
+      episodeMeta: ref(opts.episodeMeta ?? {}),
+      downloadGroups: ref(opts.downloadGroups ?? new Map()),
+      watchProgress: ref(opts.watchProgress ?? {})
+    })
+    const list = useEpisodeList(deps)
+    list.episodes.value = new Map([
+      [
+        100,
+        {
+          ...ep,
+          translations: opts.translations,
+          duration: 1440,
+          mediaInfo: null,
+          translationCount: opts.translations.length
+        } as unknown as EpisodeDetail
+      ]
+    ])
+    return list
+  }
+
+  it('priority 1: queued download locks the row', () => {
+    const groups = new Map<string, EpisodeGroup>([
+      [
+        'Episode 5',
+        {
+          animeName: 'X',
+          episodeLabel: 'Episode 5',
+          translationId: 200,
+          mergeStatus: 'idle',
+          video: { status: 'downloading' }
+        } as unknown as EpisodeGroup
+      ]
+    ])
+    const list = build({
+      translations: [mkTr(200, 'voiceRu', 'A'), mkTr(201, 'subRu', 'B')],
+      downloadGroups: groups
+    })
+    const row = list.episodeRows.value[0]
+    expect(row.isLocked).toBe(true)
+    expect(row.lockSource).toBe('queued')
+    expect(row.selectedTr?.id).toBe(200)
+  })
+
+  it('priority 2: episodeOverrides wins over downloaded & defaults', () => {
+    const list = build({
+      translationType: 'subRu',
+      translations: [mkTr(1, 'subRu', 'A'), mkTr(2, 'subRu', 'B')]
+    })
+    list.episodeOverrides.value = new Map([[100, 2]])
+    expect(list.episodeRows.value[0].selectedTr?.id).toBe(2)
+  })
+
+  it('priority 3: remembered watchProgress translationId wins over downloaded', () => {
+    const list = build({
+      translationType: 'subRu',
+      episodeMeta: {
+        '5': [{ translationId: 1, translationType: 'subRu', author: 'A' } as unknown as EpisodeMeta]
+      },
+      watchProgress: {
+        '5': { position: 0, duration: 0, translationId: 99 } as unknown as WatchProgressEntry
+      },
+      translations: [mkTr(1, 'subRu', 'A'), mkTr(99, 'voiceRu', 'B')]
+    })
+    expect(list.episodeRows.value[0].selectedTr?.id).toBe(99)
+  })
+
+  it('priority 4: any downloaded translation beats global default', () => {
+    const list = build({
+      translationType: 'subRu',
+      selectedAuthor: 'A',
+      episodeMeta: {
+        '5': [
+          { translationId: 50, translationType: 'voiceRu', author: 'A' } as unknown as EpisodeMeta
+        ]
+      },
+      translations: [mkTr(10, 'subRu', 'A'), mkTr(50, 'voiceRu', 'A')]
+    })
+    expect(list.episodeRows.value[0].selectedTr?.id).toBe(50)
+  })
+
+  it('priority 5: global default (translationType + author)', () => {
+    const list = build({
+      translationType: 'subRu',
+      selectedAuthor: 'B',
+      translations: [mkTr(1, 'subRu', 'A'), mkTr(2, 'subRu', 'B')]
+    })
+    expect(list.episodeRows.value[0].selectedTr?.id).toBe(2)
+  })
+
+  it('falls through to first translation of matching type when author missing', () => {
+    const list = build({
+      translationType: 'voiceRu',
+      selectedAuthor: 'Missing',
+      translations: [mkTr(1, 'voiceRu', 'X'), mkTr(2, 'voiceRu', 'Y')]
+    })
+    const row = list.episodeRows.value[0]
+    expect(row.selectedTr?.type).toBe('voiceRu')
+    expect(['X', 'Y']).toContain(row.selectedTr?.authorsSummary)
+  })
+})
+
+describe('useEpisodeList — helpers', () => {
+  it('qualityLabel rounds down', () => {
+    const list = useEpisodeList(makeDeps())
+    expect(list.qualityLabel(1080)).toBe('1080p')
+    expect(list.qualityLabel(900)).toBe('720p')
+    expect(list.qualityLabel(700)).toBe('480p')
+    expect(list.qualityLabel(360)).toBe('360p')
+  })
+
+  it('getRealHeight reads probed quality before reported', () => {
+    const list = useEpisodeList(makeDeps())
+    list.realQuality.value = new Map([[5, 1080]])
+    expect(list.getRealHeight(mkTr(5, 'subRu', 'X', 720))).toBe(1080)
+    expect(list.getRealHeight(mkTr(6, 'subRu', 'Y', 480))).toBe(480)
+  })
+
+  it('bestPerAuthor keeps highest quality per (type, author)', () => {
+    const list = useEpisodeList(makeDeps())
+    const out = list.bestPerAuthor([
+      mkTr(1, 'subRu', 'A', 480),
+      mkTr(2, 'subRu', 'A', 1080),
+      mkTr(3, 'subRu', 'B', 720)
+    ])
+    expect(out.map((t) => t.id).sort()).toEqual([2, 3])
+  })
+})
+
+describe('useEpisodeList — onEpisodeTranslationChange', () => {
+  it('updates overrides and persists via IPC', async () => {
+    const save = vi.fn().mockResolvedValue(undefined)
+    setApi({ watchProgressSave: save })
+    const deps = makeDeps({
+      watchProgress: ref({
+        '3': { position: 60, duration: 1440, translationId: 1 } as unknown as WatchProgressEntry
+      })
+    })
+    const list = useEpisodeList(deps)
+    list.onEpisodeTranslationChange(7, '3', 99)
+    expect(list.episodeOverrides.value.get(7)).toBe(99)
+    expect(save).toHaveBeenCalledWith(1, '3', 60, 1440, undefined, 99)
+  })
+})
+
+describe('useEpisodeList — applyFocusEpisode', () => {
+  it('clears focus when target is not in the list', async () => {
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: [mkEpisode(1, '1')] }))
+    const deps = makeDeps({ anime })
+    const list = useEpisodeList(deps)
+    await list.applyFocusEpisode('999')
+    expect(list.focusApplied.value).toBe(true)
+  })
+
+  it('marks focus applied even if DOM lookup fails', async () => {
+    setApi({
+      getEpisode: vi
+        .fn()
+        .mockImplementation((id: number) =>
+          Promise.resolve({ data: { id, translations: [] } as unknown as EpisodeDetail })
+        ),
+      getSetting: vi.fn().mockResolvedValue(false)
+    })
+    const eps: EpisodeSummary[] = []
+    for (let i = 1; i <= 50; i++) eps.push(mkEpisode(i, String(i)))
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const deps = makeDeps({ anime })
+    const list = useEpisodeList(deps)
+    // target on page 1 (index 35), forces goToPage(1)
+    await list.applyFocusEpisode('35')
+    expect(list.focusApplied.value).toBe(true)
+    expect(list.currentPage.value).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

First sub-slice of **Phase 5 slice 5b** (#118 / epic #84). Per the iterative strategy chosen with the user, this PR extracts the three lowest-risk composables from `AnimeDetailView.vue` **without changing component structure**. The component still lives in one `.vue` file — it just consumes composables for the testable, reusable state machines. Component decomposition into `detail/` sub-components ships later.

`AnimeDetailView.vue`: **3624 → 3260 lines** (~365-line script shrink). Behavior is byte-identical.

## Sub-slicing decision

The original Phase 5 5b plan listed four composables. After exploring the file I flagged that `useEpisodeDownloads` is the most entangled — it wraps file-on-disk state, the download orchestration, watch-progress, continue-watching, and the player payload builders, with cross-dependencies into Shikimori state. Splitting it out cleanly is its own slice. The three composables in this PR are the safer, more independent extractions. Subsequent slices:

- **5b.2** — extract `useEpisodeDownloads`.
- **5b.3** — split components (`detail/{EpisodeList,EpisodeRow,TranslationPicker,ChronologyPanel}.vue`).

## New composables

### `src/renderer/src/composables/use-chronology.ts` (35 L)

Shikimori chronology panel state (`shikiRelated`, `relatedLoading`, `relatedCollapsed`) + `loadRelated(malId)` IPC action. Replaces ~20 lines of inline state + the inline IPC block inside `loadShikimoriData`. Component invokes `loadRelated()` when `anime.value.myAnimeListId` is known.

### `src/renderer/src/composables/use-anime-detail-prefs.ts` (64 L)

Per-anime translation type + selected author refs, `applyDownloadedTranslationDefault(snapshot)` heuristic, `loadInitialTranslationType(initialPrefsValue)`. The snapshot is passed in (not held as a reactive dep) to avoid a circular construction with `useEpisodeList`, which derives `availableAuthors` from `translationType`.

### `src/renderer/src/composables/use-episode-list.ts` (452 L)

The central reactivity surface of `AnimeDetailView`. Owns:

- `episodes` Map, `currentPage`, `realQuality` (probed quality cache), `episodeOverrides`, `focusApplied`, `loadingEpisodes`

Exposes:

- Derived: `filteredEpisodes`, `pagedEpisodes`, `episodeRows` (the **5-priority** selection: queued lock ▸ session override ▸ remembered `watchProgress` ▸ any downloaded ▸ global default), `totalPages`, `isPaginated`, `translationTypeCounts`, `availableAuthors`
- Helpers: `bestPerAuthor`, `getRealHeight`, `qualityLabel` (`bestPerAuthor` closes over `realQuality` via `getRealHeight`, so it's an instance method, not a pure module-level fn)
- Actions: `loadPageEpisodes`, `goToPage`, `probeSelectedQualities`, `onEpisodeTranslationChange`, `applyFocusEpisode`, `resetEpisodeOverrides`
- Constants: `PAGE_SIZE` (re-exported from the module for component use)

## Composable design

- **No `onMounted`/`onUnmounted` inside composables.** The component wires lifecycle. Keeps composables callable from Vitest without a Vue component context. (`useKeyboardShortcuts` from slice 4e does call `onMounted` because it owns a window listener; the 5b.1 composables are pure-logic.)
- **The `episodeRows` priority algorithm is byte-identical to the original.** Only the dep references switch from inline refs to `deps.*` getters. The 5-priority order, the `bestPerAuthor` collapse, the `sorted` ordering, and all type/author tie-breakers are preserved.
- **`useAnimeDetailPrefs` is a self-contained refs holder.** The component runs the `watch` that persists changes to `usePlayerStore.saveAnimePrefs` and calls `resetEpisodeOverrides()` + `probeSelectedQualities()` on prefs change. This keeps the prefs composable from importing the player store.

## Tests (484 lines, 27 new tests, 111 → 138 total)

### `test/renderer/composables/use-chronology.test.ts` (4 tests)

- Defaults (empty list, not loading, collapsed)
- `loadRelated(malId)` IPC happy path + loading-flag transitions
- No-op on `malId === 0`
- Clears loading on IPC failure

### `test/renderer/composables/use-anime-detail-prefs.test.ts` (6 tests)

- Defaults (`'subRu'`, empty author)
- `loadInitialTranslationType` prefers initialPrefs over `getSetting`
- `loadInitialTranslationType` falls back to `getSetting`/`'subRu'`
- `applyDownloadedTranslationDefault` picks highest-frequency `(type, author)` combo
- `applyDownloadedTranslationDefault` only sets author if present in `availableAuthors`
- `applyDownloadedTranslationDefault` is a no-op on empty `episodeMeta`

### `test/renderer/composables/use-episode-list.test.ts` (17 tests)

**Filtering & paging (5):** initial empty state, `anime.type` filter when matched count equals `numberOfEpisodes`, fallback to `allActive` otherwise, **fractional `.5` episodes preserved** ([[feedback_episode_filtering]]), pagination at `PAGE_SIZE=30`.

**Episode-row 5-priority selection (6):** queued lock → in-session override → remembered `watchProgress.translationId` → any downloaded translation → global default → fall-through to first matching type when author missing.

**Helpers (3):** `qualityLabel` rounding, `getRealHeight` probed-over-reported, `bestPerAuthor` collapse.

**Actions (3):** `onEpisodeTranslationChange` updates overrides + persists via IPC; `applyFocusEpisode` clears focus on missing target and on multi-page jumps.

The test file installs minimal `document` + `CSS.escape` stubs so the DOM-touching `applyFocusEpisode` path can run in the node test environment.

## AnimeDetailView integration

The component:

1. Constructs `prefs = useAnimeDetailPrefs()`, `chronology = useChronology()`, and `episodeList = useEpisodeList({...})` at the top of `<script setup>`.
2. Owns the shared dep refs at the component level (`anime`, `episodeMeta`, `fileStatus`, `downloadGroups`, `watchProgress`) so both `useEpisodeList` (reads) and the component's download orchestration (writes via `checkFileStatus`, `loadWatchProgress`, `updateDownloadGroups`) share the same source of truth.
3. Replaces the inline `applyDownloadedTranslationDefault()` wrapper with a thin shim calling `prefs.applyDownloadedTranslationDefault({ episodeMeta: episodeMeta.value, availableAuthors: availableAuthors.value })`.
4. Replaces the inline `relatedLoading.value = true; window.api.shikimoriGetRelated(...).then(...)` block in `loadShikimoriData` with `chronology.loadRelated(malId)`.
5. Keeps the `watch([translationType, selectedAuthor], …)` watcher; it now calls `resetEpisodeOverrides()` (composable method) instead of mutating `episodeOverrides.value` directly.
6. The `watch([() => props.focusEpisodeInt, filteredEpisodes, loadingEpisodes], …)` watcher with `immediate: true` is unchanged and continues to drive `applyFocusEpisode`.

## Out of scope

- `useEpisodeDownloads` (next slice 5b.2).
- Component decomposition (5b.3).
- Any behavior, UI, or persistence change.
- Player code (`PlayerView.vue` is unchanged). Smoke noted a small delay on MKV seek — that's the documented ffmpeg respawn behavior on unbuffered seeks (CLAUDE.md, "Stream MKV Playback Without Full Remux Wait"), not introduced by this PR.

## Quality gate

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; 8 pre-existing warnings in `main/index.ts` and `AnimeDetailView.vue`, unchanged)
- `npm run format:check` ✓
- `npm run test` ✓ — **138/138 passing** (111 prior + 27 new)
- `npm run build` ✓
- `bash scripts/check-subscription-contract.sh` ✓ — no `removeAllListeners` / `window.api.off*`

## Test plan

- [ ] **Episode list renders** with the same content as before. Pagination kicks in for shows >30 episodes.
- [ ] **Fractional `.5` episodes still listed** ([[feedback_episode_filtering]]).
- [ ] **Translation/author dropdowns** update each row's selection per the 5-priority logic.
- [ ] **Per-episode override** via row dropdown persists across page reload (watchProgress remembers).
- [ ] **Download orchestration** still locks rows with the queued lock-source (Priority 1).
- [ ] **Continue watching** jumps to the right page + row + plays (downloaded → openFile, otherwise → playStream).
- [ ] **Focus episode** from Home (Resume/Next-up row) lands on the right episode + scrolls into view.
- [ ] **Quality probe** runs on selected translations after page load; background full scan if `backgroundQualityProbe` enabled.
- [ ] **Chronology panel** loads related anime for shows with a Shikimori `myAnimeListId`.
- [ ] **Shikimori panel** (rate/status/episodes/score/save) unchanged.
- [ ] **Skip detection + chapter inject** unchanged.
- [ ] Switch between anime detail views — no leaked listeners (`onFileEpisodesChanged`, skip-detector progress, chapter-inject progress disposed on unmount).

Part of #84 (Phase 5 slice 5b.1).