### PR TITLE
refactor: Phase 5 slice 5b.2 — useEpisodeDownloads composable (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -421,6 +421,26 @@ Global app glue that doesn't belong on a Pinia store goes into
   `onEpisodeTranslationChange`, `applyFocusEpisode`, `resetEpisodeOverrides`).
   Lifecycle hooks are *not* registered here — the consumer wires `onMounted` /
   watchers — which keeps the composable callable from Vitest. (Phase 5 slice 5b.1)
+- `useEpisodeDownloads({ anime, episodeMeta, fileStatus, downloadGroups, watchProgress, …, shiki*, downloadsStore, playerStore, playerMode, … })`
+  — file-on-disk helpers, download orchestration, watch progress, and
+  continue-watching. Owns only the transient flags `downloading` +
+  `errorMessage`; the data refs live at the component level so both this
+  composable and `useEpisodeList` can read them without circular construction.
+  Exposes:
+  helpers (`episodeProgressPercent`, `isEpisodeWatched`, `getFileForTranslation`,
+  `hasAnyFile`, `selectedTrHasFile`, `buildTranslationList`, `buildAllEpisodes`,
+  `dlProgress`, `getGroup`, `downloadGroupChanged`);
+  computeds (`continueTarget`, `continueReady`, `continueLabel`,
+  `hasActiveDownloads`);
+  actions (`loadWatchProgress`, `checkFileStatus`, `updateDownloadGroups`,
+  `downloadAll`, `downloadEpisode`, `cancelEpisodeDownload`,
+  `cancelAllDownloads`, `openFile`, `playStream`, `showInFolder`, `deleteFile`,
+  `continueWatching`);
+  subscription (`subscribeFileEpisodesChanged`).
+  `continueTarget` implements the 4-priority continue-watching algorithm
+  (Shikimori-completed → eps[0] rewatch; Shikimori reports N → eps[N+1]; most
+  recent unfinished saved position; first ep after last watched; else last ep).
+  (Phase 5 slice 5b.2)
 
 Composables that own broadcast subscriptions or DOM listeners (like
 `useKeyboardShortcuts`) bind those inside themselves; pure-logic composables

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -1,12 +1,6 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed, watch, nextTick } from 'vue';
-import {
-  formatBytes,
-  formatSpeed,
-  formatEta,
-  getAnimeName as _getAnimeName,
-  sanitizeFilename
-} from '../utils';
+import { ref, onMounted, onUnmounted, computed, watch } from 'vue';
+import { formatSpeed, formatEta, getAnimeName as _getAnimeName } from '../utils';
 import CleanupModal from './CleanupModal.vue';
 import { useLibraryStore } from '../stores/library';
 import { usePlayerStore } from '../stores/player';
@@ -15,7 +9,8 @@ import { useDownloadsStore } from '../stores/downloads';
 import { storeToRefs } from 'pinia';
 import { useAnimeDetailPrefs } from '../composables/use-anime-detail-prefs';
 import { useChronology } from '../composables/use-chronology';
-import { useEpisodeList, PAGE_SIZE, type EpisodeRow } from '../composables/use-episode-list';
+import { useEpisodeList, PAGE_SIZE } from '../composables/use-episode-list';
+import { useEpisodeDownloads } from '../composables/use-episode-downloads';
 
 const props = defineProps<{
   animeId: number;
@@ -214,6 +209,61 @@ const friendsSummary = computed(() => {
 });
 
 const playerMode = ref<'system' | 'builtin'>('system');
+
+const downloads = useEpisodeDownloads({
+  anime,
+  getAnimeId: () => props.animeId,
+  getAnimeName: () => getAnimeName(),
+  episodeMeta,
+  fileStatus,
+  downloadGroups,
+  watchProgress,
+  filteredEpisodes,
+  episodes,
+  episodeRows,
+  getRealHeight,
+  currentPage,
+  isPaginated,
+  goToPage,
+  loadingEpisodes,
+  shikiRate,
+  shikiUser,
+  shikiEpisodes,
+  shikiUserChecked,
+  shikiLoading,
+  downloadsStore,
+  playerStore,
+  playerMode,
+  pageSize: PAGE_SIZE
+});
+
+const {
+  downloading,
+  errorMessage,
+  continueReady,
+  continueLabel,
+  hasActiveDownloads,
+  episodeProgressPercent,
+  isEpisodeWatched,
+  getFileForTranslation,
+  hasAnyFile,
+  selectedTrHasFile,
+  dlProgress,
+  getGroup,
+  loadWatchProgress,
+  checkFileStatus,
+  updateDownloadGroups,
+  downloadAll,
+  downloadEpisode,
+  cancelEpisodeDownload,
+  cancelAllDownloads,
+  openFile,
+  playStream,
+  showInFolder,
+  deleteFile,
+  continueWatching,
+  subscribeFileEpisodesChanged
+} = downloads;
 
 const TRANSLATION_TYPES = [
   { value: 'subRu', label: 'Russian Subtitles', short: 'RU SUB', color: '#6ab04c' },
@@ -508,23 +558,7 @@ onMounted(async () => {
 
   // Subscribe to background file rescan updates (component-local — keyed off
   // the currently displayed anime name).
-  unsubFileEpisodesChanged = window.api.onFileEpisodesChanged((animeName, data) => {
-    if (anime.value && animeName === getAnimeName()) {
-      const episodeInts = filteredEpisodes.value.map((ep) => ep.episodeInt);
-      const baseMap = new Map<string, string>();
-      for (const epInt of episodeInts) {
-        const padded = epInt.padStart(2, '0');
-        const base = sanitizeFilename(`${animeName} - ${padded}`);
-        baseMap.set(base, epInt);
-      }
-      const filtered: typeof fileStatus.value = {};
-      for (const [base, files] of Object.entries(data)) {
-        const epInt = baseMap.get(base);
-        if (epInt) filtered[epInt] = files;
-      }
-      fileStatus.value = filtered;
-    }
-  });
+  unsubFileEpisodesChanged = subscribeFileEpisodesChanged();
 
   // Load Shikimori data (non-blocking — don't hold up the episode list)
   loadShikimoriData();
@@ -663,108 +697,6 @@ function applyDownloadedTranslationDefault(): void {
   });
 }
 
-async function loadWatchProgress(): Promise<void> {
-  try {
-    watchProgress.value = await window.api.watchProgressGetAll(props.animeId);
-  } catch (err) {
-    console.error('Failed to load watch progress:', err);
-  }
-}
-
-function episodeProgressPercent(episodeInt: string): number {
-  const entry = watchProgress.value[episodeInt];
-  if (!entry || !entry.duration) return 0;
-  const pct = Math.min(100, Math.round((entry.position / entry.duration) * 100));
-  return pct < 2 ? 0 : pct;
-}
-
-function isEpisodeWatched(episodeInt: string): boolean {
-  if (shikiRate.value?.status === 'completed') return true;
-  return !!watchProgress.value[episodeInt]?.watched;
-}
-
-const continueTarget = computed((): EpisodeSummary | null => {
-  const eps = filteredEpisodes.value;
-  if (eps.length === 0) return null;
-
-  // Completed → "Continue" means "start rewatching from ep 1". Without this the
-  // shikiEpisodes >= eps.length branch below would land on the last episode.
-  if (shikiRate.value?.status === 'completed') {
-    return eps[0];
-  }
-
-  // 1) If Shikimori reports N completed episodes, jump to episode N+1.
-  // Shikimori is authoritative — ignore local saved positions for earlier episodes.
-  if (shikiUser.value && shikiEpisodes.value > 0 && shikiEpisodes.value < eps.length) {
-    return eps[shikiEpisodes.value];
-  }
-
-  // 2) Prefer an episode with an unfinished saved position (most recent).
-  let bestResume: EpisodeSummary | null = null;
-  let bestUpdatedAt = 0;
-  for (const ep of eps) {
-    const entry = watchProgress.value[ep.episodeInt];
-    if (!entry || entry.watched) continue;
-    if (!entry.position || !entry.duration) continue;
-    if (entry.updatedAt > bestUpdatedAt) {
-      bestUpdatedAt = entry.updatedAt;
-      bestResume = ep;
-    }
-  }
-  if (bestResume) return bestResume;
-
-  // 3) First episode after the last locally-watched one.
-  let lastWatchedIdx = -1;
-  for (let i = 0; i < eps.length; i++) {
-    if (isEpisodeWatched(eps[i].episodeInt)) lastWatchedIdx = i;
-  }
-  const nextIdx = lastWatchedIdx + 1;
-  if (nextIdx < eps.length) return eps[nextIdx];
-
-  // 4) Everything watched — fall back to the last episode.
-  return eps[eps.length - 1];
-});
-
-const continueReady = computed((): boolean => {
-  if (!anime.value || filteredEpisodes.value.length === 0) return false;
-  if (loadingEpisodes.value) return false;
-  if (anime.value.myAnimeListId && !shikiUserChecked.value) return false;
-  if (shikiUser.value && shikiLoading.value) return false;
-  return continueTarget.value !== null;
-});
-
-const continueLabel = computed((): string => {
-  const target = continueTarget.value;
-  if (!target) return 'Continue';
-  const entry = watchProgress.value[target.episodeInt];
-  const verb = entry && entry.position > 0 && !entry.watched ? 'Resume' : 'Continue';
-  return `${verb} · Ep ${target.episodeInt}`;
-});
-
-async function continueWatching(): Promise<void> {
-  const target = continueTarget.value;
-  if (!target) return;
-
-  const eps = filteredEpisodes.value;
-  const targetIdx = eps.findIndex((e) => e.episodeInt === target.episodeInt);
-  if (targetIdx < 0) return;
-
-  const targetPage = isPaginated.value ? Math.floor(targetIdx / PAGE_SIZE) : 0;
-  if (targetPage !== currentPage.value) {
-    await goToPage(targetPage);
-  }
-  await nextTick();
-
-  const row = episodeRows.value.find((r) => r.episode.episodeInt === target.episodeInt);
-  if (!row || !row.selectedTr) return;
-
-  if (selectedTrHasFile(row)) {
-    await openFile(row);
-  } else {
-    await playStream(row);
-  }
-}
-
 async function toggleStar(): Promise<void> {
   if (!anime.value) return;
   const stripped: AnimeSearchResult = {
@@ -835,9 +767,6 @@ async function onCleanupDeleted(): Promise<void> {
   await checkFileStatus();
 }
 
-const downloading = ref(false);
-const errorMessage = ref('');
-
 watch(
   [() => props.focusEpisodeInt, filteredEpisodes, loadingEpisodes],
   async () => {
@@ -853,121 +782,6 @@ watch(
 function getAnimeName(): string {
   if (!anime.value) return '';
   return _getAnimeName(anime.value);
-}
-
-async function checkToken(): Promise<boolean> {
-  const token = (await window.api.getSetting('token')) as string;
-  if (!token) {
-    errorMessage.value = 'API token is required for downloads. Set it in Settings.';
-    setTimeout(() => {
-      errorMessage.value = '';
-    }, 5000);
-    return false;
-  }
-  return true;
-}
-
-async function downloadAll(): Promise<void> {
-  if (!anime.value) return;
-  if (!(await checkToken())) return;
-
-  const name = getAnimeName();
-  const requests: DownloadRequest[] = [];
-
-  for (const row of episodeRows.value) {
-    if (row.selectedTr && !row.isLocked && !selectedTrHasFile(row)) {
-      requests.push({
-        translationId: row.selectedTr.id,
-        height: getRealHeight(row.selectedTr),
-        animeName: name,
-        episodeLabel: row.episode.episodeFull,
-        episodeInt: row.episode.episodeInt,
-        animeId: anime.value!.id,
-        translationType: row.selectedTr.type,
-        author: row.selectedTr.authorsSummary
-      });
-    }
-  }
-
-  if (requests.length === 0) return;
-  downloading.value = true;
-  try {
-    await window.api.downloadedAnimeAdd(JSON.parse(JSON.stringify(anime.value)));
-    await window.api.downloadEnqueue(requests);
-  } finally {
-    downloading.value = false;
-  }
-}
-
-async function downloadEpisode(row: EpisodeRow): Promise<void> {
-  if (!row.selectedTr || !anime.value) return;
-  if (!(await checkToken())) return;
-
-  await window.api.downloadedAnimeAdd(JSON.parse(JSON.stringify(anime.value)));
-  await window.api.downloadEnqueue([
-    {
-      translationId: row.selectedTr.id,
-      height: getRealHeight(row.selectedTr),
-      animeName: getAnimeName(),
-      episodeLabel: row.episode.episodeFull,
-      episodeInt: row.episode.episodeInt,
-      animeId: anime.value!.id,
-      translationType: row.selectedTr.type,
-      author: row.selectedTr.authorsSummary
-    }
-  ]);
-}
-
-function downloadGroupChanged(a: EpisodeGroup | undefined, b: EpisodeGroup | undefined): boolean {
-  if (!a && !b) return false;
-  if (!a || !b) return true;
-  if (a.mergeStatus !== b.mergeStatus || a.mergePercent !== b.mergePercent) return true;
-  const av = a.video,
-    bv = b.video;
-  if (!av && !bv) return false;
-  if (!av || !bv) return true;
-  return (
-    av.status !== bv.status ||
-    av.bytesReceived !== bv.bytesReceived ||
-    av.totalBytes !== bv.totalBytes ||
-    av.speed !== bv.speed
-  );
-}
-
-function updateDownloadGroups(groups: EpisodeGroup[]): void {
-  const prev = downloadGroups.value;
-  const map = new Map<string, EpisodeGroup>();
-  let newlyCompleted = false;
-  let changed = false;
-  for (const g of groups) {
-    if (g.animeName === getAnimeName()) {
-      map.set(g.episodeLabel, g);
-      const old = prev.get(g.episodeLabel);
-      if (downloadGroupChanged(old, g)) changed = true;
-      if (g.mergeStatus === 'completed' && old?.mergeStatus !== 'completed') {
-        newlyCompleted = true;
-      }
-      if (g.video?.status === 'completed' && old?.video?.status !== 'completed') {
-        newlyCompleted = true;
-      }
-    }
-  }
-  // Also detect removals (prev had entries that new map doesn't)
-  if (prev.size !== map.size) changed = true;
-  if (!changed) return;
-  downloadGroups.value = map;
-  if (newlyCompleted) {
-    checkFileStatus();
-  }
-}
-
-function dlProgress(item: DownloadProgressItem | null): number {
-  if (!item || item.totalBytes <= 0) return 0;
-  return (item.bytesReceived / item.totalBytes) * 100;
-}
-
-function getGroup(episodeFull: string): EpisodeGroup | undefined {
-  return downloadGroups.value.get(episodeFull);
 }
 
 watch([translationType, selectedAuthor], () => {
@@ -995,182 +809,6 @@ async function onPosterError(): Promise<void> {
   posterFallbackAttempted.value = true;
   const cached = await window.api.getCachedPoster(props.animeId);
   if (cached) posterSrc.value = cached;
-}
-
-async function checkFileStatus(): Promise<void> {
-  if (!anime.value || filteredEpisodes.value.length === 0) return;
-  const name = getAnimeName();
-  const episodeInts = filteredEpisodes.value.map((ep) => ep.episodeInt);
-  fileStatus.value = await window.api.fileCheckEpisodes(name, episodeInts);
-  episodeMeta.value = await window.api.downloadedEpisodesGet(props.animeId);
-}
-
-function buildTranslationList(
-  row: EpisodeRow | undefined
-): { id: number; label: string; type: string; height: number }[] {
-  if (!row) return [];
-  return row.allTranslations.map((tr) => ({
-    id: tr.id,
-    label: tr.authorsSummary,
-    type: tr.type,
-    height: getRealHeight(tr)
-  }));
-}
-
-function buildAllEpisodes(): {
-  episodeInt: string;
-  episodeFull: string;
-  translations: { id: number; label: string; type: string; height: number }[];
-  downloadedTrIds: number[];
-}[] {
-  return filteredEpisodes.value.map((ep) => {
-    const detail = episodes.value.get(ep.id);
-    const translations = detail
-      ? detail.translations
-          .filter((t) => t.isActive === 1)
-          .map((t) => ({
-            id: t.id,
-            label: t.authorsSummary,
-            type: t.type,
-            height: getRealHeight(t)
-          }))
-      : [];
-    const metas = episodeMeta.value[ep.episodeInt] || [];
-    const downloadedTrIds = metas.map((m) => m.translationId);
-    return {
-      episodeInt: ep.episodeInt,
-      episodeFull: ep.episodeFull,
-      translations,
-      downloadedTrIds
-    };
-  });
-}
-
-function getFileForTranslation(
-  episodeInt: string,
-  translationId: number | undefined
-): { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string } | null {
-  const files = fileStatus.value[episodeInt];
-  if (!files || files.length === 0) return null;
-  // Find file matching the translation's author via metadata
-  if (translationId) {
-    const metas = episodeMeta.value[episodeInt] || [];
-    const meta = metas.find((m) => m.translationId === translationId);
-    if (meta) {
-      // Match by author tag
-      const authorTag = sanitizeFilename(meta.author);
-      const match = files.find((f) => f.author === authorTag);
-      if (match) return match;
-      // Legacy file (no author tag) — only match if it's the sole metadata entry
-      if (metas.length === 1 && files.length === 1 && !files[0].author) {
-        return files[0];
-      }
-    }
-  }
-  // No specific match found
-  return null;
-}
-
-function hasAnyFile(episodeInt: string): boolean {
-  const files = fileStatus.value[episodeInt];
-  return !!files && files.length > 0;
-}
-
-function selectedTrHasFile(row: EpisodeRow): boolean {
-  if (!row.selectedTr) return false;
-  return !!getFileForTranslation(row.episode.episodeInt, row.selectedTr.id);
-}
-
-async function openFile(row: EpisodeRow): Promise<void> {
-  if (!row.selectedTr) return;
-  const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id);
-  if (!info) return;
-
-  if (playerMode.value === 'builtin') {
-    const name = anime.value ? getAnimeName() : '';
-    const localSubs = await window.api.playerGetLocalSubtitles(info.filePath);
-    const allEps = buildAllEpisodes();
-    const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt);
-    playerStore.openPlayer({
-      filePath: info.filePath,
-      streamUrl: '',
-      subtitleContent: localSubs || '',
-      animeName: name,
-      episodeLabel: row.episode.episodeInt,
-      availableStreams: [],
-      translationId: row.selectedTr.id,
-      translations: buildTranslationList(row),
-      downloadedTrIds: [...row.downloadedTrIds],
-      allEpisodes: allEps,
-      episodeIndex: epIdx,
-      animeId: props.animeId,
-      malId: anime.value?.myAnimeListId ?? 0
-    });
-  } else {
-    const result = await window.api.fileOpen(info.filePath);
-    if (result) {
-      errorMessage.value = result;
-      await checkFileStatus();
-    }
-  }
-}
-
-async function playStream(row: EpisodeRow): Promise<void> {
-  if (!row.selectedTr) return;
-  const name = anime.value ? getAnimeName() : '';
-  const result = await window.api.playerGetStreamUrl(
-    row.selectedTr.id,
-    getRealHeight(row.selectedTr)
-  );
-  if (result) {
-    const allEps = buildAllEpisodes();
-    const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt);
-    playerStore.openPlayer({
-      filePath: '',
-      streamUrl: result.streamUrl,
-      subtitleContent: result.subtitleContent || '',
-      animeName: name,
-      episodeLabel: row.episode.episodeInt,
-      availableStreams: result.availableStreams,
-      translationId: row.selectedTr.id,
-      translations: buildTranslationList(row),
-      downloadedTrIds: [...row.downloadedTrIds],
-      allEpisodes: allEps,
-      episodeIndex: epIdx,
-      animeId: props.animeId,
-      malId: anime.value?.myAnimeListId ?? 0
-    });
-  }
-}
-
-function showInFolder(row: EpisodeRow): void {
-  if (!row.selectedTr) return;
-  const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id);
-  if (!info) return;
-  window.api.fileShowInFolder(info.filePath);
-}
-
-async function deleteFile(row: EpisodeRow): Promise<void> {
-  if (!row.selectedTr) return;
-  const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id);
-  if (!info) return;
-  await window.api.fileDeleteEpisode(
-    getAnimeName(),
-    row.episode.episodeInt,
-    props.animeId,
-    row.selectedTr.id
-  );
-  await checkFileStatus();
-}
-
-async function cancelEpisodeDownload(episodeLabel: string): Promise<void> {
-  await window.api.downloadCancelByEpisode(getAnimeName(), episodeLabel);
-}
-
-const hasActiveDownloads = computed(() => downloadGroups.value.size > 0);
-
-async function cancelAllDownloads(): Promise<void> {
-  await window.api.downloadCancelByEpisode(getAnimeName());
 }
 
 function translationTypeLabel(type: string): string {

--- a/src/renderer/src/composables/use-episode-downloads.ts
+++ b/src/renderer/src/composables/use-episode-downloads.ts
@@ -1,0 +1,544 @@
+// File-on-disk helpers, download orchestration, watch progress, and
+// continue-watching for AnimeDetailView. Phase 5 slice 5b.2 (#118).
+//
+// Owns only the transient flags `downloading` + `errorMessage`. The data refs
+// (episodeMeta, fileStatus, downloadGroups, watchProgress) live at the
+// component level so both this composable and useEpisodeList can read them
+// without a circular construction. The composable's job is the actions +
+// helpers + computeds derived from those refs.
+//
+// Lifecycle hooks are NOT registered here — the component wires its own
+// onMounted/onUnmounted around `subscribeFileEpisodesChanged()`. Keeps the
+// composable callable from Vitest without a Vue component context.
+
+import { ref, computed, nextTick, type Ref, type ComputedRef } from 'vue'
+import { sanitizeFilename } from '../utils'
+import type { EpisodeRow } from './use-episode-list'
+import type { useDownloadsStore } from '../stores/downloads'
+import type { usePlayerStore } from '../stores/player'
+
+type FileEntry = {
+  type: 'mkv' | 'mp4'
+  filePath: string
+  translationId?: number
+  author?: string
+}
+
+type TranslationListEntry = { id: number; label: string; type: string; height: number }
+
+type AllEpisodesEntry = {
+  episodeInt: string
+  episodeFull: string
+  translations: TranslationListEntry[]
+  downloadedTrIds: number[]
+}
+
+export function useEpisodeDownloads(deps: {
+  anime: Ref<AnimeDetail | null>
+  getAnimeId: () => number
+  getAnimeName: () => string
+  // Component-owned data refs (write access)
+  episodeMeta: Ref<Record<string, EpisodeMeta[]>>
+  fileStatus: Ref<Record<string, FileEntry[]>>
+  downloadGroups: Ref<Map<string, EpisodeGroup>>
+  watchProgress: Ref<Record<string, WatchProgressEntry>>
+  // From useEpisodeList
+  filteredEpisodes: ComputedRef<EpisodeSummary[]>
+  episodes: Ref<Map<number, EpisodeDetail>>
+  episodeRows: ComputedRef<EpisodeRow[]>
+  getRealHeight: (tr: Translation) => number
+  currentPage: Ref<number>
+  isPaginated: ComputedRef<boolean>
+  goToPage: (page: number) => Promise<void>
+  loadingEpisodes: Ref<boolean>
+  // From component Shikimori state
+  shikiRate: Ref<ShikiUserRate | null>
+  shikiUser: Ref<ShikiUser | null>
+  shikiEpisodes: Ref<number>
+  shikiUserChecked: Ref<boolean>
+  shikiLoading: Ref<boolean>
+  // Stores + settings
+  downloadsStore: ReturnType<typeof useDownloadsStore>
+  playerStore: ReturnType<typeof usePlayerStore>
+  playerMode: Ref<'system' | 'builtin'>
+  pageSize: number
+}): {
+  downloading: Ref<boolean>
+  errorMessage: Ref<string>
+  continueTarget: ComputedRef<EpisodeSummary | null>
+  continueReady: ComputedRef<boolean>
+  continueLabel: ComputedRef<string>
+  hasActiveDownloads: ComputedRef<boolean>
+  episodeProgressPercent: (episodeInt: string) => number
+  isEpisodeWatched: (episodeInt: string) => boolean
+  getFileForTranslation: (episodeInt: string, translationId: number | undefined) => FileEntry | null
+  hasAnyFile: (episodeInt: string) => boolean
+  selectedTrHasFile: (row: EpisodeRow) => boolean
+  buildTranslationList: (row: EpisodeRow | undefined) => TranslationListEntry[]
+  buildAllEpisodes: () => AllEpisodesEntry[]
+  dlProgress: (item: DownloadProgressItem | null) => number
+  getGroup: (episodeFull: string) => EpisodeGroup | undefined
+  downloadGroupChanged: (a: EpisodeGroup | undefined, b: EpisodeGroup | undefined) => boolean
+  loadWatchProgress: () => Promise<void>
+  checkFileStatus: () => Promise<void>
+  updateDownloadGroups: (groups: EpisodeGroup[]) => void
+  downloadAll: () => Promise<void>
+  downloadEpisode: (row: EpisodeRow) => Promise<void>
+  cancelEpisodeDownload: (episodeLabel: string) => Promise<void>
+  cancelAllDownloads: () => Promise<void>
+  openFile: (row: EpisodeRow) => Promise<void>
+  playStream: (row: EpisodeRow) => Promise<void>
+  showInFolder: (row: EpisodeRow) => void
+  deleteFile: (row: EpisodeRow) => Promise<void>
+  continueWatching: () => Promise<void>
+  subscribeFileEpisodesChanged: () => Unsubscribe
+} {
+  const downloading = ref(false)
+  const errorMessage = ref('')
+
+  async function loadWatchProgress(): Promise<void> {
+    try {
+      deps.watchProgress.value = await window.api.watchProgressGetAll(deps.getAnimeId())
+    } catch (err) {
+      console.error('Failed to load watch progress:', err)
+    }
+  }
+
+  function episodeProgressPercent(episodeInt: string): number {
+    const entry = deps.watchProgress.value[episodeInt]
+    if (!entry || !entry.duration) return 0
+    const pct = Math.min(100, Math.round((entry.position / entry.duration) * 100))
+    return pct < 2 ? 0 : pct
+  }
+
+  function isEpisodeWatched(episodeInt: string): boolean {
+    if (deps.shikiRate.value?.status === 'completed') return true
+    return !!deps.watchProgress.value[episodeInt]?.watched
+  }
+
+  const continueTarget = computed<EpisodeSummary | null>(() => {
+    const eps = deps.filteredEpisodes.value
+    if (eps.length === 0) return null
+
+    // Completed → "Continue" means "start rewatching from ep 1". Without this
+    // the shikiEpisodes >= eps.length branch below would land on the last
+    // episode.
+    if (deps.shikiRate.value?.status === 'completed') {
+      return eps[0]
+    }
+
+    // 1) If Shikimori reports N completed episodes, jump to episode N+1.
+    // Shikimori is authoritative — ignore local saved positions for earlier
+    // episodes.
+    if (
+      deps.shikiUser.value &&
+      deps.shikiEpisodes.value > 0 &&
+      deps.shikiEpisodes.value < eps.length
+    ) {
+      return eps[deps.shikiEpisodes.value]
+    }
+
+    // 2) Prefer an episode with an unfinished saved position (most recent).
+    let bestResume: EpisodeSummary | null = null
+    let bestUpdatedAt = 0
+    for (const ep of eps) {
+      const entry = deps.watchProgress.value[ep.episodeInt]
+      if (!entry || entry.watched) continue
+      if (!entry.position || !entry.duration) continue
+      if (entry.updatedAt > bestUpdatedAt) {
+        bestUpdatedAt = entry.updatedAt
+        bestResume = ep
+      }
+    }
+    if (bestResume) return bestResume
+
+    // 3) First episode after the last locally-watched one.
+    let lastWatchedIdx = -1
+    for (let i = 0; i < eps.length; i++) {
+      if (isEpisodeWatched(eps[i].episodeInt)) lastWatchedIdx = i
+    }
+    const nextIdx = lastWatchedIdx + 1
+    if (nextIdx < eps.length) return eps[nextIdx]
+
+    // 4) Everything watched — fall back to the last episode.
+    return eps[eps.length - 1]
+  })
+
+  const continueReady = computed<boolean>(() => {
+    if (!deps.anime.value || deps.filteredEpisodes.value.length === 0) return false
+    if (deps.loadingEpisodes.value) return false
+    if (deps.anime.value.myAnimeListId && !deps.shikiUserChecked.value) return false
+    if (deps.shikiUser.value && deps.shikiLoading.value) return false
+    return continueTarget.value !== null
+  })
+
+  const continueLabel = computed<string>(() => {
+    const target = continueTarget.value
+    if (!target) return 'Continue'
+    const entry = deps.watchProgress.value[target.episodeInt]
+    const verb = entry && entry.position > 0 && !entry.watched ? 'Resume' : 'Continue'
+    return `${verb} · Ep ${target.episodeInt}`
+  })
+
+  async function checkFileStatus(): Promise<void> {
+    if (!deps.anime.value || deps.filteredEpisodes.value.length === 0) return
+    const name = deps.getAnimeName()
+    const episodeInts = deps.filteredEpisodes.value.map((ep) => ep.episodeInt)
+    deps.fileStatus.value = await window.api.fileCheckEpisodes(name, episodeInts)
+    deps.episodeMeta.value = await window.api.downloadedEpisodesGet(deps.getAnimeId())
+  }
+
+  function buildTranslationList(row: EpisodeRow | undefined): TranslationListEntry[] {
+    if (!row) return []
+    return row.allTranslations.map((tr) => ({
+      id: tr.id,
+      label: tr.authorsSummary,
+      type: tr.type,
+      height: deps.getRealHeight(tr)
+    }))
+  }
+
+  function buildAllEpisodes(): AllEpisodesEntry[] {
+    return deps.filteredEpisodes.value.map((ep) => {
+      const detail = deps.episodes.value.get(ep.id)
+      const translations = detail
+        ? detail.translations
+            .filter((t) => t.isActive === 1)
+            .map((t) => ({
+              id: t.id,
+              label: t.authorsSummary,
+              type: t.type,
+              height: deps.getRealHeight(t)
+            }))
+        : []
+      const metas = deps.episodeMeta.value[ep.episodeInt] || []
+      const downloadedTrIds = metas.map((m) => m.translationId)
+      return {
+        episodeInt: ep.episodeInt,
+        episodeFull: ep.episodeFull,
+        translations,
+        downloadedTrIds
+      }
+    })
+  }
+
+  function getFileForTranslation(
+    episodeInt: string,
+    translationId: number | undefined
+  ): FileEntry | null {
+    const files = deps.fileStatus.value[episodeInt]
+    if (!files || files.length === 0) return null
+    // Find file matching the translation's author via metadata
+    if (translationId) {
+      const metas = deps.episodeMeta.value[episodeInt] || []
+      const meta = metas.find((m) => m.translationId === translationId)
+      if (meta) {
+        // Match by author tag
+        const authorTag = sanitizeFilename(meta.author)
+        const match = files.find((f) => f.author === authorTag)
+        if (match) return match
+        // Legacy file (no author tag) — only match if it's the sole metadata
+        // entry
+        if (metas.length === 1 && files.length === 1 && !files[0].author) {
+          return files[0]
+        }
+      }
+    }
+    // No specific match found
+    return null
+  }
+
+  function hasAnyFile(episodeInt: string): boolean {
+    const files = deps.fileStatus.value[episodeInt]
+    return !!files && files.length > 0
+  }
+
+  function selectedTrHasFile(row: EpisodeRow): boolean {
+    if (!row.selectedTr) return false
+    return !!getFileForTranslation(row.episode.episodeInt, row.selectedTr.id)
+  }
+
+  function downloadGroupChanged(a: EpisodeGroup | undefined, b: EpisodeGroup | undefined): boolean {
+    if (!a && !b) return false
+    if (!a || !b) return true
+    if (a.mergeStatus !== b.mergeStatus || a.mergePercent !== b.mergePercent) return true
+    const av = a.video,
+      bv = b.video
+    if (!av && !bv) return false
+    if (!av || !bv) return true
+    return (
+      av.status !== bv.status ||
+      av.bytesReceived !== bv.bytesReceived ||
+      av.totalBytes !== bv.totalBytes ||
+      av.speed !== bv.speed
+    )
+  }
+
+  function updateDownloadGroups(groups: EpisodeGroup[]): void {
+    const prev = deps.downloadGroups.value
+    const map = new Map<string, EpisodeGroup>()
+    let newlyCompleted = false
+    let changed = false
+    const animeName = deps.getAnimeName()
+    for (const g of groups) {
+      if (g.animeName === animeName) {
+        map.set(g.episodeLabel, g)
+        const old = prev.get(g.episodeLabel)
+        if (downloadGroupChanged(old, g)) changed = true
+        if (g.mergeStatus === 'completed' && old?.mergeStatus !== 'completed') {
+          newlyCompleted = true
+        }
+        if (g.video?.status === 'completed' && old?.video?.status !== 'completed') {
+          newlyCompleted = true
+        }
+      }
+    }
+    // Also detect removals (prev had entries that new map doesn't)
+    if (prev.size !== map.size) changed = true
+    if (!changed) return
+    deps.downloadGroups.value = map
+    if (newlyCompleted) {
+      void checkFileStatus()
+    }
+  }
+
+  function dlProgress(item: DownloadProgressItem | null): number {
+    if (!item || item.totalBytes <= 0) return 0
+    return (item.bytesReceived / item.totalBytes) * 100
+  }
+
+  function getGroup(episodeFull: string): EpisodeGroup | undefined {
+    return deps.downloadGroups.value.get(episodeFull)
+  }
+
+  const hasActiveDownloads = computed(() => deps.downloadGroups.value.size > 0)
+
+  async function checkToken(): Promise<boolean> {
+    const token = (await window.api.getSetting('token')) as string
+    if (!token) {
+      errorMessage.value = 'API token is required for downloads. Set it in Settings.'
+      setTimeout(() => {
+        errorMessage.value = ''
+      }, 5000)
+      return false
+    }
+    return true
+  }
+
+  async function downloadAll(): Promise<void> {
+    if (!deps.anime.value) return
+    if (!(await checkToken())) return
+
+    const name = deps.getAnimeName()
+    const requests: DownloadRequest[] = []
+
+    for (const row of deps.episodeRows.value) {
+      if (row.selectedTr && !row.isLocked && !selectedTrHasFile(row)) {
+        requests.push({
+          translationId: row.selectedTr.id,
+          height: deps.getRealHeight(row.selectedTr),
+          animeName: name,
+          episodeLabel: row.episode.episodeFull,
+          episodeInt: row.episode.episodeInt,
+          animeId: deps.anime.value!.id,
+          translationType: row.selectedTr.type,
+          author: row.selectedTr.authorsSummary
+        })
+      }
+    }
+
+    if (requests.length === 0) return
+    downloading.value = true
+    try {
+      await window.api.downloadedAnimeAdd(JSON.parse(JSON.stringify(deps.anime.value)))
+      await window.api.downloadEnqueue(requests)
+    } finally {
+      downloading.value = false
+    }
+  }
+
+  async function downloadEpisode(row: EpisodeRow): Promise<void> {
+    if (!row.selectedTr || !deps.anime.value) return
+    if (!(await checkToken())) return
+
+    await window.api.downloadedAnimeAdd(JSON.parse(JSON.stringify(deps.anime.value)))
+    await window.api.downloadEnqueue([
+      {
+        translationId: row.selectedTr.id,
+        height: deps.getRealHeight(row.selectedTr),
+        animeName: deps.getAnimeName(),
+        episodeLabel: row.episode.episodeFull,
+        episodeInt: row.episode.episodeInt,
+        animeId: deps.anime.value!.id,
+        translationType: row.selectedTr.type,
+        author: row.selectedTr.authorsSummary
+      }
+    ])
+  }
+
+  async function cancelEpisodeDownload(episodeLabel: string): Promise<void> {
+    await window.api.downloadCancelByEpisode(deps.getAnimeName(), episodeLabel)
+  }
+
+  async function cancelAllDownloads(): Promise<void> {
+    await window.api.downloadCancelByEpisode(deps.getAnimeName())
+  }
+
+  async function openFile(row: EpisodeRow): Promise<void> {
+    if (!row.selectedTr) return
+    const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id)
+    if (!info) return
+
+    if (deps.playerMode.value === 'builtin') {
+      const name = deps.anime.value ? deps.getAnimeName() : ''
+      const localSubs = await window.api.playerGetLocalSubtitles(info.filePath)
+      const allEps = buildAllEpisodes()
+      const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt)
+      deps.playerStore.openPlayer({
+        filePath: info.filePath,
+        streamUrl: '',
+        subtitleContent: localSubs || '',
+        animeName: name,
+        episodeLabel: row.episode.episodeInt,
+        availableStreams: [],
+        translationId: row.selectedTr.id,
+        translations: buildTranslationList(row),
+        downloadedTrIds: [...row.downloadedTrIds],
+        allEpisodes: allEps,
+        episodeIndex: epIdx,
+        animeId: deps.getAnimeId(),
+        malId: deps.anime.value?.myAnimeListId ?? 0
+      })
+    } else {
+      const result = await window.api.fileOpen(info.filePath)
+      if (result) {
+        errorMessage.value = result
+        await checkFileStatus()
+      }
+    }
+  }
+
+  async function playStream(row: EpisodeRow): Promise<void> {
+    if (!row.selectedTr) return
+    const name = deps.anime.value ? deps.getAnimeName() : ''
+    const result = await window.api.playerGetStreamUrl(
+      row.selectedTr.id,
+      deps.getRealHeight(row.selectedTr)
+    )
+    if (result) {
+      const allEps = buildAllEpisodes()
+      const epIdx = allEps.findIndex((e) => e.episodeInt === row.episode.episodeInt)
+      deps.playerStore.openPlayer({
+        filePath: '',
+        streamUrl: result.streamUrl,
+        subtitleContent: result.subtitleContent || '',
+        animeName: name,
+        episodeLabel: row.episode.episodeInt,
+        availableStreams: result.availableStreams,
+        translationId: row.selectedTr.id,
+        translations: buildTranslationList(row),
+        downloadedTrIds: [...row.downloadedTrIds],
+        allEpisodes: allEps,
+        episodeIndex: epIdx,
+        animeId: deps.getAnimeId(),
+        malId: deps.anime.value?.myAnimeListId ?? 0
+      })
+    }
+  }
+
+  function showInFolder(row: EpisodeRow): void {
+    if (!row.selectedTr) return
+    const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id)
+    if (!info) return
+    void window.api.fileShowInFolder(info.filePath)
+  }
+
+  async function deleteFile(row: EpisodeRow): Promise<void> {
+    if (!row.selectedTr) return
+    const info = getFileForTranslation(row.episode.episodeInt, row.selectedTr.id)
+    if (!info) return
+    await window.api.fileDeleteEpisode(
+      deps.getAnimeName(),
+      row.episode.episodeInt,
+      deps.getAnimeId(),
+      row.selectedTr.id
+    )
+    await checkFileStatus()
+  }
+
+  async function continueWatching(): Promise<void> {
+    const target = continueTarget.value
+    if (!target) return
+
+    const eps = deps.filteredEpisodes.value
+    const targetIdx = eps.findIndex((e) => e.episodeInt === target.episodeInt)
+    if (targetIdx < 0) return
+
+    const targetPage = deps.isPaginated.value ? Math.floor(targetIdx / deps.pageSize) : 0
+    if (targetPage !== deps.currentPage.value) {
+      await deps.goToPage(targetPage)
+    }
+    await nextTick()
+
+    const row = deps.episodeRows.value.find((r) => r.episode.episodeInt === target.episodeInt)
+    if (!row || !row.selectedTr) return
+
+    if (selectedTrHasFile(row)) {
+      await openFile(row)
+    } else {
+      await playStream(row)
+    }
+  }
+
+  function subscribeFileEpisodesChanged(): Unsubscribe {
+    return window.api.onFileEpisodesChanged((animeName, data) => {
+      if (deps.anime.value && animeName === deps.getAnimeName()) {
+        const episodeInts = deps.filteredEpisodes.value.map((ep) => ep.episodeInt)
+        const baseMap = new Map<string, string>()
+        for (const epInt of episodeInts) {
+          const padded = epInt.padStart(2, '0')
+          const base = sanitizeFilename(`${animeName} - ${padded}`)
+          baseMap.set(base, epInt)
+        }
+        const filtered: typeof deps.fileStatus.value = {}
+        for (const [base, files] of Object.entries(data)) {
+          const epInt = baseMap.get(base)
+          if (epInt) filtered[epInt] = files
+        }
+        deps.fileStatus.value = filtered
+      }
+    })
+  }
+
+  return {
+    downloading,
+    errorMessage,
+    continueTarget,
+    continueReady,
+    continueLabel,
+    hasActiveDownloads,
+    episodeProgressPercent,
+    isEpisodeWatched,
+    getFileForTranslation,
+    hasAnyFile,
+    selectedTrHasFile,
+    buildTranslationList,
+    buildAllEpisodes,
+    dlProgress,
+    getGroup,
+    downloadGroupChanged,
+    loadWatchProgress,
+    checkFileStatus,
+    updateDownloadGroups,
+    downloadAll,
+    downloadEpisode,
+    cancelEpisodeDownload,
+    cancelAllDownloads,
+    openFile,
+    playStream,
+    showInFolder,
+    deleteFile,
+    continueWatching,
+    subscribeFileEpisodesChanged
+  }
+}

--- a/test/renderer/composables/use-episode-downloads.test.ts
+++ b/test/renderer/composables/use-episode-downloads.test.ts
@@ -1,0 +1,588 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, computed, type ComputedRef } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useDownloadsStore } from '../../../src/renderer/src/stores/downloads'
+import { usePlayerStore } from '../../../src/renderer/src/stores/player'
+import { useEpisodeDownloads } from '../../../src/renderer/src/composables/use-episode-downloads'
+import type { EpisodeRow } from '../../../src/renderer/src/composables/use-episode-list'
+
+type FileEntry = {
+  type: 'mkv' | 'mp4'
+  filePath: string
+  translationId?: number
+  author?: string
+}
+
+type Api = {
+  watchProgressGetAll: (animeId: number) => Promise<Record<string, WatchProgressEntry>>
+  fileCheckEpisodes: (
+    animeName: string,
+    episodeInts: string[]
+  ) => Promise<Record<string, FileEntry[]>>
+  downloadedEpisodesGet: (animeId: number) => Promise<Record<string, EpisodeMeta[]>>
+  downloadedAnimeAdd: (anime: AnimeDetail) => Promise<void>
+  downloadEnqueue: (requests: DownloadRequest[]) => Promise<void>
+  downloadCancelByEpisode: (animeName: string, episodeLabel?: string) => Promise<void>
+  fileOpen: (path: string) => Promise<string | null>
+  fileShowInFolder: (path: string) => Promise<void>
+  fileDeleteEpisode: (...args: unknown[]) => Promise<void>
+  playerGetLocalSubtitles: (path: string) => Promise<string | null>
+  playerGetStreamUrl: (
+    translationId: number,
+    height: number
+  ) => Promise<{ streamUrl: string; subtitleContent?: string; availableStreams: unknown[] }>
+  onFileEpisodesChanged: (cb: (animeName: string, data: unknown) => void) => Unsubscribe
+  onDownloadProgress: (cb: (data: unknown) => void) => Unsubscribe
+  onScanMergeProgress: (cb: (data: unknown) => void) => Unsubscribe
+  onFixMetadataProgress: (cb: (data: unknown) => void) => Unsubscribe
+  downloadGetQueue: () => Promise<EpisodeGroup[]>
+  getSetting: (key: string) => Promise<unknown>
+}
+
+function noopSub(): Unsubscribe {
+  return () => {}
+}
+
+// Pinia stores subscribe to broadcasts at construction; stub them so
+// useDownloadsStore() doesn't throw under Vitest.
+const STORE_BROADCAST_STUBS: Partial<Api> = {
+  onDownloadProgress: noopSub,
+  onScanMergeProgress: noopSub,
+  onFixMetadataProgress: noopSub,
+  downloadGetQueue: () => Promise.resolve([])
+}
+
+function setApi(api: Partial<Api>): void {
+  const w = (globalThis as { window?: { api?: Partial<Api> } }).window
+  const prev = w?.api ?? {}
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: { ...prev, ...api } }
+}
+
+function installDefaultApi(): void {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: { ...STORE_BROADCAST_STUBS } }
+}
+
+function mkEpisode(id: number, episodeInt: string): EpisodeSummary {
+  return {
+    id,
+    episodeInt,
+    episodeFull: `Episode ${episodeInt}`,
+    episodeType: 'tv',
+    isActive: 1,
+    firstUploadedDateTime: '2025-01-01'
+  } as unknown as EpisodeSummary
+}
+
+function mkRow(opts: {
+  episodeId?: number
+  episodeInt?: string
+  selectedTrId?: number
+  selectedTrType?: string
+  selectedTrAuthor?: string
+  selectedTrHeight?: number
+  isLocked?: boolean
+}): EpisodeRow {
+  const ep = mkEpisode(opts.episodeId ?? 1, opts.episodeInt ?? '1')
+  const selectedTr =
+    opts.selectedTrId != null
+      ? ({
+          id: opts.selectedTrId,
+          type: opts.selectedTrType ?? 'subRu',
+          authorsSummary: opts.selectedTrAuthor ?? 'A',
+          height: opts.selectedTrHeight ?? 720,
+          isActive: 1
+        } as unknown as Translation)
+      : null
+  return {
+    episode: ep,
+    allTranslations: selectedTr ? [selectedTr] : [],
+    selectedTr,
+    isLocked: opts.isLocked ?? false,
+    lockSource: opts.isLocked ? 'queued' : null,
+    downloadedTrIds: new Set()
+  }
+}
+
+function makeDeps(overrides: Partial<Parameters<typeof useEpisodeDownloads>[0]> = {}) {
+  setActivePinia(createPinia())
+  return {
+    anime: ref<AnimeDetail | null>(null),
+    getAnimeId: () => 1,
+    getAnimeName: () => 'TestAnime',
+    episodeMeta: ref<Record<string, EpisodeMeta[]>>({}),
+    fileStatus: ref<Record<string, FileEntry[]>>({}),
+    downloadGroups: ref<Map<string, EpisodeGroup>>(new Map()),
+    watchProgress: ref<Record<string, WatchProgressEntry>>({}),
+    filteredEpisodes: computed(() => [] as EpisodeSummary[]),
+    episodes: ref(new Map<number, EpisodeDetail>()),
+    episodeRows: computed<EpisodeRow[]>(() => []),
+    getRealHeight: (tr: Translation) => tr.height,
+    currentPage: ref(0),
+    isPaginated: computed(() => false),
+    goToPage: vi.fn().mockResolvedValue(undefined),
+    loadingEpisodes: ref(false),
+    shikiRate: ref<ShikiUserRate | null>(null),
+    shikiUser: ref<ShikiUser | null>(null),
+    shikiEpisodes: ref(0),
+    shikiUserChecked: ref(true),
+    shikiLoading: ref(false),
+    downloadsStore: useDownloadsStore(),
+    playerStore: usePlayerStore(),
+    playerMode: ref<'system' | 'builtin'>('system'),
+    pageSize: 30,
+    ...overrides
+  } as Parameters<typeof useEpisodeDownloads>[0]
+}
+
+function eps3(): ComputedRef<EpisodeSummary[]> {
+  return computed(() => [mkEpisode(1, '1'), mkEpisode(2, '2'), mkEpisode(3, '3')])
+}
+
+beforeEach(() => {
+  installDefaultApi()
+})
+
+describe('useEpisodeDownloads — watch progress', () => {
+  it('loadWatchProgress fetches via IPC and writes to deps.watchProgress', async () => {
+    const data: Record<string, WatchProgressEntry> = {
+      '1': { position: 60, duration: 1440, updatedAt: 1 } as unknown as WatchProgressEntry
+    }
+    setApi({ watchProgressGetAll: vi.fn().mockResolvedValue(data) })
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    await dl.loadWatchProgress()
+    expect(deps.watchProgress.value).toEqual(data)
+  })
+
+  it('episodeProgressPercent returns 0 below 2%', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '1': { position: 10, duration: 1440 } as unknown as WatchProgressEntry,
+      '2': { position: 60, duration: 1440 } as unknown as WatchProgressEntry
+    }
+    expect(dl.episodeProgressPercent('1')).toBe(0)
+    expect(dl.episodeProgressPercent('2')).toBe(4)
+  })
+
+  it('isEpisodeWatched honors shiki completed status', () => {
+    const shikiRate = ref<ShikiUserRate | null>({
+      status: 'completed'
+    } as unknown as ShikiUserRate)
+    const deps = makeDeps({ shikiRate })
+    const dl = useEpisodeDownloads(deps)
+    expect(dl.isEpisodeWatched('1')).toBe(true)
+  })
+
+  it('isEpisodeWatched falls back to local watchProgress.watched', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '1': { watched: true } as unknown as WatchProgressEntry
+    }
+    expect(dl.isEpisodeWatched('1')).toBe(true)
+    expect(dl.isEpisodeWatched('2')).toBe(false)
+  })
+})
+
+describe('useEpisodeDownloads — continueTarget priority', () => {
+  it('returns null when no episodes', () => {
+    const dl = useEpisodeDownloads(makeDeps())
+    expect(dl.continueTarget.value).toBeNull()
+  })
+
+  it('completed status → first episode (start rewatch)', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        filteredEpisodes: eps3(),
+        shikiRate: ref({ status: 'completed' } as unknown as ShikiUserRate)
+      })
+    )
+    expect(dl.continueTarget.value?.episodeInt).toBe('1')
+  })
+
+  it('priority 1: shikimori reports N completed → ep N+1', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        filteredEpisodes: eps3(),
+        shikiUser: ref({ id: 1 } as unknown as ShikiUser),
+        shikiEpisodes: ref(2)
+      })
+    )
+    expect(dl.continueTarget.value?.episodeInt).toBe('3')
+  })
+
+  it('priority 2: unfinished saved position wins (most recent)', () => {
+    const deps = makeDeps({ filteredEpisodes: eps3() })
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '1': { position: 100, duration: 1440, updatedAt: 10 } as unknown as WatchProgressEntry,
+      '2': { position: 200, duration: 1440, updatedAt: 20 } as unknown as WatchProgressEntry
+    }
+    expect(dl.continueTarget.value?.episodeInt).toBe('2')
+  })
+
+  it('priority 3: first episode after last locally-watched', () => {
+    const deps = makeDeps({ filteredEpisodes: eps3() })
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '1': { watched: true } as unknown as WatchProgressEntry
+    }
+    expect(dl.continueTarget.value?.episodeInt).toBe('2')
+  })
+
+  it('priority 4: everything watched → last episode', () => {
+    const deps = makeDeps({ filteredEpisodes: eps3() })
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '1': { watched: true } as unknown as WatchProgressEntry,
+      '2': { watched: true } as unknown as WatchProgressEntry,
+      '3': { watched: true } as unknown as WatchProgressEntry
+    }
+    expect(dl.continueTarget.value?.episodeInt).toBe('3')
+  })
+})
+
+describe('useEpisodeDownloads — continueReady', () => {
+  it('false while episodes loading', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        anime: ref({ id: 1 } as unknown as AnimeDetail),
+        filteredEpisodes: computed(() => [mkEpisode(1, '1')]),
+        loadingEpisodes: ref(true)
+      })
+    )
+    expect(dl.continueReady.value).toBe(false)
+  })
+
+  it('false when MAL anime but shikiUser not yet checked', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        anime: ref({ id: 1, myAnimeListId: 99 } as unknown as AnimeDetail),
+        filteredEpisodes: computed(() => [mkEpisode(1, '1')]),
+        shikiUserChecked: ref(false)
+      })
+    )
+    expect(dl.continueReady.value).toBe(false)
+  })
+
+  it('false while shiki is loading', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        anime: ref({ id: 1, myAnimeListId: 99 } as unknown as AnimeDetail),
+        filteredEpisodes: computed(() => [mkEpisode(1, '1')]),
+        shikiUser: ref({ id: 1 } as unknown as ShikiUser),
+        shikiLoading: ref(true)
+      })
+    )
+    expect(dl.continueReady.value).toBe(false)
+  })
+
+  it('true once everything is settled', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        anime: ref({ id: 1 } as unknown as AnimeDetail),
+        filteredEpisodes: computed(() => [mkEpisode(1, '1')])
+      })
+    )
+    expect(dl.continueReady.value).toBe(true)
+  })
+})
+
+describe('useEpisodeDownloads — continueLabel', () => {
+  it('shows Resume when position > 0 and not watched', () => {
+    const deps = makeDeps({
+      filteredEpisodes: computed(() => [mkEpisode(1, '5')])
+    })
+    const dl = useEpisodeDownloads(deps)
+    deps.watchProgress.value = {
+      '5': { position: 60, duration: 1440, updatedAt: 1 } as unknown as WatchProgressEntry
+    }
+    expect(dl.continueLabel.value).toBe('Resume · Ep 5')
+  })
+
+  it('shows Continue when no saved position', () => {
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        filteredEpisodes: computed(() => [mkEpisode(1, '5')])
+      })
+    )
+    expect(dl.continueLabel.value).toBe('Continue · Ep 5')
+  })
+})
+
+describe('useEpisodeDownloads — file helpers', () => {
+  it('hasAnyFile reflects fileStatus', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.fileStatus.value = {
+      '1': [{ type: 'mkv', filePath: '/x.mkv', author: 'tag' }]
+    }
+    expect(dl.hasAnyFile('1')).toBe(true)
+    expect(dl.hasAnyFile('2')).toBe(false)
+  })
+
+  it('getFileForTranslation matches by sanitized author tag', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.fileStatus.value = {
+      '1': [
+        { type: 'mkv', filePath: '/Anidub.mkv', author: 'Anidub' },
+        { type: 'mp4', filePath: '/AniLibria.mp4', author: 'AniLibria' }
+      ]
+    }
+    deps.episodeMeta.value = {
+      '1': [
+        { translationId: 10, author: 'Anidub' } as unknown as EpisodeMeta,
+        { translationId: 20, author: 'AniLibria' } as unknown as EpisodeMeta
+      ]
+    }
+    expect(dl.getFileForTranslation('1', 10)?.filePath).toBe('/Anidub.mkv')
+    expect(dl.getFileForTranslation('1', 20)?.filePath).toBe('/AniLibria.mp4')
+    expect(dl.getFileForTranslation('1', 999)).toBeNull()
+  })
+
+  it('getFileForTranslation falls back to a legacy untagged file when sole entry', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.fileStatus.value = { '1': [{ type: 'mkv', filePath: '/legacy.mkv' }] }
+    deps.episodeMeta.value = {
+      '1': [{ translationId: 7, author: 'X' } as unknown as EpisodeMeta]
+    }
+    expect(dl.getFileForTranslation('1', 7)?.filePath).toBe('/legacy.mkv')
+  })
+
+  it('selectedTrHasFile only true when selectedTr is set and matched', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    deps.fileStatus.value = {
+      '1': [{ type: 'mkv', filePath: '/file.mkv', author: 'A' }]
+    }
+    deps.episodeMeta.value = {
+      '1': [{ translationId: 100, author: 'A' } as unknown as EpisodeMeta]
+    }
+    const row = mkRow({ episodeId: 1, episodeInt: '1', selectedTrId: 100 })
+    expect(dl.selectedTrHasFile(row)).toBe(true)
+    const noTr = mkRow({ episodeInt: '1' })
+    expect(dl.selectedTrHasFile(noTr)).toBe(false)
+  })
+})
+
+describe('useEpisodeDownloads — buildTranslationList / buildAllEpisodes', () => {
+  it('buildTranslationList projects allTranslations through getRealHeight', () => {
+    const probed = new Map<number, number>([[2, 1080]])
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        getRealHeight: (tr: Translation) => probed.get(tr.id) ?? tr.height
+      })
+    )
+    const row = mkRow({ selectedTrId: 1, selectedTrAuthor: 'A', selectedTrHeight: 720 })
+    row.allTranslations = [
+      { id: 1, type: 'subRu', authorsSummary: 'A', height: 720, isActive: 1 } as Translation,
+      { id: 2, type: 'voiceRu', authorsSummary: 'B', height: 720, isActive: 1 } as Translation
+    ]
+    const list = dl.buildTranslationList(row)
+    expect(list).toEqual([
+      { id: 1, label: 'A', type: 'subRu', height: 720 },
+      { id: 2, label: 'B', type: 'voiceRu', height: 1080 }
+    ])
+  })
+
+  it('buildAllEpisodes covers active translations + downloadedTrIds', () => {
+    const ep = mkEpisode(1, '1')
+    const detail = {
+      ...ep,
+      translations: [
+        { id: 10, type: 'subRu', authorsSummary: 'A', height: 720, isActive: 1 } as Translation,
+        { id: 11, type: 'voiceRu', authorsSummary: 'B', height: 480, isActive: 0 } as Translation
+      ],
+      duration: 1440,
+      mediaInfo: null,
+      translationCount: 2
+    } as unknown as EpisodeDetail
+    const episodes = ref(new Map<number, EpisodeDetail>([[1, detail]]))
+    const deps = makeDeps({
+      filteredEpisodes: computed(() => [ep]),
+      episodes
+    })
+    const dl = useEpisodeDownloads(deps)
+    deps.episodeMeta.value = {
+      '1': [{ translationId: 10, author: 'A' } as unknown as EpisodeMeta]
+    }
+    const out = dl.buildAllEpisodes()
+    expect(out).toHaveLength(1)
+    expect(out[0].translations).toEqual([{ id: 10, label: 'A', type: 'subRu', height: 720 }])
+    expect(out[0].downloadedTrIds).toEqual([10])
+  })
+})
+
+describe('useEpisodeDownloads — downloadGroupChanged', () => {
+  it('returns false for two undefineds', () => {
+    const dl = useEpisodeDownloads(makeDeps())
+    expect(dl.downloadGroupChanged(undefined, undefined)).toBe(false)
+  })
+
+  it('returns true when one side missing', () => {
+    const dl = useEpisodeDownloads(makeDeps())
+    expect(dl.downloadGroupChanged(undefined, { mergeStatus: 'idle' } as EpisodeGroup)).toBe(true)
+  })
+
+  it('detects mergeStatus / video.bytesReceived deltas', () => {
+    const dl = useEpisodeDownloads(makeDeps())
+    const a = {
+      mergeStatus: 'idle',
+      video: { status: 'downloading', bytesReceived: 100, totalBytes: 200, speed: 50 }
+    } as unknown as EpisodeGroup
+    const b = {
+      mergeStatus: 'idle',
+      video: { status: 'downloading', bytesReceived: 150, totalBytes: 200, speed: 50 }
+    } as unknown as EpisodeGroup
+    expect(dl.downloadGroupChanged(a, b)).toBe(true)
+    expect(dl.downloadGroupChanged(a, a)).toBe(false)
+  })
+})
+
+describe('useEpisodeDownloads — updateDownloadGroups', () => {
+  it('filters by animeName + writes change-detected snapshot', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    dl.updateDownloadGroups([
+      {
+        animeName: 'TestAnime',
+        episodeLabel: 'Episode 1',
+        mergeStatus: 'idle',
+        video: { status: 'downloading', bytesReceived: 50, totalBytes: 100 }
+      } as unknown as EpisodeGroup,
+      {
+        animeName: 'OtherAnime',
+        episodeLabel: 'Episode 1'
+      } as unknown as EpisodeGroup
+    ])
+    expect(deps.downloadGroups.value.size).toBe(1)
+    expect(deps.downloadGroups.value.has('Episode 1')).toBe(true)
+  })
+
+  it('skips write when nothing changed', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    const group = {
+      animeName: 'TestAnime',
+      episodeLabel: 'Episode 1',
+      mergeStatus: 'idle',
+      video: { status: 'downloading', bytesReceived: 50, totalBytes: 100 }
+    } as unknown as EpisodeGroup
+    dl.updateDownloadGroups([group])
+    const ref1 = deps.downloadGroups.value
+    dl.updateDownloadGroups([group])
+    expect(deps.downloadGroups.value).toBe(ref1)
+  })
+
+  it('detects removals as a change', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    dl.updateDownloadGroups([
+      {
+        animeName: 'TestAnime',
+        episodeLabel: 'Episode 1',
+        mergeStatus: 'idle'
+      } as unknown as EpisodeGroup
+    ])
+    dl.updateDownloadGroups([])
+    expect(deps.downloadGroups.value.size).toBe(0)
+  })
+})
+
+describe('useEpisodeDownloads — actions', () => {
+  it('downloadAll skips locked / has-file rows; enqueues the rest', async () => {
+    const downloadEnqueue = vi.fn().mockResolvedValue(undefined)
+    const downloadedAnimeAdd = vi.fn().mockResolvedValue(undefined)
+    setApi({
+      getSetting: vi.fn().mockResolvedValue('valid-token'),
+      downloadEnqueue,
+      downloadedAnimeAdd
+    })
+    const lockedRow = mkRow({
+      episodeId: 1,
+      episodeInt: '1',
+      selectedTrId: 100,
+      isLocked: true
+    })
+    const hasFileRow = mkRow({ episodeId: 2, episodeInt: '2', selectedTrId: 101 })
+    const newRow = mkRow({
+      episodeId: 3,
+      episodeInt: '3',
+      selectedTrId: 102,
+      selectedTrType: 'voiceRu',
+      selectedTrAuthor: 'X',
+      selectedTrHeight: 1080
+    })
+    const deps = makeDeps({
+      anime: ref({ id: 99 } as unknown as AnimeDetail),
+      episodeRows: computed(() => [lockedRow, hasFileRow, newRow])
+    })
+    const dl = useEpisodeDownloads(deps)
+    // Mark episode 2 as having a file
+    deps.fileStatus.value = {
+      '2': [{ type: 'mkv', filePath: '/x.mkv', author: 'A' }]
+    }
+    deps.episodeMeta.value = {
+      '2': [{ translationId: 101, author: 'A' } as unknown as EpisodeMeta]
+    }
+    await dl.downloadAll()
+    expect(downloadedAnimeAdd).toHaveBeenCalled()
+    expect(downloadEnqueue).toHaveBeenCalledTimes(1)
+    const requests = downloadEnqueue.mock.calls[0][0] as DownloadRequest[]
+    expect(requests).toHaveLength(1)
+    expect(requests[0].translationId).toBe(102)
+    expect(requests[0].height).toBe(1080)
+  })
+
+  it('downloadAll early-returns on missing token', async () => {
+    const downloadEnqueue = vi.fn()
+    setApi({
+      getSetting: vi.fn().mockResolvedValue(''),
+      downloadEnqueue
+    })
+    const dl = useEpisodeDownloads(
+      makeDeps({
+        anime: ref({ id: 1 } as unknown as AnimeDetail),
+        episodeRows: computed(() => [mkRow({ episodeId: 1, episodeInt: '1', selectedTrId: 50 })])
+      })
+    )
+    await dl.downloadAll()
+    expect(downloadEnqueue).not.toHaveBeenCalled()
+    expect(dl.errorMessage.value).toMatch(/token/i)
+  })
+
+  it('cancelEpisodeDownload + cancelAllDownloads route to IPC', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    setApi({ downloadCancelByEpisode: cancel })
+    const dl = useEpisodeDownloads(makeDeps())
+    await dl.cancelEpisodeDownload('Episode 7')
+    expect(cancel).toHaveBeenCalledWith('TestAnime', 'Episode 7')
+    await dl.cancelAllDownloads()
+    expect(cancel).toHaveBeenCalledWith('TestAnime')
+  })
+})
+
+describe('useEpisodeDownloads — pure utilities', () => {
+  it('dlProgress returns 0 on null/zero totalBytes, otherwise percent', () => {
+    const dl = useEpisodeDownloads(makeDeps())
+    expect(dl.dlProgress(null)).toBe(0)
+    expect(
+      dl.dlProgress({ totalBytes: 0, bytesReceived: 10 } as unknown as DownloadProgressItem)
+    ).toBe(0)
+    expect(
+      dl.dlProgress({ totalBytes: 200, bytesReceived: 50 } as unknown as DownloadProgressItem)
+    ).toBe(25)
+  })
+
+  it('getGroup lookups the per-episodeFull entry', () => {
+    const deps = makeDeps()
+    const dl = useEpisodeDownloads(deps)
+    const g = { episodeLabel: 'Episode 1' } as unknown as EpisodeGroup
+    deps.downloadGroups.value = new Map([['Episode 1', g]])
+    expect(dl.getGroup('Episode 1')).toStrictEqual(g)
+    expect(dl.getGroup('Episode 2')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Second sub-slice of **Phase 5 slice 5b** (#118 / epic #84). Stacked on top of #121 (slice 5b.1). Extracts the last and largest composable from `AnimeDetailView.vue` — `useEpisodeDownloads`, which carries the file-on-disk helpers, download orchestration, watch-progress, and continue-watching logic.

`AnimeDetailView.vue`: **3260 → 2898 lines** (another ~360-line script shrink). After both 5b.1 + 5b.2, the original 3624-line monolith is **3624 → 2898**, ~726 lines of state machines + helpers + actions extracted into 4 testable composables.

> **Base branch is `phase5-slice-5b1-detail-composables`** — the diff against `main` will retarget itself once #121 lands. Per [[feedback_stacked_pr_base_branch]] I'll switch the base to `main` *before* the 5b.1 branch is deleted on merge.

## What's in this slice

`src/renderer/src/composables/use-episode-downloads.ts` (~510 L) owns only the two transient flags `downloading` + `errorMessage`. The four data refs (`episodeMeta`, `fileStatus`, `downloadGroups`, `watchProgress`) remain at the component level so both this composable and `useEpisodeList` can read them without a circular construction. The composable is a thin layer of helpers + actions + computeds over those refs.

### Surfaces (28 exports)

- **Helpers** (pure-ish):
  - `episodeProgressPercent(episodeInt)`, `isEpisodeWatched(episodeInt)`
  - `getFileForTranslation(episodeInt, translationId)`, `hasAnyFile(episodeInt)`, `selectedTrHasFile(row)`
  - `buildTranslationList(row)`, `buildAllEpisodes()` (player payload projections)
  - `dlProgress(item)`, `getGroup(episodeFull)`, `downloadGroupChanged(a, b)`
- **Computeds**:
  - `continueTarget` — the 4-priority continue-watching algorithm: Shikimori-completed → `eps[0]` (start rewatch); Shikimori reports N → `eps[N+1]`; most recent unfinished saved position; first ep after last locally-watched; else last ep.
  - `continueReady` — gates on anime load + episode load + Shikimori user check + Shikimori loading.
  - `continueLabel` — verb ("Resume" or "Continue") + episode number.
  - `hasActiveDownloads` — true if `downloadGroups.size > 0`.
- **Actions**:
  - `loadWatchProgress`, `checkFileStatus`, `updateDownloadGroups(groups)`
  - `downloadAll`, `downloadEpisode(row)`, `cancelEpisodeDownload(episodeLabel)`, `cancelAllDownloads`
  - `openFile(row)`, `playStream(row)`, `showInFolder(row)`, `deleteFile(row)`
  - `continueWatching` — navigates pages + finds the target row + dispatches to `openFile` or `playStream`.
- **Subscription init**: `subscribeFileEpisodesChanged()` returns an `Unsubscribe`. Component invokes from `onMounted` (replacing the inline `window.api.onFileEpisodesChanged(...)` block).

### Behavior preserved (byte-identical)

- `continueTarget` priority logic unchanged.
- `updateDownloadGroups` still no-ops when `downloadGroupChanged` returns false AND `prev.size === map.size` (preserves the size-difference removal-detection branch that triggers reactivity even when individual entries are unchanged).
- `openFile` / `playStream` still build the player payload identically (same `buildTranslationList` + `buildAllEpisodes` outputs).
- `onCleanupDeleted` still resets `isDownloaded` + `episodeMeta` and calls `checkFileStatus`.
- The `window.api.onFileEpisodesChanged` subscription body is unchanged — it just moved into the composable.

### Component changes

- New import: `useEpisodeDownloads` from `../composables/use-episode-downloads`.
- One construction block after `playerMode` declaration, destructuring all 28 returned surfaces.
- ~360 lines of inline functions deleted (replaced by the destructured composable references).
- `onMounted`'s 18-line inline `onFileEpisodesChanged` block collapses to `unsubFileEpisodesChanged = subscribeFileEpisodesChanged()`.

## Tests (33 new tests across 588 lines)

`test/renderer/composables/use-episode-downloads.test.ts`:

- **Watch progress (4)**: `loadWatchProgress` writes through deps.ref; `episodeProgressPercent` rounds and floors at 2%; `isEpisodeWatched` honors Shikimori completed status; falls back to local `watchProgress.watched`.
- **continueTarget (6)**: empty list → null; Shikimori completed → `eps[0]`; Shikimori reports N → `eps[N+1]`; unfinished saved position wins (most recent); first ep after last watched; everything watched → last ep.
- **continueReady (4)**: false while loading episodes; false when MAL anime and `shikiUserChecked === false`; false while `shikiUser` exists and `shikiLoading`; true once settled.
- **continueLabel (2)**: "Resume · Ep N" with progress; "Continue · Ep N" without.
- **File helpers (4)**: `hasAnyFile` reflects `fileStatus`; `getFileForTranslation` matches by sanitized author tag (multi-author shows); falls back to a legacy untagged file when sole metadata entry; `selectedTrHasFile` requires both `selectedTr` and a file match.
- **buildTranslationList / buildAllEpisodes (2)**: probed quality projection; active translations + downloadedTrIds.
- **downloadGroupChanged (3)**: two-undefined → false; one missing → true; detects merge/bytes/speed deltas.
- **updateDownloadGroups (3)**: filters by `animeName`; skips write on identical input; detects removals as change.
- **Actions (3)**: `downloadAll` skips locked + has-file rows; early-returns on missing token; `cancelEpisodeDownload` + `cancelAllDownloads` route to IPC.
- **Pure utilities (2)**: `dlProgress` handles null/zero/positive; `getGroup` lookups + misses.

Total composable test count after 5b.2: **60** (4 + 6 + 17 + 33). Total project tests: **138 → 171** passing.

## DESIGN.md

Added `useEpisodeDownloads` entry under the renderer composables section with surface list + the `continueTarget` 4-priority spec.

## Quality gate

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; 7 pre-existing warnings unchanged from `main`)
- `npm run format:check` ✓
- `npm run test` ✓ — **171/171 passing**
- `npm run build` ✓
- `bash scripts/check-subscription-contract.sh` ✓ — no `removeAllListeners` / `window.api.off*`

## Test plan

(Same plan as #121 since this slice changes the same surface — anything that worked before this slice must work after.)

- [ ] **Episode list renders** with the same content; pagination + fractional `.5` episodes still work.
- [ ] **Per-episode translation override** persists + lock-on-queue still works (5-priority `episodeRows`).
- [ ] **Download orchestration**: Download all skips locked / already-downloaded rows; per-episode download works; cancel by episode + cancel all work.
- [ ] **File ops**: Open file (system/built-in), Play stream, Show in folder, Delete file.
- [ ] **Continue watching**: jumps to the right page + row + plays (file vs stream).
  - Empty anime → no button.
  - Shikimori completed → starts at Ep 1.
  - Shikimori reports N → jumps to Ep N+1.
  - Unfinished saved position → resumes from there.
  - All watched → last ep.
- [ ] **Cleanup modal**: after delete, `isDownloaded` resets + `episodeMeta` clears + file status refreshes.
- [ ] **Background file rescan**: triggering a file change via the main process repopulates `fileStatus` correctly via `subscribeFileEpisodesChanged()`.
- [ ] **Switch between anime detail views**: no leaked listeners; the new `onFileEpisodesChanged` disposer fires on unmount.

Part of #84 (Phase 5 slice 5b.2). Stacked on #121.