### PR TITLE
refactor: Phase 5 slice 5b.3 — extract ChronologyPanel + FriendsPanel (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -83,7 +83,9 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/renderer/src/components/SearchView.vue` | Anime search + results grid (persistent across tab switches) |
 | `src/renderer/src/components/AnimeCard.vue` | Reusable anime poster card |
 | `src/renderer/src/components/LibraryView.vue` | Starred + downloaded anime collection, folder deletion |
-| `src/renderer/src/components/AnimeDetailView.vue` | Episode list, translations, download/open/delete per episode, dequeue, download progress |
+| `src/renderer/src/components/AnimeDetailView.vue` | Episode list, translations, download/open/delete per episode, dequeue, download progress. Consumes `useAnimeDetailPrefs` + `useChronology` + `useEpisodeList` + `useEpisodeDownloads`. Renders `detail/ChronologyPanel.vue` + `detail/FriendsPanel.vue` for the Shikimori-driven sidebar panels |
+| `src/renderer/src/components/detail/ChronologyPanel.vue` | Related-anime list (Shikimori chronology). Props: `shikiRelated`, `relatedLoading`; v-model: `collapsed`. Calls `useLibraryStore().openAnime()` directly to navigate. Includes its own KIND_LABELS + STATUS_LABELS + scoped CSS |
+| `src/renderer/src/components/detail/FriendsPanel.vue` | Friends' Shikimori watch status. Props: `friendsRates`, `friendsLoading`, `numberOfEpisodes`; v-model: `collapsed`. Owns the `friendsSummary` computed (status counts) |
 | `src/renderer/src/components/DownloadsView.vue` | Real-time download queue with progress, merge controls |
 | `src/renderer/src/components/ShikimoriView.vue` | Shikimori anime list: browse watchlist, status filter, MAL ID resolution |
 | `src/renderer/src/components/FriendsActivityView.vue` | Chronological feed of recent anime activity from Shikimori friends |

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -11,6 +11,8 @@ import { useAnimeDetailPrefs } from '../composables/use-anime-detail-prefs';
 import { useChronology } from '../composables/use-chronology';
 import { useEpisodeList, PAGE_SIZE } from '../composables/use-episode-list';
 import { useEpisodeDownloads } from '../composables/use-episode-downloads';
+import ChronologyPanel from './detail/ChronologyPanel.vue';
+import FriendsPanel from './detail/FriendsPanel.vue';
 
 const props = defineProps<{
   animeId: number;
@@ -135,30 +137,6 @@ const chapterInjectResult = ref<{
   total: number;
 } | null>(null);
 
-const KIND_LABELS: Record<string, string> = {
-  tv: 'TV',
-  tv_13: 'TV',
-  tv_24: 'TV',
-  tv_48: 'TV',
-  movie: 'Movie',
-  ova: 'OVA',
-  ona: 'ONA',
-  special: 'Special',
-  music: 'Music',
-  tv_special: 'TV Special',
-  pv: 'PV',
-  cm: 'CM'
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  planned: 'Planned',
-  watching: 'Watching',
-  rewatching: 'Rewatching',
-  completed: 'Watched',
-  on_hold: 'On Hold',
-  dropped: 'Dropped'
-};
-
 const shikiDetailsDescription = computed<string>(() => {
   if (!shikiDetails.value) return '';
   const src = shikiDetails.value.description;
@@ -188,24 +166,6 @@ const shikiDetailsDescription = computed<string>(() => {
     .replace(/&(?:amp|nbsp|lt|gt|quot|#39);/gi, (m) => entities[m.toLowerCase()] ?? m)
     .replace(/\s+/g, ' ')
     .trim();
-});
-
-const friendsSummary = computed(() => {
-  const counts = new Map<string, number>();
-  for (const r of friendsRates.value) {
-    counts.set(r.status, (counts.get(r.status) || 0) + 1);
-  }
-  const labels: Record<string, string> = {
-    watching: 'watching',
-    completed: 'completed',
-    planned: 'planned',
-    on_hold: 'on hold',
-    dropped: 'dropped',
-    rewatching: 'rewatching'
-  };
-  return [...counts.entries()]
-    .map(([status, count]) => `${count} ${labels[status] || status}`)
-    .join(' \u00b7 ');
 });
 
 const playerMode = ref<'system' | 'builtin'>('system');
@@ -1064,96 +1024,12 @@ function typeChip(type: string): { short: string; color: string } {
         <div v-else class="shiki-loading">Loading...</div>
       </div>
 
-      <div
+      <ChronologyPanel
         v-if="anime.myAnimeListId && (relatedLoading || shikiRelated.length > 0)"
-        class="related-panel"
-      >
-        <div class="related-header" @click="relatedCollapsed = !relatedCollapsed">
-          <div class="related-header-left">
-            <svg
-              class="related-chevron"
-              :class="{ collapsed: relatedCollapsed }"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="14"
-              height="14"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
-            </svg>
-            <span class="related-label">Chronology</span>
-          </div>
-          <span v-if="relatedLoading" class="related-summary">Loading...</span>
-          <span v-else-if="shikiRelated.length > 0" class="related-summary"
-            >{{ shikiRelated.length }} {{ shikiRelated.length === 1 ? 'entry' : 'entries' }}</span
-          >
-        </div>
-        <div v-if="!relatedCollapsed" class="related-body">
-          <div v-if="relatedLoading" class="related-loading">Loading chronology...</div>
-          <div v-else class="related-list">
-            <div
-              v-for="entry in shikiRelated"
-              :key="entry.shikiAnime.id"
-              class="related-row"
-              :class="{
-                clickable: entry.smotretAnime && !entry.isCurrent,
-                unavailable: !entry.smotretAnime,
-                current: entry.isCurrent
-              }"
-              :role="entry.smotretAnime && !entry.isCurrent ? 'button' : undefined"
-              :tabindex="entry.smotretAnime && !entry.isCurrent ? 0 : undefined"
-              @click="
-                entry.smotretAnime &&
-                !entry.isCurrent &&
-                libraryStore.openAnime(entry.smotretAnime.id)
-              "
-              @keydown.enter.prevent="
-                entry.smotretAnime &&
-                !entry.isCurrent &&
-                libraryStore.openAnime(entry.smotretAnime.id)
-              "
-              @keydown.space.prevent="
-                entry.smotretAnime &&
-                !entry.isCurrent &&
-                libraryStore.openAnime(entry.smotretAnime.id)
-              "
-            >
-              <img
-                :src="entry.smotretAnime?.posterUrlSmall || entry.shikiAnime.image_url || ''"
-                :alt="entry.shikiAnime.name"
-                class="related-thumb"
-                loading="lazy"
-              />
-              <div class="related-info">
-                <div class="related-title">{{ entry.shikiAnime.name }}</div>
-                <div class="related-meta">
-                  <span v-if="entry.shikiAnime.kind" class="related-kind">{{
-                    KIND_LABELS[entry.shikiAnime.kind] || entry.shikiAnime.kind.toUpperCase()
-                  }}</span>
-                  <span v-if="entry.shikiAnime.year" class="related-year">{{
-                    entry.shikiAnime.year
-                  }}</span>
-                  <span v-if="entry.relation" class="related-relation">{{ entry.relation }}</span>
-                  <span v-if="entry.isCurrent" class="related-current-badge">Current</span>
-                  <span
-                    v-if="entry.watchStatus"
-                    class="related-status-badge"
-                    :class="'status-' + entry.watchStatus"
-                  >
-                    {{ STATUS_LABELS[entry.watchStatus] }}
-                  </span>
-                  <span
-                    v-if="!entry.smotretAnime && !entry.isCurrent"
-                    class="related-unavailable-badge"
-                    >Not available</span
-                  >
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+        v-model:collapsed="relatedCollapsed"
+        :shiki-related="shikiRelated"
+        :related-loading="relatedLoading"
+      />
 
       <div class="skip-panel">
         <div class="skip-header" @click="skipPanelCollapsed = !skipPanelCollapsed">
@@ -1280,61 +1156,13 @@ function typeChip(type: string): { short: string; color: string } {
         </div>
       </div>
 
-      <div v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)" class="friends-panel">
-        <div class="friends-header" @click="friendsCollapsed = !friendsCollapsed">
-          <div class="friends-header-left">
-            <svg
-              class="friends-chevron"
-              :class="{ collapsed: friendsCollapsed }"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="14"
-              height="14"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
-            </svg>
-            <span class="friends-label">Friends</span>
-          </div>
-          <span v-if="!friendsLoading && friendsRates.length > 0" class="friends-summary">{{
-            friendsSummary
-          }}</span>
-          <span v-if="friendsLoading" class="friends-summary">Loading...</span>
-        </div>
-        <div v-if="!friendsCollapsed" class="friends-body">
-          <div v-if="friendsLoading" class="friends-loading">Loading friends...</div>
-          <div v-else-if="friendsRates.length === 0" class="friends-empty">
-            None of your friends have watched this anime
-          </div>
-          <div v-else class="friends-list">
-            <div v-for="friend in friendsRates" :key="friend.nickname" class="friend-row">
-              <img :src="friend.avatar" class="friend-avatar" />
-              <span class="friend-name">{{ friend.nickname }}</span>
-              <span class="friend-status-badge" :class="'status-' + friend.status">
-                {{
-                  {
-                    planned: 'Planned',
-                    watching: 'Watching',
-                    rewatching: 'Rewatching',
-                    completed: 'Completed',
-                    on_hold: 'On Hold',
-                    dropped: 'Dropped'
-                  }[friend.status]
-                }}
-              </span>
-              <span class="friend-score">{{ friend.score > 0 ? friend.score + '/10' : '—' }}</span>
-              <span class="friend-episodes">{{
-                friend.episodes > 0
-                  ? 'ep ' +
-                    friend.episodes +
-                    (anime.numberOfEpisodes ? '/' + anime.numberOfEpisodes : '')
-                  : ''
-              }}</span>
-            </div>
-          </div>
-        </div>
-      </div>
+      <FriendsPanel
+        v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)"
+        v-model:collapsed="friendsCollapsed"
+        :friends-rates="friendsRates"
+        :friends-loading="friendsLoading"
+        :number-of-episodes="anime.numberOfEpisodes"
+      />
 
       <div class="controls">
         <div class="control-group">
@@ -2477,14 +2305,6 @@ function typeChip(type: string): { short: string; color: string } {
   text-decoration: underline;
 }
 
-.related-panel {
-  background-color: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 10px;
-  padding: 14px 18px;
-  margin-bottom: 20px;
-}
-
 .skip-panel {
   background-color: #16213e;
   border: 1px solid #0f3460;
@@ -2617,282 +2437,5 @@ function typeChip(type: string): { short: string; color: string } {
 
 .skip-empty {
   color: #4a4a6a;
-}
-
-.related-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  user-select: none;
-}
-
-.related-header-left {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.related-chevron {
-  color: #a0a0b8;
-  transition: transform 0.15s;
-}
-
-.related-chevron.collapsed {
-  transform: rotate(-90deg);
-}
-
-.related-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #a0a0b8;
-}
-
-.related-summary {
-  font-size: 0.8rem;
-  color: #6a6a8a;
-}
-
-.related-body {
-  margin-top: 10px;
-}
-
-.related-loading {
-  font-size: 0.85rem;
-  color: #6a6a8a;
-}
-
-.related-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.related-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  transition: background-color 0.1s;
-}
-
-.related-row.clickable {
-  cursor: pointer;
-}
-
-.related-row.clickable:hover,
-.related-row.clickable:focus-visible {
-  background-color: #1a2a4d;
-  outline: none;
-}
-
-.related-row.unavailable {
-  opacity: 0.55;
-}
-
-.related-row.current {
-  background-color: #0f3460;
-}
-
-.related-thumb {
-  width: 40px;
-  height: 56px;
-  object-fit: cover;
-  border-radius: 4px;
-  flex-shrink: 0;
-  background-color: #0f3460;
-}
-
-.related-info {
-  flex: 1;
-  min-width: 0;
-}
-
-.related-title {
-  color: #e0e0e0;
-  font-size: 0.9rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.related-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 3px;
-  flex-wrap: wrap;
-}
-
-.related-kind {
-  font-size: 0.7rem;
-  font-weight: 600;
-  color: #6a6a8a;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.related-year {
-  font-size: 0.72rem;
-  color: #6a6a8a;
-}
-
-.related-relation {
-  font-size: 0.78rem;
-  color: #a0a0b8;
-}
-
-.related-current-badge {
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  background-color: #e9456033;
-  color: #e94560;
-  white-space: nowrap;
-}
-
-.related-status-badge {
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  white-space: nowrap;
-}
-
-.related-unavailable-badge {
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.72rem;
-  font-weight: 600;
-  background-color: #6a6a8a1a;
-  color: #6a6a8a;
-  white-space: nowrap;
-}
-
-.friends-panel {
-  background-color: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 10px;
-  padding: 14px 18px;
-  margin-bottom: 20px;
-}
-
-.friends-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  user-select: none;
-}
-
-.friends-header-left {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.friends-chevron {
-  color: #a0a0b8;
-  transition: transform 0.15s;
-}
-
-.friends-chevron.collapsed {
-  transform: rotate(-90deg);
-}
-
-.friends-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #a0a0b8;
-}
-
-.friends-summary {
-  font-size: 0.8rem;
-  color: #6a6a8a;
-}
-
-.friends-body {
-  margin-top: 10px;
-}
-
-.friends-loading,
-.friends-empty {
-  font-size: 0.85rem;
-  color: #6a6a8a;
-}
-
-.friends-list {
-  display: grid;
-  grid-template-columns: 24px minmax(80px, auto) auto auto auto;
-  gap: 8px 12px;
-  align-items: center;
-  font-size: 0.85rem;
-}
-
-.friend-row {
-  display: contents;
-}
-
-.friend-avatar {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.friend-name {
-  color: #e0e0e0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.friend-status-badge {
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-align: center;
-  white-space: nowrap;
-}
-
-.status-watching {
-  background-color: #27ae601a;
-  color: #6ab04c;
-}
-.status-completed {
-  background-color: #3498db1a;
-  color: #3498db;
-}
-.status-planned {
-  background-color: #9b59b61a;
-  color: #9b59b6;
-}
-.status-on_hold {
-  background-color: #f39c121a;
-  color: #f39c12;
-}
-.status-dropped {
-  background-color: #e945601a;
-  color: #e94560;
-}
-.status-rewatching {
-  background-color: #1abc9c1a;
-  color: #1abc9c;
-}
-
-.friend-score {
-  color: #f39c12;
-  font-size: 0.8rem;
-  text-align: right;
-  white-space: nowrap;
-}
-
-.friend-episodes {
-  color: #6a6a8a;
-  font-size: 0.8rem;
-  white-space: nowrap;
 }
 </style>

--- a/src/renderer/src/components/detail/ChronologyPanel.vue
+++ b/src/renderer/src/components/detail/ChronologyPanel.vue
@@ -1,0 +1,311 @@
+<script setup lang="ts">
+import { useLibraryStore } from '../../stores/library';
+
+const props = defineProps<{
+  shikiRelated: ShikiRelatedEntry[];
+  relatedLoading: boolean;
+}>();
+
+const collapsed = defineModel<boolean>('collapsed', { default: true });
+
+const libraryStore = useLibraryStore();
+
+const KIND_LABELS: Record<string, string> = {
+  tv: 'TV',
+  tv_13: 'TV',
+  tv_24: 'TV',
+  tv_48: 'TV',
+  movie: 'Movie',
+  ova: 'OVA',
+  ona: 'ONA',
+  special: 'Special',
+  music: 'Music',
+  tv_special: 'TV Special',
+  pv: 'PV',
+  cm: 'CM'
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  planned: 'Planned',
+  watching: 'Watching',
+  rewatching: 'Rewatching',
+  completed: 'Watched',
+  on_hold: 'On Hold',
+  dropped: 'Dropped'
+};
+
+function open(entry: ShikiRelatedEntry): void {
+  if (entry.smotretAnime && !entry.isCurrent) {
+    libraryStore.openAnime(entry.smotretAnime.id);
+  }
+}
+</script>
+
+<template>
+  <div class="related-panel">
+    <div class="related-header" @click="collapsed = !collapsed">
+      <div class="related-header-left">
+        <svg
+          class="related-chevron"
+          :class="{ collapsed }"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="14"
+          height="14"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+        </svg>
+        <span class="related-label">Chronology</span>
+      </div>
+      <span v-if="relatedLoading" class="related-summary">Loading...</span>
+      <span v-else-if="props.shikiRelated.length > 0" class="related-summary"
+        >{{ props.shikiRelated.length }}
+        {{ props.shikiRelated.length === 1 ? 'entry' : 'entries' }}</span
+      >
+    </div>
+    <div v-if="!collapsed" class="related-body">
+      <div v-if="relatedLoading" class="related-loading">Loading chronology...</div>
+      <div v-else class="related-list">
+        <div
+          v-for="entry in props.shikiRelated"
+          :key="entry.shikiAnime.id"
+          class="related-row"
+          :class="{
+            clickable: entry.smotretAnime && !entry.isCurrent,
+            unavailable: !entry.smotretAnime,
+            current: entry.isCurrent
+          }"
+          :role="entry.smotretAnime && !entry.isCurrent ? 'button' : undefined"
+          :tabindex="entry.smotretAnime && !entry.isCurrent ? 0 : undefined"
+          @click="open(entry)"
+          @keydown.enter.prevent="open(entry)"
+          @keydown.space.prevent="open(entry)"
+        >
+          <img
+            :src="entry.smotretAnime?.posterUrlSmall || entry.shikiAnime.image_url || ''"
+            :alt="entry.shikiAnime.name"
+            class="related-thumb"
+            loading="lazy"
+          />
+          <div class="related-info">
+            <div class="related-title">{{ entry.shikiAnime.name }}</div>
+            <div class="related-meta">
+              <span v-if="entry.shikiAnime.kind" class="related-kind">{{
+                KIND_LABELS[entry.shikiAnime.kind] || entry.shikiAnime.kind.toUpperCase()
+              }}</span>
+              <span v-if="entry.shikiAnime.year" class="related-year">{{
+                entry.shikiAnime.year
+              }}</span>
+              <span v-if="entry.relation" class="related-relation">{{ entry.relation }}</span>
+              <span v-if="entry.isCurrent" class="related-current-badge">Current</span>
+              <span
+                v-if="entry.watchStatus"
+                class="related-status-badge"
+                :class="'status-' + entry.watchStatus"
+              >
+                {{ STATUS_LABELS[entry.watchStatus] }}
+              </span>
+              <span v-if="!entry.smotretAnime && !entry.isCurrent" class="related-unavailable-badge"
+                >Not available</span
+              >
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.related-panel {
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.related-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.related-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.related-chevron {
+  color: #a0a0b8;
+  transition: transform 0.15s;
+}
+
+.related-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.related-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.related-summary {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.related-body {
+  margin-top: 10px;
+}
+
+.related-loading {
+  font-size: 0.85rem;
+  color: #6a6a8a;
+}
+
+.related-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.related-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  transition: background-color 0.1s;
+}
+
+.related-row.clickable {
+  cursor: pointer;
+}
+
+.related-row.clickable:hover,
+.related-row.clickable:focus-visible {
+  background-color: #1a2a4d;
+  outline: none;
+}
+
+.related-row.unavailable {
+  opacity: 0.55;
+}
+
+.related-row.current {
+  background-color: #0f3460;
+}
+
+.related-thumb {
+  width: 40px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+  background-color: #0f3460;
+}
+
+.related-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.related-title {
+  color: #e0e0e0;
+  font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.related-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.related-kind {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #6a6a8a;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.related-year {
+  font-size: 0.72rem;
+  color: #6a6a8a;
+}
+
+.related-relation {
+  font-size: 0.78rem;
+  color: #a0a0b8;
+}
+
+.related-current-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background-color: #e9456033;
+  color: #e94560;
+  white-space: nowrap;
+}
+
+.related-status-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.related-unavailable-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background-color: #6a6a8a1a;
+  color: #6a6a8a;
+  white-space: nowrap;
+}
+
+.status-watching {
+  background-color: #27ae601a;
+  color: #6ab04c;
+}
+
+.status-completed {
+  background-color: #3498db1a;
+  color: #3498db;
+}
+
+.status-planned {
+  background-color: #9b59b61a;
+  color: #9b59b6;
+}
+
+.status-on_hold {
+  background-color: #f39c121a;
+  color: #f39c12;
+}
+
+.status-dropped {
+  background-color: #e945601a;
+  color: #e94560;
+}
+
+.status-rewatching {
+  background-color: #1abc9c1a;
+  color: #1abc9c;
+}
+</style>

--- a/src/renderer/src/components/detail/FriendsPanel.vue
+++ b/src/renderer/src/components/detail/FriendsPanel.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  friendsRates: ShikiFriendRate[];
+  friendsLoading: boolean;
+  numberOfEpisodes?: number;
+}>();
+
+const collapsed = defineModel<boolean>('collapsed', { default: false });
+
+const STATUS_LABELS: Record<string, string> = {
+  planned: 'Planned',
+  watching: 'Watching',
+  rewatching: 'Rewatching',
+  completed: 'Completed',
+  on_hold: 'On Hold',
+  dropped: 'Dropped'
+};
+
+const friendsSummary = computed(() => {
+  const counts = new Map<string, number>();
+  for (const r of props.friendsRates) {
+    counts.set(r.status, (counts.get(r.status) || 0) + 1);
+  }
+  const labels: Record<string, string> = {
+    watching: 'watching',
+    completed: 'completed',
+    planned: 'planned',
+    on_hold: 'on hold',
+    dropped: 'dropped',
+    rewatching: 'rewatching'
+  };
+  return [...counts.entries()]
+    .map(([status, count]) => `${count} ${labels[status] || status}`)
+    .join(' · ');
+});
+</script>
+
+<template>
+  <div class="friends-panel">
+    <div class="friends-header" @click="collapsed = !collapsed">
+      <div class="friends-header-left">
+        <svg
+          class="friends-chevron"
+          :class="{ collapsed }"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="14"
+          height="14"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+        </svg>
+        <span class="friends-label">Friends</span>
+      </div>
+      <span v-if="!friendsLoading && friendsRates.length > 0" class="friends-summary">{{
+        friendsSummary
+      }}</span>
+      <span v-if="friendsLoading" class="friends-summary">Loading...</span>
+    </div>
+    <div v-if="!collapsed" class="friends-body">
+      <div v-if="friendsLoading" class="friends-loading">Loading friends...</div>
+      <div v-else-if="friendsRates.length === 0" class="friends-empty">
+        None of your friends have watched this anime
+      </div>
+      <div v-else class="friends-list">
+        <div v-for="friend in friendsRates" :key="friend.nickname" class="friend-row">
+          <img :src="friend.avatar" class="friend-avatar" />
+          <span class="friend-name">{{ friend.nickname }}</span>
+          <span class="friend-status-badge" :class="'status-' + friend.status">
+            {{ STATUS_LABELS[friend.status] || friend.status }}
+          </span>
+          <span class="friend-score">{{ friend.score > 0 ? friend.score + '/10' : '—' }}</span>
+          <span class="friend-episodes">{{
+            friend.episodes > 0
+              ? 'ep ' + friend.episodes + (numberOfEpisodes ? '/' + numberOfEpisodes : '')
+              : ''
+          }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.friends-panel {
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.friends-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.friends-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.friends-chevron {
+  color: #a0a0b8;
+  transition: transform 0.15s;
+}
+
+.friends-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.friends-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.friends-summary {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.friends-body {
+  margin-top: 10px;
+}
+
+.friends-loading,
+.friends-empty {
+  font-size: 0.85rem;
+  color: #6a6a8a;
+}
+
+.friends-list {
+  display: grid;
+  grid-template-columns: 24px minmax(80px, auto) auto auto auto;
+  gap: 8px 12px;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.friend-row {
+  display: contents;
+}
+
+.friend-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.friend-name {
+  color: #e0e0e0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.friend-status-badge {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.status-watching {
+  background-color: #27ae601a;
+  color: #6ab04c;
+}
+
+.status-completed {
+  background-color: #3498db1a;
+  color: #3498db;
+}
+
+.status-planned {
+  background-color: #9b59b61a;
+  color: #9b59b6;
+}
+
+.status-on_hold {
+  background-color: #f39c121a;
+  color: #f39c12;
+}
+
+.status-dropped {
+  background-color: #e945601a;
+  color: #e94560;
+}
+
+.status-rewatching {
+  background-color: #1abc9c1a;
+  color: #1abc9c;
+}
+
+.friend-score {
+  color: #f39c12;
+  font-size: 0.8rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.friend-episodes {
+  color: #6a6a8a;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
## Summary

Third sub-slice of **Phase 5 slice 5b** (#118 / epic #84). Stacked on top of #122. First component decomposition of `AnimeDetailView` — two of the lower-risk sidebar panels move into `components/detail/`.

`AnimeDetailView.vue`: **2898 → 2441 lines** (~460-line shrink, +258 lines of component extraction).

> **Base branch is `phase5-slice-5b2-downloads-composable`** — diff against `main` retargets itself once #122 lands. Per [[feedback_stacked_pr_base_branch]] I'll switch the base to `main` *before* the 5b.2 branch is deleted on merge.

## Scope choice

Of the four sidebar panels in `AnimeDetailView` (Shikimori, Chronology, Friends, Skip Detection), this slice extracts the two with the simplest external contract: Chronology and Friends. Each takes a small prop set, has v-model'd collapsed state, and contains its own scoped CSS.

The **Shikimori panel** (rate edit form + offline indicator + sync state) and the **Skip Detection panel** (three broadcast subscriptions + chapter inject lifecycle) stay in `AnimeDetailView` because they'd benefit from their own composables before clean extraction. Those become later slices (5b.4 / 5c) if needed.

## What's in this slice

### `src/renderer/src/components/detail/ChronologyPanel.vue` (311 L)

Shikimori chronology (related anime in the franchise).

- **Props**: `shikiRelated: ShikiRelatedEntry[]`, `relatedLoading: boolean`
- **v-model**: `collapsed: boolean` (default `true`)
- Owns: `KIND_LABELS`, `STATUS_LABELS`, click/keyboard navigation, scoped CSS (`.related-*` + `.status-*`).
- Calls `useLibraryStore().openAnime()` directly to navigate when a related entry is clicked.

### `src/renderer/src/components/detail/FriendsPanel.vue` (217 L)

Friends' Shikimori watch status grid.

- **Props**: `friendsRates: ShikiFriendRate[]`, `friendsLoading: boolean`, `numberOfEpisodes?: number`
- **v-model**: `collapsed: boolean` (default `false`)
- Owns: the `friendsSummary` computed (status counts), `STATUS_LABELS`, scoped CSS (`.friends-*` + `.friend-*` + `.status-*`).

### `AnimeDetailView.vue` changes

- Two new imports (`ChronologyPanel`, `FriendsPanel`).
- The 89-line `<div class=\"related-panel\">` block collapses to a single `<ChronologyPanel ... />` invocation.
- The 55-line `<div class=\"friends-panel\">` block collapses to a single `<FriendsPanel ... />` invocation.
- `KIND_LABELS`, `STATUS_LABELS`, `friendsSummary` deleted from the parent's `<script setup>` (no longer used).
- `.related-*` + `.friends-*` + `.friend-*` + `.status-*` scoped CSS (~270 lines) removed from the parent and lives in the respective component scoped blocks.

## Behavior preserved (byte-identical)

- Same `v-if` gates: `anime.myAnimeListId && (relatedLoading || shikiRelated.length > 0)` for Chronology; `anime.myAnimeListId && (shikiUser || !shikiUserChecked)` for Friends.
- Same collapsed-state toggle behavior via `v-model`.
- Same click/keyboard navigation in Chronology (clickable rows for available smotret entries; disabled for current/unavailable).
- Same friend list grid layout + status badges.
- `.status-*` color classes preserved per-component since each tab scopes its styles independently — the cascade is identical to what one big scoped block produced before.

## Quality gate

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; 7 pre-existing warnings unchanged from `main`)
- `npm run format:check` ✓
- `npm run test` ✓ — **171/171 passing** (no new tests in this slice; existing composable tests still cover the data flow)
- `npm run build` ✓
- `bash scripts/check-subscription-contract.sh` ✓ — no `removeAllListeners` / `window.api.off*`

## Test plan

- [ ] Open an anime detail view for a show **with** a Shikimori MAL entry:
  - **Chronology panel** renders the related anime list. Click rows navigate to the related anime via the library store. \"Current\" badge appears on the current show. Unavailable entries are dimmed and not clickable. Keyboard Enter/Space on a clickable row navigates.
  - **Friends panel** shows friends' avatars/nicknames/status badges/scores/episodes. The summary line reflects the per-status counts. Empty state displays when no friends have watched.
- [ ] Open an anime **without** a Shikimori MAL entry — neither panel renders.
- [ ] Toggle the chevron on each panel — collapse/expand state persists per session.
- [ ] No visual difference vs. main (same layout, spacing, colors).

## Cumulative Phase 5 slice 5b trajectory

`AnimeDetailView.vue`: **3624 (main) → 3260 (5b.1) → 2898 (5b.2) → 2441 (5b.3)** — ~33% script reduction across 3 PRs.

| Slice | What | LoC delta |
|---|---|---:|
| 5b.1 (#121) | `useChronology` + `useAnimeDetailPrefs` + `useEpisodeList` composables | −365 |
| 5b.2 (#122) | `useEpisodeDownloads` composable | −362 |
| 5b.3 (this PR) | `ChronologyPanel` + `FriendsPanel` sub-components | −457 |

Plus: **4 composables** (1063 LoC) + **60 unit tests** (1072 LoC tests) + **2 sub-components** (528 LoC) — testable surface significantly larger than what was extracted.

Out of scope: ShikimoriPanel, SkipDetectionPanel, EpisodeList/EpisodeRow/TranslationPicker — those need their own composables first.

Part of #84 (Phase 5 slice 5b.3). Stacked on #122.