### PR TITLE
refactor: Phase 5 slice 5b.4 — Shikimori + Skip Detection composables + panels (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,6 +86,9 @@ Renderer (Vue)  --ipcRenderer.invoke-->  Preload (bridge)  --ipcMain.handle-->  
 | `src/renderer/src/components/AnimeDetailView.vue` | Episode list, translations, download/open/delete per episode, dequeue, download progress. Consumes `useAnimeDetailPrefs` + `useChronology` + `useEpisodeList` + `useEpisodeDownloads`. Renders `detail/ChronologyPanel.vue` + `detail/FriendsPanel.vue` for the Shikimori-driven sidebar panels |
 | `src/renderer/src/components/detail/ChronologyPanel.vue` | Related-anime list (Shikimori chronology). Props: `shikiRelated`, `relatedLoading`; v-model: `collapsed`. Calls `useLibraryStore().openAnime()` directly to navigate. Includes its own KIND_LABELS + STATUS_LABELS + scoped CSS |
 | `src/renderer/src/components/detail/FriendsPanel.vue` | Friends' Shikimori watch status. Props: `friendsRates`, `friendsLoading`, `numberOfEpisodes`; v-model: `collapsed`. Owns the `friendsSummary` computed (status counts) |
+| `src/renderer/src/components/detail/ShikimoriPanel.vue` | Shikimori rate edit form + offline indicator + sync state + details (genres + description with collapse). Props: `anime`. Injects the `useShikimori` composable instance via `ShikimoriKey` for state + actions; reads `offlineQueueLength` directly from `useShikimoriStore` |
+| `src/renderer/src/components/detail/SkipDetectionPanel.vue` | Local skip-detection + chapter-inject panel with collapse, run/cancel buttons, chapter-inject button, results table. Props: `filteredEpisodes`. Injects the `useSkipDetection` composable instance via `SkipDetectionKey` |
+| `src/renderer/src/components/detail/keys.ts` | Typed `InjectionKey` symbols (`ShikimoriKey`, `SkipDetectionKey`) the parent uses to `provide` composable instances to deeply-nested detail panels |
 | `src/renderer/src/components/DownloadsView.vue` | Real-time download queue with progress, merge controls |
 | `src/renderer/src/components/ShikimoriView.vue` | Shikimori anime list: browse watchlist, status filter, MAL ID resolution |
 | `src/renderer/src/components/FriendsActivityView.vue` | Chronological feed of recent anime activity from Shikimori friends |
@@ -443,6 +446,20 @@ Global app glue that doesn't belong on a Pinia store goes into
   (Shikimori-completed → eps[0] rewatch; Shikimori reports N → eps[N+1]; most
   recent unfinished saved position; first ep after last watched; else last ep).
   (Phase 5 slice 5b.2)
+- `useShikimori({ anime, shikimoriStore })` — Shikimori panel state: rate
+  edit form refs (status/episodes/score/rewatches), shikiUser + shikiUserChecked,
+  shikiLoading/Saving/Error, shikiDetails + descExpanded, friendsRates +
+  friendsLoading + friendsCollapsed, syncState + lastSyncError. Actions:
+  `loadShikimoriData(loadRelated)`, `shikiSave`, `triggerSyncNow`. Owns the
+  auto-status nudge watcher on shikiEpisodes plus the two store-cache mirror
+  watchers (rateByMalId, animeDetailsByMalId). (Phase 5 slice 5b.4)
+- `useSkipDetection({ getAnimeId, filteredEpisodes, fileStatus })` — local
+  skip-detection state: detections, analyzing flags, progress, errors, chapter
+  inject lifecycle. Computeds: `skipEpisodeInputs` (filtered/prefers-mkv),
+  `skipMkvEpisodeCount`, `skipProgressLabel`, `chapterInjectProgressLabel`.
+  Actions: `loadSkipDetections`, `hydrateSkipStatus`, `runSkipAnalysis`,
+  `cancelSkipAnalysis`, `injectChaptersToMkv`. Three `subscribe*` init
+  functions for the per-animeId-filtered broadcasts. (Phase 5 slice 5b.4)
 
 Composables that own broadcast subscriptions or DOM listeners (like
 `useKeyboardShortcuts`) bind those inside themselves; pure-logic composables

--- a/src/renderer/src/components/AnimeDetailView.vue
+++ b/src/renderer/src/components/AnimeDetailView.vue
@@ -6,13 +6,18 @@ import { useLibraryStore } from '../stores/library';
 import { usePlayerStore } from '../stores/player';
 import { useShikimoriStore } from '../stores/shikimori';
 import { useDownloadsStore } from '../stores/downloads';
-import { storeToRefs } from 'pinia';
 import { useAnimeDetailPrefs } from '../composables/use-anime-detail-prefs';
 import { useChronology } from '../composables/use-chronology';
+import { provide } from 'vue';
 import { useEpisodeList, PAGE_SIZE } from '../composables/use-episode-list';
 import { useEpisodeDownloads } from '../composables/use-episode-downloads';
+import { useShikimori } from '../composables/use-shikimori';
+import { useSkipDetection } from '../composables/use-skip-detection';
 import ChronologyPanel from './detail/ChronologyPanel.vue';
 import FriendsPanel from './detail/FriendsPanel.vue';
+import ShikimoriPanel from './detail/ShikimoriPanel.vue';
+import SkipDetectionPanel from './detail/SkipDetectionPanel.vue';
+import { ShikimoriKey, SkipDetectionKey } from './detail/keys';
 
 const props = defineProps<{
   animeId: number;
@@ -24,7 +29,8 @@ const libraryStore = useLibraryStore();
 const playerStore = usePlayerStore();
 const shikimoriStore = useShikimoriStore();
 const downloadsStore = useDownloadsStore();
-const { syncStatus, offlineQueueLength } = storeToRefs(shikimoriStore);
+// syncStatus + offlineQueueLength are consumed by ShikimoriPanel directly from
+// the store; the composable handles syncState/lastSyncError projections.
 
 const anime = ref<AnimeDetail | null>(null);
 const loading = ref(true);
@@ -97,76 +103,32 @@ const {
   resetEpisodeOverrides
 } = episodeList;
 
-// Shikimori state
-const shikiUser = ref<ShikiUser | null>(null);
-const shikiRate = ref<ShikiUserRate | null>(null);
-const shikiStatus = ref<ShikiUserRateStatus>('planned');
-const shikiEpisodes = ref(0);
-const shikiScore = ref(0);
-const shikiRewatches = ref(0);
-const shikiLoading = ref(false);
-const shikiSaving = ref(false);
-const shikiError = ref('');
-// syncState + lastSyncError are projections of `shikimoriStore.syncStatus`.
-const syncState = computed(() => syncStatus.value.state);
-const lastSyncError = computed(() => syncStatus.value.lastSyncError);
+const shikimori = useShikimori({ anime, shikimoriStore });
+provide(ShikimoriKey, shikimori);
+const {
+  shikiUser,
+  shikiRate,
+  shikiEpisodes,
+  shikiUserChecked,
+  shikiLoading,
+  friendsRates,
+  friendsLoading,
+  friendsCollapsed
+} = shikimori;
 
-// Friends state
-const friendsRates = ref<ShikiFriendRate[]>([]);
-const friendsLoading = ref(false);
-const friendsCollapsed = ref(false);
-const shikiUserChecked = ref(false);
-
-// Shikimori detailed info (description / genres) — cached in main process
-const shikiDetails = ref<ShikiAnimeDetails | null>(null);
-const descExpanded = ref(false);
-
-// Skip detection (Chromaprint local fingerprinting — debug panel only for now)
-const skipPanelCollapsed = ref(true);
-const skipDetections = ref<ShowSkipDetections | null>(null);
-const skipAnalyzing = ref(false);
-const skipProgress = ref<SkipDetectorProgress | null>(null);
-const skipError = ref<string>('');
-const chapterInjecting = ref(false);
-const chapterInjectProgress = ref<ChapterInjectProgress | null>(null);
-const chapterInjectError = ref<string>('');
-const chapterInjectResult = ref<{
-  written: number;
-  skipped: number;
-  failed: number;
-  total: number;
-} | null>(null);
-
-const shikiDetailsDescription = computed<string>(() => {
-  if (!shikiDetails.value) return '';
-  const src = shikiDetails.value.description;
-  if (src) {
-    return src
-      .replace(/\[\/?[a-zA-Z][^\]]*\]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
-  }
-  const html = shikiDetails.value.description_html;
-  if (!html) return '';
-  let stripped = html.replace(/<br\s*\/?>/gi, ' ');
-  let prev: string;
-  do {
-    prev = stripped;
-    stripped = stripped.replace(/<[^>]*>/g, '');
-  } while (stripped !== prev);
-  const entities: Record<string, string> = {
-    '&amp;': '&',
-    '&nbsp;': ' ',
-    '&lt;': '<',
-    '&gt;': '>',
-    '&quot;': '"',
-    '&#39;': "'"
-  };
-  return stripped
-    .replace(/&(?:amp|nbsp|lt|gt|quot|#39);/gi, (m) => entities[m.toLowerCase()] ?? m)
-    .replace(/\s+/g, ' ')
-    .trim();
+const skipDetection = useSkipDetection({
+  getAnimeId: () => props.animeId,
+  filteredEpisodes,
+  fileStatus
 });
+provide(SkipDetectionKey, skipDetection);
+const {
+  subscribeSkipDetectorProgress,
+  subscribeSkipDetectorSignatureUpdated,
+  subscribeChapterInjectProgress,
+  loadSkipDetections,
+  hydrateSkipStatus
+} = skipDetection;
 
 const playerMode = ref<'system' | 'builtin'>('system');
 
@@ -237,215 +199,6 @@ function onMouseBack(e: MouseEvent): void {
   if (e.button === 3) {
     e.preventDefault();
     libraryStore.closeAnime();
-  }
-}
-
-async function loadShikimoriData(): Promise<void> {
-  try {
-    shikiUser.value = await window.api.shikimoriGetUser();
-  } catch (err) {
-    console.error('Failed to load Shikimori user:', err);
-  } finally {
-    shikiUserChecked.value = true;
-  }
-  if (!anime.value?.myAnimeListId) return;
-
-  const relatedPromise = chronology.loadRelated(anime.value.myAnimeListId);
-
-  if (!shikiUser.value) {
-    await relatedPromise;
-    return;
-  }
-
-  shikiLoading.value = true;
-  friendsLoading.value = true;
-
-  // Load rate and friends in parallel, neither blocks the other
-  const ratePromise = window.api
-    .shikimoriGetRate(anime.value.myAnimeListId)
-    .then((rate) => {
-      shikiRate.value = rate;
-      if (rate) {
-        shikiStatus.value = rate.status;
-        shikiEpisodes.value = rate.episodes;
-        shikiScore.value = rate.score;
-        shikiRewatches.value = rate.rewatches ?? 0;
-      }
-    })
-    .catch((err) => console.error('Failed to load Shikimori rate:', err))
-    .finally(() => {
-      shikiLoading.value = false;
-    });
-
-  const friendsPromise = window.api
-    .shikimoriGetFriendsRates(anime.value.myAnimeListId)
-    .then((rates) => {
-      friendsRates.value = rates;
-    })
-    .catch((err) => console.error('Failed to load friends rates:', err))
-    .finally(() => {
-      friendsLoading.value = false;
-    });
-
-  const detailsPromise = window.api
-    .shikimoriGetAnimeDetails(anime.value.myAnimeListId)
-    .then((details) => {
-      shikiDetails.value = details;
-    })
-    .catch((err) => console.error('Failed to load Shikimori details:', err));
-
-  await Promise.all([ratePromise, friendsPromise, detailsPromise, relatedPromise]);
-}
-
-// --- Skip Detection (debug) -------------------------------------------------
-
-interface SkipEpisodeInput {
-  episodeInt: string;
-  episodeLabel: string;
-  filePath: string;
-}
-
-const skipEpisodeInputs = computed<SkipEpisodeInput[]>(() => {
-  const inputs: SkipEpisodeInput[] = [];
-  const seen = new Set<string>();
-  // Walk filteredEpisodes to keep an ordered, label-aware list. fileStatus is keyed by episodeInt.
-  for (const ep of filteredEpisodes.value) {
-    const files = fileStatus.value[ep.episodeInt];
-    if (!files || files.length === 0) continue;
-    // Prefer .mkv (merged) over .mp4 (raw); first match wins.
-    const mkv = files.find((f) => f.type === 'mkv');
-    const pick = mkv || files[0];
-    if (!pick || !pick.filePath) continue;
-    if (seen.has(ep.episodeInt)) continue;
-    seen.add(ep.episodeInt);
-    inputs.push({
-      episodeInt: ep.episodeInt,
-      episodeLabel: ep.episodeFull || `Episode ${ep.episodeInt}`,
-      filePath: pick.filePath
-    });
-  }
-  return inputs;
-});
-
-function formatSkipTime(sec: number): string {
-  if (!Number.isFinite(sec) || sec < 0) return '—';
-  const total = Math.round(sec);
-  const m = Math.floor(total / 60);
-  const s = total % 60;
-  return `${m}:${s.toString().padStart(2, '0')}`;
-}
-
-const skipProgressLabel = computed<string>(() => {
-  const p = skipProgress.value;
-  if (!p) return '';
-  if (p.phase === 'fingerprinting') {
-    const label = p.episodeLabel ? ` — ${p.episodeLabel}` : '';
-    return `Fingerprinting ${p.current}/${p.total}${label}`;
-  }
-  if (p.phase === 'comparing') {
-    return `Comparing pairs ${p.current}/${p.total}`;
-  }
-  return 'Done';
-});
-
-async function loadSkipDetections(): Promise<void> {
-  try {
-    const res = await window.api.skipDetectorGetDetections(props.animeId);
-    skipDetections.value = res;
-  } catch (err) {
-    console.error('Failed to load skip detections:', err);
-  }
-}
-
-// Recover the analyzing state if the user navigated away mid-analysis and
-// came back. Without this, the panel would show idle even though main is
-// still chewing on fingerprints — and a fresh "Analyze" click for this
-// same animeId would dedupe onto the in-flight promise (good), while a
-// click on a different anime's panel would now reject (also good).
-async function hydrateSkipStatus(): Promise<void> {
-  try {
-    const status = await window.api.skipDetectorGetStatus();
-    if (status && status.animeId === props.animeId) {
-      skipAnalyzing.value = true;
-      skipProgress.value = status.lastProgress;
-    }
-  } catch (err) {
-    console.error('Failed to hydrate skip status:', err);
-  }
-}
-
-async function runSkipAnalysis(): Promise<void> {
-  if (skipAnalyzing.value) return;
-  const inputs = skipEpisodeInputs.value;
-  if (inputs.length < 2) {
-    skipError.value = 'Need at least 2 downloaded episodes';
-    return;
-  }
-  skipError.value = '';
-  skipAnalyzing.value = true;
-  skipProgress.value = {
-    animeId: props.animeId,
-    phase: 'fingerprinting',
-    current: 0,
-    total: inputs.length
-  };
-  try {
-    const result = await window.api.skipDetectorAnalyzeShow(props.animeId, inputs);
-    skipDetections.value = result;
-  } catch (err) {
-    skipError.value = err instanceof Error ? err.message : String(err);
-  } finally {
-    skipAnalyzing.value = false;
-    skipProgress.value = null;
-  }
-}
-
-async function cancelSkipAnalysis(): Promise<void> {
-  try {
-    await window.api.skipDetectorCancel();
-  } catch (err) {
-    console.error('Failed to cancel skip analysis:', err);
-  }
-}
-
-const skipMkvEpisodeCount = computed<number>(
-  () => skipEpisodeInputs.value.filter((e) => e.filePath.toLowerCase().endsWith('.mkv')).length
-);
-
-const chapterInjectProgressLabel = computed<string>(() => {
-  const p = chapterInjectProgress.value;
-  if (!p) return '';
-  if (p.phase === 'analyzing') return 'Analyzing fingerprints…';
-  if (p.phase === 'writing') {
-    const label = p.episodeLabel ? ` — ${p.episodeLabel}` : '';
-    return `Writing chapters ${p.current + 1}/${p.total}${label}`;
-  }
-  return 'Done';
-});
-
-async function injectChaptersToMkv(): Promise<void> {
-  if (chapterInjecting.value) return;
-  if (skipMkvEpisodeCount.value < 3) {
-    chapterInjectError.value = 'Need at least 3 downloaded MKV episodes';
-    return;
-  }
-  chapterInjectError.value = '';
-  chapterInjectResult.value = null;
-  chapterInjecting.value = true;
-  chapterInjectProgress.value = {
-    animeId: props.animeId,
-    phase: 'writing',
-    current: 0,
-    total: skipMkvEpisodeCount.value
-  };
-  try {
-    const res = await window.api.injectChapters(props.animeId, skipEpisodeInputs.value);
-    chapterInjectResult.value = res;
-  } catch (err) {
-    chapterInjectError.value = err instanceof Error ? err.message : String(err);
-  } finally {
-    chapterInjecting.value = false;
-    chapterInjectProgress.value = null;
   }
 }
 
@@ -521,7 +274,7 @@ onMounted(async () => {
   unsubFileEpisodesChanged = subscribeFileEpisodesChanged();
 
   // Load Shikimori data (non-blocking — don't hold up the episode list)
-  loadShikimoriData();
+  void shikimori.loadShikimoriData(chronology.loadRelated);
 
   // Load watch progress for episode indicators
   loadWatchProgress();
@@ -534,56 +287,12 @@ onMounted(async () => {
 
   // Skip-detector + chapter-inject progress are anime-specific, so they stay
   // as component-local subscriptions (filtered by props.animeId).
-  unsubSkipDetectorProgress = window.api.onSkipDetectorProgress((data) => {
-    if (data.animeId !== props.animeId) return;
-    skipProgress.value = data;
-    skipAnalyzing.value = data.phase !== 'done';
-  });
-  unsubSkipDetectorSignatureUpdated = window.api.onSkipDetectorSignatureUpdated((data) => {
-    if (data.animeId !== props.animeId) return;
-    loadSkipDetections();
-  });
-  unsubChapterInjectProgress = window.api.onChapterInjectProgress((data) => {
-    if (data.animeId !== props.animeId) return;
-    chapterInjectProgress.value = data;
-    chapterInjecting.value = data.phase !== 'done';
-  });
-  loadSkipDetections();
-  hydrateSkipStatus();
+  unsubSkipDetectorProgress = subscribeSkipDetectorProgress();
+  unsubSkipDetectorSignatureUpdated = subscribeSkipDetectorSignatureUpdated();
+  unsubChapterInjectProgress = subscribeChapterInjectProgress();
+  void loadSkipDetections();
+  void hydrateSkipStatus();
 });
-
-// Sync the editable shiki* refs whenever the store's rate cache for this
-// anime's malId changes (broadcast-driven by the store).
-watch(
-  () => (anime.value?.myAnimeListId ? shikimoriStore.rateByMalId(anime.value.myAnimeListId) : null),
-  (entry) => {
-    if (!entry) return;
-    shikiRate.value = {
-      id: entry.rate.id,
-      score: entry.rate.score,
-      status: entry.rate.status,
-      episodes: entry.rate.episodes,
-      rewatches: entry.rate.rewatches ?? 0,
-      target_id: entry.rate.target_id,
-      target_type: 'Anime'
-    };
-    shikiStatus.value = entry.rate.status;
-    shikiEpisodes.value = entry.rate.episodes;
-    shikiScore.value = entry.rate.score;
-    shikiRewatches.value = entry.rate.rewatches ?? 0;
-  }
-);
-
-// Sync shikiDetails from the store's per-malId cache.
-watch(
-  () =>
-    anime.value?.myAnimeListId
-      ? shikimoriStore.animeDetailsByMalId(anime.value.myAnimeListId)
-      : null,
-  (details) => {
-    if (details) shikiDetails.value = details;
-  }
-);
 
 // Mirror store-owned download progress into the local episode-row projection.
 watch(
@@ -602,52 +311,6 @@ onUnmounted(() => {
   unsubSkipDetectorSignatureUpdated?.();
   unsubChapterInjectProgress?.();
 });
-
-async function triggerSyncNow(): Promise<void> {
-  await shikimoriStore.triggerSync();
-}
-
-const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
-  { value: 'planned', label: 'Planned' },
-  { value: 'watching', label: 'Watching' },
-  { value: 'rewatching', label: 'Rewatching' },
-  { value: 'completed', label: 'Completed' },
-  { value: 'on_hold', label: 'On Hold' },
-  { value: 'dropped', label: 'Dropped' }
-];
-
-watch(shikiEpisodes, (eps) => {
-  if (anime.value?.numberOfEpisodes && eps >= anime.value.numberOfEpisodes) {
-    shikiStatus.value = 'completed';
-  } else if (eps > 0) {
-    if (shikiStatus.value === 'completed') {
-      shikiStatus.value = 'rewatching';
-    } else if (shikiStatus.value === 'planned') {
-      shikiStatus.value = 'watching';
-    }
-  }
-});
-
-async function shikiSave(): Promise<void> {
-  if (!anime.value?.myAnimeListId) return;
-  shikiSaving.value = true;
-  shikiError.value = '';
-  try {
-    const rate = await window.api.shikimoriUpdateRate(
-      anime.value.myAnimeListId,
-      shikiEpisodes.value,
-      shikiStatus.value,
-      shikiScore.value,
-      shikiRewatches.value
-    );
-    shikiRate.value = rate;
-    shikiRewatches.value = rate.rewatches ?? shikiRewatches.value;
-  } catch (err) {
-    shikiError.value = String(err);
-  } finally {
-    shikiSaving.value = false;
-  }
-}
 
 // Wraps the prefs composable's helper so call sites stay terse.
 function applyDownloadedTranslationDefault(): void {
@@ -674,7 +337,7 @@ async function toggleStar(): Promise<void> {
 }
 
 const isShowFinished = computed<boolean>(() => {
-  const status = shikiDetails.value?.status;
+  const status = shikimori.shikiDetails.value?.status;
   return status === 'released';
 });
 
@@ -899,130 +562,10 @@ function typeChip(type: string): { short: string; color: string } {
         </div>
       </div>
 
-      <div v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)" class="shiki-panel">
-        <template v-if="shikiUser">
-          <div class="shiki-header">
-            <span class="shiki-label">Shikimori</span>
-            <a
-              :href="`https://shikimori.one/animes/${anime.myAnimeListId}`"
-              target="_blank"
-              class="shiki-link"
-            >
-              Open on Shikimori
-            </a>
-          </div>
-          <div v-if="shikiLoading" class="shiki-loading">Loading...</div>
-          <div v-else class="shiki-controls">
-            <select v-model="shikiStatus" class="select shiki-select">
-              <option v-for="s in SHIKI_STATUSES" :key="s.value" :value="s.value">
-                {{ s.label }}
-              </option>
-            </select>
-            <div class="shiki-episodes">
-              <span>Episodes:</span>
-              <input
-                v-model.number="shikiEpisodes"
-                type="number"
-                min="0"
-                :max="anime.numberOfEpisodes || undefined"
-                class="shiki-ep-input"
-              />
-              <span v-if="anime.numberOfEpisodes" class="shiki-ep-total"
-                >/ {{ anime.numberOfEpisodes }}</span
-              >
-            </div>
-            <div class="shiki-episodes">
-              <span>Score:</span>
-              <select v-model.number="shikiScore" class="select shiki-score-select">
-                <option :value="0">—</option>
-                <option v-for="n in 10" :key="n" :value="n">{{ n }}</option>
-              </select>
-            </div>
-            <div class="shiki-episodes" title="Number of times you've rewatched this anime">
-              <span>Rewatches:</span>
-              <input v-model.number="shikiRewatches" type="number" min="0" class="shiki-ep-input" />
-            </div>
-            <button class="shiki-save-btn" :disabled="shikiSaving" @click="shikiSave">
-              {{ shikiSaving ? 'Saving...' : 'Save' }}
-            </button>
-          </div>
-          <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
-          <div
-            v-if="offlineQueueLength > 0"
-            class="shiki-offline"
-            :class="{ 'shiki-syncing': syncState === 'syncing' }"
-            :title="lastSyncError || ''"
-          >
-            <svg
-              v-if="syncState === 'syncing'"
-              class="shiki-offline-spin"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="14"
-              height="14"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-6.219-8.56" />
-            </svg>
-            <svg
-              v-else
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="14"
-              height="14"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M3 3l18 18M12 5a7 7 0 016.95 6.155A4 4 0 0118 19H9m-3-2a4 4 0 01-1.9-7.516"
-              />
-            </svg>
-            <span v-if="syncState === 'syncing'">
-              Syncing {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }}…
-            </span>
-            <span v-else>
-              Working offline — {{ offlineQueueLength }} change{{
-                offlineQueueLength > 1 ? 's' : ''
-              }}
-              queued
-            </span>
-            <button
-              v-if="syncState === 'idle'"
-              type="button"
-              class="shiki-offline-retry"
-              @click="triggerSyncNow"
-            >
-              Retry now
-            </button>
-          </div>
-          <div v-if="shikiDetails" class="shiki-details">
-            <div v-if="shikiDetails.genres?.length" class="shiki-genres">
-              <span v-for="g in shikiDetails.genres" :key="g.id" class="shiki-genre-tag">
-                {{ g.russian || g.name }}
-              </span>
-            </div>
-            <p
-              v-if="shikiDetailsDescription"
-              class="shiki-description"
-              :class="{ collapsed: !descExpanded }"
-            >
-              {{ shikiDetailsDescription }}
-            </p>
-            <button
-              v-if="shikiDetailsDescription && shikiDetailsDescription.length > 320"
-              type="button"
-              class="shiki-desc-toggle"
-              @click="descExpanded = !descExpanded"
-            >
-              {{ descExpanded ? 'Show less' : 'Show more' }}
-            </button>
-          </div>
-        </template>
-        <div v-else class="shiki-loading">Loading...</div>
-      </div>
+      <ShikimoriPanel
+        v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)"
+        :anime="anime"
+      />
 
       <ChronologyPanel
         v-if="anime.myAnimeListId && (relatedLoading || shikiRelated.length > 0)"
@@ -1031,130 +574,7 @@ function typeChip(type: string): { short: string; color: string } {
         :related-loading="relatedLoading"
       />
 
-      <div class="skip-panel">
-        <div class="skip-header" @click="skipPanelCollapsed = !skipPanelCollapsed">
-          <div class="skip-header-left">
-            <svg
-              class="skip-chevron"
-              :class="{ collapsed: skipPanelCollapsed }"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              width="14"
-              height="14"
-            >
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
-            </svg>
-            <span class="skip-label">Skip Detection (experimental)</span>
-          </div>
-          <span v-if="skipAnalyzing" class="skip-summary">{{ skipProgressLabel }}</span>
-          <span v-else-if="skipDetections" class="skip-summary">
-            {{ Object.keys(skipDetections.perEpisode).length }} episodes analyzed
-          </span>
-          <span v-else class="skip-summary">{{ skipEpisodeInputs.length }} downloaded</span>
-        </div>
-        <div v-if="!skipPanelCollapsed" class="skip-body">
-          <div v-if="skipEpisodeInputs.length < 2" class="skip-disabled">
-            Need at least 2 downloaded episodes to analyze. Currently downloaded:
-            {{ skipEpisodeInputs.length }}.
-          </div>
-          <template v-else>
-            <div class="skip-actions">
-              <button v-if="!skipAnalyzing" class="skip-button" @click="runSkipAnalysis">
-                {{ skipDetections ? 'Re-analyze' : `Analyze ${skipEpisodeInputs.length} episodes` }}
-              </button>
-              <button v-else class="skip-button skip-button-cancel" @click="cancelSkipAnalysis">
-                Cancel
-              </button>
-              <span v-if="skipAnalyzing" class="skip-progress-text">{{ skipProgressLabel }}</span>
-              <button
-                v-if="skipMkvEpisodeCount >= 3"
-                class="skip-button"
-                :disabled="chapterInjecting || skipAnalyzing"
-                @click="injectChaptersToMkv"
-              >
-                {{ chapterInjecting ? 'Saving chapters…' : 'Save chapters to MKV' }}
-              </button>
-              <span v-if="chapterInjecting" class="skip-progress-text">{{
-                chapterInjectProgressLabel
-              }}</span>
-            </div>
-            <div v-if="skipError" class="skip-error">{{ skipError }}</div>
-            <div v-if="chapterInjectError" class="skip-error">{{ chapterInjectError }}</div>
-            <div v-if="chapterInjectResult" class="skip-results-meta">
-              Wrote chapters to {{ chapterInjectResult.written }}/{{ chapterInjectResult.total }}
-              episodes
-              <template v-if="chapterInjectResult.skipped">
-                · {{ chapterInjectResult.skipped }} skipped (no detection)
-              </template>
-              <template v-if="chapterInjectResult.failed">
-                · {{ chapterInjectResult.failed }} failed
-              </template>
-            </div>
-            <div v-if="skipDetections" class="skip-results">
-              <div class="skip-results-meta">
-                Analyzed {{ new Date(skipDetections.analyzedAt).toLocaleString() }} · window
-                {{ skipDetections.algorithm.windowSec }}s · min run
-                {{ skipDetections.algorithm.minRunSec }}s · threshold
-                {{ skipDetections.algorithm.matchBitThreshold }}/32 bits
-              </div>
-              <table class="skip-table">
-                <thead>
-                  <tr>
-                    <th>Episode</th>
-                    <th>OP</th>
-                    <th>ED</th>
-                    <th>Duration</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="ep in filteredEpisodes" :key="ep.episodeInt">
-                    <template v-if="skipDetections.perEpisode[ep.episodeInt]">
-                      <td>{{ ep.episodeFull || `Episode ${ep.episodeInt}` }}</td>
-                      <td>
-                        <template v-if="skipDetections.perEpisode[ep.episodeInt].op">
-                          {{
-                            formatSkipTime(skipDetections.perEpisode[ep.episodeInt].op!.startSec)
-                          }}–{{
-                            formatSkipTime(skipDetections.perEpisode[ep.episodeInt].op!.endSec)
-                          }}
-                          <span class="skip-pair-count"
-                            >({{
-                              skipDetections.perEpisode[ep.episodeInt].op!.pairCount
-                            }}
-                            pairs)</span
-                          >
-                        </template>
-                        <span v-else class="skip-empty">—</span>
-                      </td>
-                      <td>
-                        <template v-if="skipDetections.perEpisode[ep.episodeInt].ed">
-                          {{
-                            formatSkipTime(skipDetections.perEpisode[ep.episodeInt].ed!.startSec)
-                          }}–{{
-                            formatSkipTime(skipDetections.perEpisode[ep.episodeInt].ed!.endSec)
-                          }}
-                          <span class="skip-pair-count"
-                            >({{
-                              skipDetections.perEpisode[ep.episodeInt].ed!.pairCount
-                            }}
-                            pairs)</span
-                          >
-                        </template>
-                        <span v-else class="skip-empty">—</span>
-                      </td>
-                      <td>
-                        {{ formatSkipTime(skipDetections.perEpisode[ep.episodeInt].durationSec) }}
-                      </td>
-                    </template>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </template>
-        </div>
-      </div>
+      <SkipDetectionPanel :filtered-episodes="filteredEpisodes" />
 
       <FriendsPanel
         v-if="anime.myAnimeListId && (shikiUser || !shikiUserChecked)"
@@ -2101,341 +1521,5 @@ function typeChip(type: string): { short: string; color: string } {
   color: #4a4a6a;
   font-size: 1.1rem;
   padding-top: 100px;
-}
-
-.shiki-panel {
-  background-color: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 10px;
-  padding: 14px 18px;
-  margin-bottom: 20px;
-}
-
-.shiki-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.shiki-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #a0a0b8;
-}
-
-.shiki-link {
-  font-size: 0.8rem;
-  color: #3498db;
-  text-decoration: none;
-}
-
-.shiki-link:hover {
-  text-decoration: underline;
-}
-
-.shiki-loading {
-  font-size: 0.85rem;
-  color: #6a6a8a;
-}
-
-.shiki-controls {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex-wrap: wrap;
-}
-
-.shiki-select {
-  min-width: 130px;
-}
-
-.shiki-episodes {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.85rem;
-  color: #a0a0b8;
-}
-
-.shiki-ep-input {
-  width: 60px;
-  padding: 6px 8px;
-  background-color: #1a1a2e;
-  border: 1px solid #0f3460;
-  border-radius: 6px;
-  color: #e0e0e0;
-  font-size: 0.85rem;
-  text-align: center;
-}
-
-.shiki-ep-input:focus {
-  outline: none;
-  border-color: #e94560;
-}
-
-.shiki-ep-total {
-  color: #6a6a8a;
-}
-
-.shiki-score-select {
-  width: 60px;
-}
-
-.shiki-save-btn {
-  padding: 6px 16px;
-  background-color: #0f3460;
-  border: none;
-  border-radius: 6px;
-  color: #e0e0e0;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background-color 0.15s;
-}
-
-.shiki-save-btn:hover {
-  background-color: #1a4a7a;
-}
-
-.shiki-save-btn:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.shiki-error {
-  margin-top: 8px;
-  font-size: 0.8rem;
-  color: #e94560;
-}
-
-.shiki-offline {
-  margin-top: 8px;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  font-size: 0.78rem;
-  color: #f0a75f;
-  background: rgba(240, 167, 95, 0.12);
-  border: 1px solid rgba(240, 167, 95, 0.3);
-  border-radius: 4px;
-}
-
-.shiki-offline.shiki-syncing {
-  color: #5e9cd8;
-  background: rgba(94, 156, 216, 0.12);
-  border-color: rgba(94, 156, 216, 0.3);
-}
-
-.shiki-offline-spin {
-  animation: shiki-offline-rotate 0.9s linear infinite;
-}
-
-@keyframes shiki-offline-rotate {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.shiki-offline-retry {
-  margin-left: 4px;
-  padding: 2px 8px;
-  font-size: 0.72rem;
-  color: #f0a75f;
-  background: transparent;
-  border: 1px solid rgba(240, 167, 95, 0.5);
-  border-radius: 3px;
-  cursor: pointer;
-}
-
-.shiki-offline-retry:hover {
-  background: rgba(240, 167, 95, 0.15);
-}
-
-.shiki-details {
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid rgba(15, 52, 96, 0.6);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.shiki-genres {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-}
-
-.shiki-genre-tag {
-  font-size: 0.72rem;
-  color: #cdd6e4;
-  background: rgba(15, 52, 96, 0.5);
-  border: 1px solid rgba(94, 156, 216, 0.25);
-  border-radius: 10px;
-  padding: 2px 8px;
-}
-
-.shiki-description {
-  margin: 0;
-  font-size: 0.85rem;
-  color: #b8c2d4;
-  line-height: 1.45;
-  white-space: pre-wrap;
-}
-
-.shiki-description.collapsed {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.shiki-desc-toggle {
-  align-self: flex-start;
-  font-size: 0.75rem;
-  color: #5e9cd8;
-  background: transparent;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-}
-
-.shiki-desc-toggle:hover {
-  text-decoration: underline;
-}
-
-.skip-panel {
-  background-color: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 10px;
-  padding: 14px 18px;
-  margin-bottom: 20px;
-}
-
-.skip-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  cursor: pointer;
-  user-select: none;
-}
-
-.skip-header-left {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.skip-chevron {
-  color: #a0a0b8;
-  transition: transform 0.15s;
-}
-
-.skip-chevron.collapsed {
-  transform: rotate(-90deg);
-}
-
-.skip-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #a0a0b8;
-}
-
-.skip-summary {
-  font-size: 0.8rem;
-  color: #6a6a8a;
-}
-
-.skip-body {
-  margin-top: 10px;
-}
-
-.skip-disabled {
-  font-size: 0.85rem;
-  color: #6a6a8a;
-  font-style: italic;
-}
-
-.skip-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 10px;
-}
-
-.skip-button {
-  background-color: #0f3460;
-  color: #e0e0e0;
-  border: 1px solid #1f4980;
-  padding: 6px 12px;
-  border-radius: 6px;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background-color 0.1s;
-}
-
-.skip-button:hover {
-  background-color: #1a4880;
-}
-
-.skip-button-cancel {
-  background-color: #5a2222;
-  border-color: #803030;
-}
-
-.skip-button-cancel:hover {
-  background-color: #803030;
-}
-
-.skip-progress-text {
-  font-size: 0.8rem;
-  color: #a0a0b8;
-}
-
-.skip-error {
-  font-size: 0.8rem;
-  color: #ff6a6a;
-  margin-bottom: 10px;
-}
-
-.skip-results-meta {
-  font-size: 0.75rem;
-  color: #6a6a8a;
-  margin-bottom: 8px;
-}
-
-.skip-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.82rem;
-}
-
-.skip-table th {
-  text-align: left;
-  padding: 4px 8px;
-  color: #a0a0b8;
-  font-weight: 600;
-  border-bottom: 1px solid #0f3460;
-}
-
-.skip-table td {
-  padding: 4px 8px;
-  color: #d0d0e0;
-  border-bottom: 1px solid #1a2a4d;
-}
-
-.skip-table tr:last-child td {
-  border-bottom: none;
-}
-
-.skip-pair-count {
-  color: #6a6a8a;
-  font-size: 0.7rem;
-  margin-left: 4px;
-}
-
-.skip-empty {
-  color: #4a4a6a;
 }
 </style>

--- a/src/renderer/src/components/detail/ShikimoriPanel.vue
+++ b/src/renderer/src/components/detail/ShikimoriPanel.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+import { inject } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useShikimoriStore } from '../../stores/shikimori';
+import { ShikimoriKey } from './keys';
+
+const props = defineProps<{
+  anime: AnimeDetail;
+}>();
+
+const shikimori = inject(ShikimoriKey);
+if (!shikimori) throw new Error('ShikimoriPanel: missing ShikimoriKey injection');
+
+const {
+  shikiUser,
+  shikiStatus,
+  shikiEpisodes,
+  shikiScore,
+  shikiRewatches,
+  shikiLoading,
+  shikiSaving,
+  shikiError,
+  shikiDetails,
+  descExpanded,
+  shikiDetailsDescription,
+  syncState,
+  lastSyncError,
+  shikiSave,
+  triggerSyncNow
+} = shikimori;
+
+const { offlineQueueLength } = storeToRefs(useShikimoriStore());
+
+const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
+  { value: 'planned', label: 'Planned' },
+  { value: 'watching', label: 'Watching' },
+  { value: 'rewatching', label: 'Rewatching' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'on_hold', label: 'On Hold' },
+  { value: 'dropped', label: 'Dropped' }
+];
+</script>
+
+<template>
+  <div class="shiki-panel">
+    <template v-if="shikiUser">
+      <div class="shiki-header">
+        <span class="shiki-label">Shikimori</span>
+        <a
+          :href="`https://shikimori.one/animes/${props.anime.myAnimeListId}`"
+          target="_blank"
+          class="shiki-link"
+        >
+          Open on Shikimori
+        </a>
+      </div>
+      <div v-if="shikiLoading" class="shiki-loading">Loading...</div>
+      <div v-else class="shiki-controls">
+        <select v-model="shikiStatus" class="select shiki-select">
+          <option v-for="s in SHIKI_STATUSES" :key="s.value" :value="s.value">
+            {{ s.label }}
+          </option>
+        </select>
+        <div class="shiki-episodes">
+          <span>Episodes:</span>
+          <input
+            v-model.number="shikiEpisodes"
+            type="number"
+            min="0"
+            :max="props.anime.numberOfEpisodes || undefined"
+            class="shiki-ep-input"
+          />
+          <span v-if="props.anime.numberOfEpisodes" class="shiki-ep-total"
+            >/ {{ props.anime.numberOfEpisodes }}</span
+          >
+        </div>
+        <div class="shiki-episodes">
+          <span>Score:</span>
+          <select v-model.number="shikiScore" class="select shiki-score-select">
+            <option :value="0">—</option>
+            <option v-for="n in 10" :key="n" :value="n">{{ n }}</option>
+          </select>
+        </div>
+        <div class="shiki-episodes" title="Number of times you've rewatched this anime">
+          <span>Rewatches:</span>
+          <input v-model.number="shikiRewatches" type="number" min="0" class="shiki-ep-input" />
+        </div>
+        <button class="shiki-save-btn" :disabled="shikiSaving" @click="shikiSave">
+          {{ shikiSaving ? 'Saving...' : 'Save' }}
+        </button>
+      </div>
+      <div v-if="shikiError" class="shiki-error">{{ shikiError }}</div>
+      <div
+        v-if="offlineQueueLength > 0"
+        class="shiki-offline"
+        :class="{ 'shiki-syncing': syncState === 'syncing' }"
+        :title="lastSyncError || ''"
+      >
+        <svg
+          v-if="syncState === 'syncing'"
+          class="shiki-offline-spin"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="14"
+          height="14"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-6.219-8.56" />
+        </svg>
+        <svg
+          v-else
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="14"
+          height="14"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M3 3l18 18M12 5a7 7 0 016.95 6.155A4 4 0 0118 19H9m-3-2a4 4 0 01-1.9-7.516"
+          />
+        </svg>
+        <span v-if="syncState === 'syncing'">
+          Syncing {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }}…
+        </span>
+        <span v-else>
+          Working offline — {{ offlineQueueLength }} change{{ offlineQueueLength > 1 ? 's' : '' }}
+          queued
+        </span>
+        <button
+          v-if="syncState === 'idle'"
+          type="button"
+          class="shiki-offline-retry"
+          @click="triggerSyncNow"
+        >
+          Retry now
+        </button>
+      </div>
+      <div v-if="shikiDetails" class="shiki-details">
+        <div v-if="shikiDetails.genres?.length" class="shiki-genres">
+          <span v-for="g in shikiDetails.genres" :key="g.id" class="shiki-genre-tag">
+            {{ g.russian || g.name }}
+          </span>
+        </div>
+        <p
+          v-if="shikiDetailsDescription"
+          class="shiki-description"
+          :class="{ collapsed: !descExpanded }"
+        >
+          {{ shikiDetailsDescription }}
+        </p>
+        <button
+          v-if="shikiDetailsDescription && shikiDetailsDescription.length > 320"
+          type="button"
+          class="shiki-desc-toggle"
+          @click="descExpanded = !descExpanded"
+        >
+          {{ descExpanded ? 'Show less' : 'Show more' }}
+        </button>
+      </div>
+    </template>
+    <div v-else class="shiki-loading">Loading...</div>
+  </div>
+</template>
+
+<style scoped>
+.shiki-panel {
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.shiki-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.shiki-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.shiki-link {
+  font-size: 0.8rem;
+  color: #3498db;
+  text-decoration: none;
+}
+
+.shiki-link:hover {
+  text-decoration: underline;
+}
+
+.shiki-loading {
+  font-size: 0.85rem;
+  color: #6a6a8a;
+}
+
+.shiki-controls {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.shiki-select {
+  min-width: 130px;
+}
+
+.shiki-episodes {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: #a0a0b8;
+}
+
+.shiki-ep-input {
+  width: 60px;
+  padding: 6px 8px;
+  background-color: #1a1a2e;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.shiki-ep-input:focus {
+  outline: none;
+  border-color: #e94560;
+}
+
+.shiki-ep-total {
+  color: #6a6a8a;
+}
+
+.shiki-score-select {
+  width: 60px;
+}
+
+.shiki-save-btn {
+  padding: 6px 16px;
+  background-color: #0f3460;
+  border: none;
+  border-radius: 6px;
+  color: #e0e0e0;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.shiki-save-btn:hover {
+  background-color: #1a4a7a;
+}
+
+.shiki-save-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.shiki-error {
+  margin-top: 8px;
+  font-size: 0.8rem;
+  color: #e94560;
+}
+
+.shiki-offline {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  color: #f0a75f;
+  background: rgba(240, 167, 95, 0.12);
+  border: 1px solid rgba(240, 167, 95, 0.3);
+  border-radius: 4px;
+}
+
+.shiki-offline.shiki-syncing {
+  color: #5e9cd8;
+  background: rgba(94, 156, 216, 0.12);
+  border-color: rgba(94, 156, 216, 0.3);
+}
+
+.shiki-offline-spin {
+  animation: shiki-offline-rotate 0.9s linear infinite;
+}
+
+@keyframes shiki-offline-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.shiki-offline-retry {
+  margin-left: 4px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  color: #f0a75f;
+  background: transparent;
+  border: 1px solid rgba(240, 167, 95, 0.5);
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.shiki-offline-retry:hover {
+  background: rgba(240, 167, 95, 0.15);
+}
+
+.shiki-details {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(15, 52, 96, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.shiki-genres {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.shiki-genre-tag {
+  font-size: 0.72rem;
+  color: #cdd6e4;
+  background: rgba(15, 52, 96, 0.5);
+  border: 1px solid rgba(94, 156, 216, 0.25);
+  border-radius: 10px;
+  padding: 2px 8px;
+}
+
+.shiki-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #b8c2d4;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.shiki-description.collapsed {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.shiki-desc-toggle {
+  align-self: flex-start;
+  font-size: 0.75rem;
+  color: #5e9cd8;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.shiki-desc-toggle:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/renderer/src/components/detail/SkipDetectionPanel.vue
+++ b/src/renderer/src/components/detail/SkipDetectionPanel.vue
@@ -1,0 +1,282 @@
+<script setup lang="ts">
+import { inject } from 'vue';
+import { SkipDetectionKey } from './keys';
+
+const props = defineProps<{
+  filteredEpisodes: EpisodeSummary[];
+}>();
+
+const skip = inject(SkipDetectionKey);
+if (!skip) throw new Error('SkipDetectionPanel: missing SkipDetectionKey injection');
+
+const {
+  skipPanelCollapsed,
+  skipDetections,
+  skipAnalyzing,
+  skipError,
+  chapterInjecting,
+  chapterInjectError,
+  chapterInjectResult,
+  skipEpisodeInputs,
+  skipMkvEpisodeCount,
+  skipProgressLabel,
+  chapterInjectProgressLabel,
+  formatSkipTime,
+  runSkipAnalysis,
+  cancelSkipAnalysis,
+  injectChaptersToMkv
+} = skip;
+</script>
+
+<template>
+  <div class="skip-panel">
+    <div class="skip-header" @click="skipPanelCollapsed = !skipPanelCollapsed">
+      <div class="skip-header-left">
+        <svg
+          class="skip-chevron"
+          :class="{ collapsed: skipPanelCollapsed }"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          width="14"
+          height="14"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+        </svg>
+        <span class="skip-label">Skip Detection (experimental)</span>
+      </div>
+      <span v-if="skipAnalyzing" class="skip-summary">{{ skipProgressLabel }}</span>
+      <span v-else-if="skipDetections" class="skip-summary">
+        {{ Object.keys(skipDetections.perEpisode).length }} episodes analyzed
+      </span>
+      <span v-else class="skip-summary">{{ skipEpisodeInputs.length }} downloaded</span>
+    </div>
+    <div v-if="!skipPanelCollapsed" class="skip-body">
+      <div v-if="skipEpisodeInputs.length < 2" class="skip-disabled">
+        Need at least 2 downloaded episodes to analyze. Currently downloaded:
+        {{ skipEpisodeInputs.length }}.
+      </div>
+      <template v-else>
+        <div class="skip-actions">
+          <button v-if="!skipAnalyzing" class="skip-button" @click="runSkipAnalysis">
+            {{ skipDetections ? 'Re-analyze' : `Analyze ${skipEpisodeInputs.length} episodes` }}
+          </button>
+          <button v-else class="skip-button skip-button-cancel" @click="cancelSkipAnalysis">
+            Cancel
+          </button>
+          <span v-if="skipAnalyzing" class="skip-progress-text">{{ skipProgressLabel }}</span>
+          <button
+            v-if="skipMkvEpisodeCount >= 3"
+            class="skip-button"
+            :disabled="chapterInjecting || skipAnalyzing"
+            @click="injectChaptersToMkv"
+          >
+            {{ chapterInjecting ? 'Saving chapters…' : 'Save chapters to MKV' }}
+          </button>
+          <span v-if="chapterInjecting" class="skip-progress-text">{{
+            chapterInjectProgressLabel
+          }}</span>
+        </div>
+        <div v-if="skipError" class="skip-error">{{ skipError }}</div>
+        <div v-if="chapterInjectError" class="skip-error">{{ chapterInjectError }}</div>
+        <div v-if="chapterInjectResult" class="skip-results-meta">
+          Wrote chapters to {{ chapterInjectResult.written }}/{{ chapterInjectResult.total }}
+          episodes
+          <template v-if="chapterInjectResult.skipped">
+            · {{ chapterInjectResult.skipped }} skipped (no detection)
+          </template>
+          <template v-if="chapterInjectResult.failed">
+            · {{ chapterInjectResult.failed }} failed
+          </template>
+        </div>
+        <div v-if="skipDetections" class="skip-results">
+          <div class="skip-results-meta">
+            Analyzed {{ new Date(skipDetections.analyzedAt).toLocaleString() }} · window
+            {{ skipDetections.algorithm.windowSec }}s · min run
+            {{ skipDetections.algorithm.minRunSec }}s · threshold
+            {{ skipDetections.algorithm.matchBitThreshold }}/32 bits
+          </div>
+          <table class="skip-table">
+            <thead>
+              <tr>
+                <th>Episode</th>
+                <th>OP</th>
+                <th>ED</th>
+                <th>Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="ep in props.filteredEpisodes" :key="ep.episodeInt">
+                <template v-if="skipDetections.perEpisode[ep.episodeInt]">
+                  <td>{{ ep.episodeFull || `Episode ${ep.episodeInt}` }}</td>
+                  <td>
+                    <template v-if="skipDetections.perEpisode[ep.episodeInt].op">
+                      {{ formatSkipTime(skipDetections.perEpisode[ep.episodeInt].op!.startSec) }}–{{
+                        formatSkipTime(skipDetections.perEpisode[ep.episodeInt].op!.endSec)
+                      }}
+                      <span class="skip-pair-count"
+                        >({{ skipDetections.perEpisode[ep.episodeInt].op!.pairCount }} pairs)</span
+                      >
+                    </template>
+                    <span v-else class="skip-empty">—</span>
+                  </td>
+                  <td>
+                    <template v-if="skipDetections.perEpisode[ep.episodeInt].ed">
+                      {{ formatSkipTime(skipDetections.perEpisode[ep.episodeInt].ed!.startSec) }}–{{
+                        formatSkipTime(skipDetections.perEpisode[ep.episodeInt].ed!.endSec)
+                      }}
+                      <span class="skip-pair-count"
+                        >({{ skipDetections.perEpisode[ep.episodeInt].ed!.pairCount }} pairs)</span
+                      >
+                    </template>
+                    <span v-else class="skip-empty">—</span>
+                  </td>
+                  <td>
+                    {{ formatSkipTime(skipDetections.perEpisode[ep.episodeInt].durationSec) }}
+                  </td>
+                </template>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.skip-panel {
+  background-color: #16213e;
+  border: 1px solid #0f3460;
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin-bottom: 20px;
+}
+
+.skip-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.skip-header-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.skip-chevron {
+  color: #a0a0b8;
+  transition: transform 0.15s;
+}
+
+.skip-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.skip-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #a0a0b8;
+}
+
+.skip-summary {
+  font-size: 0.8rem;
+  color: #6a6a8a;
+}
+
+.skip-body {
+  margin-top: 10px;
+}
+
+.skip-disabled {
+  font-size: 0.85rem;
+  color: #6a6a8a;
+  font-style: italic;
+}
+
+.skip-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.skip-button {
+  background-color: #0f3460;
+  color: #e0e0e0;
+  border: 1px solid #1f4980;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.skip-button:hover {
+  background-color: #1a4880;
+}
+
+.skip-button-cancel {
+  background-color: #5a2222;
+  border-color: #803030;
+}
+
+.skip-button-cancel:hover {
+  background-color: #803030;
+}
+
+.skip-progress-text {
+  font-size: 0.8rem;
+  color: #a0a0b8;
+}
+
+.skip-error {
+  font-size: 0.8rem;
+  color: #ff6a6a;
+  margin-bottom: 10px;
+}
+
+.skip-results-meta {
+  font-size: 0.75rem;
+  color: #6a6a8a;
+  margin-bottom: 8px;
+}
+
+.skip-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.skip-table th {
+  text-align: left;
+  padding: 4px 8px;
+  color: #a0a0b8;
+  font-weight: 600;
+  border-bottom: 1px solid #0f3460;
+}
+
+.skip-table td {
+  padding: 4px 8px;
+  color: #d0d0e0;
+  border-bottom: 1px solid #1a2a4d;
+}
+
+.skip-table tr:last-child td {
+  border-bottom: none;
+}
+
+.skip-pair-count {
+  color: #6a6a8a;
+  font-size: 0.7rem;
+  margin-left: 4px;
+}
+
+.skip-empty {
+  color: #4a4a6a;
+}
+</style>

--- a/src/renderer/src/components/detail/keys.ts
+++ b/src/renderer/src/components/detail/keys.ts
@@ -1,0 +1,12 @@
+// Injection keys shared between AnimeDetailView and its detail/* sub-components.
+// Phase 5 slice 5b.4 (#118). The parent provides composable instances under
+// these keys so the panel components can read state + actions without each
+// of them receiving a long prop list.
+
+import type { InjectionKey } from 'vue'
+import type { useShikimori } from '../../composables/use-shikimori'
+import type { useSkipDetection } from '../../composables/use-skip-detection'
+
+export const ShikimoriKey: InjectionKey<ReturnType<typeof useShikimori>> = Symbol('shikimori')
+export const SkipDetectionKey: InjectionKey<ReturnType<typeof useSkipDetection>> =
+  Symbol('skipDetection')

--- a/src/renderer/src/composables/use-shikimori.ts
+++ b/src/renderer/src/composables/use-shikimori.ts
@@ -1,0 +1,258 @@
+// Shikimori panel state + friends + details + sync indicator for
+// AnimeDetailView. Phase 5 slice 5b.4 (#118).
+//
+// Owns all per-anime Shikimori state: the rate edit form refs (status,
+// episodes, score, rewatches), the user check, friends list + collapsed,
+// the Shikimori details (genres + description) + descExpanded.
+//
+// Consumes: anime ref + the shikimoriStore. Drives the rate edit form,
+// mirrors the store's per-malId rate cache, and exposes shikiSave +
+// triggerSyncNow.
+//
+// Lifecycle hooks (onMounted/onUnmounted) are NOT registered here — the
+// component calls loadShikimoriData() from its own onMounted. The two
+// rate-cache watchers ARE registered inside via vue's watch(), which
+// binds to the caller's effect scope.
+
+import { computed, ref, watch, type ComputedRef, type Ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import type { useShikimoriStore } from '../stores/shikimori'
+
+export type LoadRelatedFn = (malId: number) => Promise<void>
+
+export function useShikimori(deps: {
+  anime: Ref<AnimeDetail | null>
+  shikimoriStore: ReturnType<typeof useShikimoriStore>
+}): {
+  shikiUser: Ref<ShikiUser | null>
+  shikiRate: Ref<ShikiUserRate | null>
+  shikiStatus: Ref<ShikiUserRateStatus>
+  shikiEpisodes: Ref<number>
+  shikiScore: Ref<number>
+  shikiRewatches: Ref<number>
+  shikiLoading: Ref<boolean>
+  shikiSaving: Ref<boolean>
+  shikiError: Ref<string>
+  shikiUserChecked: Ref<boolean>
+  shikiDetails: Ref<ShikiAnimeDetails | null>
+  descExpanded: Ref<boolean>
+  shikiDetailsDescription: ComputedRef<string>
+  friendsRates: Ref<ShikiFriendRate[]>
+  friendsLoading: Ref<boolean>
+  friendsCollapsed: Ref<boolean>
+  syncState: ComputedRef<'idle' | 'syncing'>
+  lastSyncError: ComputedRef<string | null>
+  loadShikimoriData: (loadRelated: LoadRelatedFn) => Promise<void>
+  shikiSave: () => Promise<void>
+  triggerSyncNow: () => Promise<void>
+} {
+  const shikiUser = ref<ShikiUser | null>(null)
+  const shikiRate = ref<ShikiUserRate | null>(null)
+  const shikiStatus = ref<ShikiUserRateStatus>('planned')
+  const shikiEpisodes = ref(0)
+  const shikiScore = ref(0)
+  const shikiRewatches = ref(0)
+  const shikiLoading = ref(false)
+  const shikiSaving = ref(false)
+  const shikiError = ref('')
+  const shikiUserChecked = ref(false)
+  const shikiDetails = ref<ShikiAnimeDetails | null>(null)
+  const descExpanded = ref(false)
+  const friendsRates = ref<ShikiFriendRate[]>([])
+  const friendsLoading = ref(false)
+  const friendsCollapsed = ref(false)
+
+  const { syncStatus } = storeToRefs(deps.shikimoriStore)
+  const syncState = computed(() => syncStatus.value.state)
+  const lastSyncError = computed(() => syncStatus.value.lastSyncError)
+
+  const shikiDetailsDescription = computed<string>(() => {
+    if (!shikiDetails.value) return ''
+    const src = shikiDetails.value.description
+    if (src) {
+      return src
+        .replace(/\[\/?[a-zA-Z][^\]]*\]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+    }
+    const html = shikiDetails.value.description_html
+    if (!html) return ''
+    let stripped = html.replace(/<br\s*\/?>/gi, ' ')
+    let prev: string
+    do {
+      prev = stripped
+      stripped = stripped.replace(/<[^>]*>/g, '')
+    } while (stripped !== prev)
+    const entities: Record<string, string> = {
+      '&amp;': '&',
+      '&nbsp;': ' ',
+      '&lt;': '<',
+      '&gt;': '>',
+      '&quot;': '"',
+      '&#39;': "'"
+    }
+    return stripped
+      .replace(/&(?:amp|nbsp|lt|gt|quot|#39);/gi, (m) => entities[m.toLowerCase()] ?? m)
+      .replace(/\s+/g, ' ')
+      .trim()
+  })
+
+  async function loadShikimoriData(loadRelated: LoadRelatedFn): Promise<void> {
+    try {
+      shikiUser.value = await window.api.shikimoriGetUser()
+    } catch (err) {
+      console.error('Failed to load Shikimori user:', err)
+    } finally {
+      shikiUserChecked.value = true
+    }
+    if (!deps.anime.value?.myAnimeListId) return
+
+    const relatedPromise = loadRelated(deps.anime.value.myAnimeListId)
+
+    if (!shikiUser.value) {
+      await relatedPromise
+      return
+    }
+
+    shikiLoading.value = true
+    friendsLoading.value = true
+
+    // Load rate and friends in parallel, neither blocks the other
+    const ratePromise = window.api
+      .shikimoriGetRate(deps.anime.value.myAnimeListId)
+      .then((rate) => {
+        shikiRate.value = rate
+        if (rate) {
+          shikiStatus.value = rate.status
+          shikiEpisodes.value = rate.episodes
+          shikiScore.value = rate.score
+          shikiRewatches.value = rate.rewatches ?? 0
+        }
+      })
+      .catch((err) => console.error('Failed to load Shikimori rate:', err))
+      .finally(() => {
+        shikiLoading.value = false
+      })
+
+    const friendsPromise = window.api
+      .shikimoriGetFriendsRates(deps.anime.value.myAnimeListId)
+      .then((rates) => {
+        friendsRates.value = rates
+      })
+      .catch((err) => console.error('Failed to load friends rates:', err))
+      .finally(() => {
+        friendsLoading.value = false
+      })
+
+    const detailsPromise = window.api
+      .shikimoriGetAnimeDetails(deps.anime.value.myAnimeListId)
+      .then((details) => {
+        shikiDetails.value = details
+      })
+      .catch((err) => console.error('Failed to load Shikimori details:', err))
+
+    await Promise.all([ratePromise, friendsPromise, detailsPromise, relatedPromise])
+  }
+
+  async function shikiSave(): Promise<void> {
+    if (!deps.anime.value?.myAnimeListId) return
+    shikiSaving.value = true
+    shikiError.value = ''
+    try {
+      const rate = await window.api.shikimoriUpdateRate(
+        deps.anime.value.myAnimeListId,
+        shikiEpisodes.value,
+        shikiStatus.value,
+        shikiScore.value,
+        shikiRewatches.value
+      )
+      shikiRate.value = rate
+      shikiRewatches.value = rate.rewatches ?? shikiRewatches.value
+    } catch (err) {
+      shikiError.value = String(err)
+    } finally {
+      shikiSaving.value = false
+    }
+  }
+
+  async function triggerSyncNow(): Promise<void> {
+    await deps.shikimoriStore.triggerSync()
+  }
+
+  // Auto-status nudge when the user adjusts the episode counter. Matches the
+  // original component behavior: at numberOfEpisodes → 'completed';
+  // any positive value → 'rewatching' if previously 'completed', else
+  // 'watching' if previously 'planned'.
+  watch(shikiEpisodes, (eps) => {
+    if (deps.anime.value?.numberOfEpisodes && eps >= deps.anime.value.numberOfEpisodes) {
+      shikiStatus.value = 'completed'
+    } else if (eps > 0) {
+      if (shikiStatus.value === 'completed') {
+        shikiStatus.value = 'rewatching'
+      } else if (shikiStatus.value === 'planned') {
+        shikiStatus.value = 'watching'
+      }
+    }
+  })
+
+  // Mirror store-owned rate cache for this anime's malId into the editable
+  // refs. Driven by the shikimori store's broadcast.
+  watch(
+    () =>
+      deps.anime.value?.myAnimeListId
+        ? deps.shikimoriStore.rateByMalId(deps.anime.value.myAnimeListId)
+        : null,
+    (entry) => {
+      if (!entry) return
+      shikiRate.value = {
+        id: entry.rate.id,
+        score: entry.rate.score,
+        status: entry.rate.status,
+        episodes: entry.rate.episodes,
+        rewatches: entry.rate.rewatches ?? 0,
+        target_id: entry.rate.target_id,
+        target_type: 'Anime'
+      }
+      shikiStatus.value = entry.rate.status
+      shikiEpisodes.value = entry.rate.episodes
+      shikiScore.value = entry.rate.score
+      shikiRewatches.value = entry.rate.rewatches ?? 0
+    }
+  )
+
+  // Mirror store-owned per-malId details cache. Driven by the shikimori
+  // store's onShikimoriAnimeDetailsUpdated broadcast.
+  watch(
+    () =>
+      deps.anime.value?.myAnimeListId
+        ? deps.shikimoriStore.animeDetailsByMalId(deps.anime.value.myAnimeListId)
+        : null,
+    (details) => {
+      if (details) shikiDetails.value = details
+    }
+  )
+
+  return {
+    shikiUser,
+    shikiRate,
+    shikiStatus,
+    shikiEpisodes,
+    shikiScore,
+    shikiRewatches,
+    shikiLoading,
+    shikiSaving,
+    shikiError,
+    shikiUserChecked,
+    shikiDetails,
+    descExpanded,
+    shikiDetailsDescription,
+    friendsRates,
+    friendsLoading,
+    friendsCollapsed,
+    syncState,
+    lastSyncError,
+    loadShikimoriData,
+    shikiSave,
+    triggerSyncNow
+  }
+}

--- a/src/renderer/src/composables/use-skip-detection.ts
+++ b/src/renderer/src/composables/use-skip-detection.ts
@@ -1,0 +1,272 @@
+// Local skip-detection / chapter-inject panel state for AnimeDetailView.
+// Phase 5 slice 5b.4 (#118).
+//
+// Owns all per-anime skip-detection state: detections, running flags,
+// progress, errors, plus the chapter-inject lifecycle. Exposes the three
+// `subscribe*` init functions that the component wires from onMounted —
+// each filters broadcasts to this anime's id (component-local subscriptions
+// rather than store-global, since the panel only cares about its current
+// anime).
+//
+// Consumes: animeId getter + filteredEpisodes + fileStatus refs (to project
+// `skipEpisodeInputs` from on-disk files).
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+
+type FileEntry = {
+  type: 'mkv' | 'mp4'
+  filePath: string
+  translationId?: number
+  author?: string
+}
+
+export interface SkipEpisodeInput {
+  episodeInt: string
+  episodeLabel: string
+  filePath: string
+}
+
+export function useSkipDetection(deps: {
+  getAnimeId: () => number
+  filteredEpisodes: ComputedRef<EpisodeSummary[]> | Ref<EpisodeSummary[]>
+  fileStatus: Ref<Record<string, FileEntry[]>>
+}): {
+  skipPanelCollapsed: Ref<boolean>
+  skipDetections: Ref<ShowSkipDetections | null>
+  skipAnalyzing: Ref<boolean>
+  skipProgress: Ref<SkipDetectorProgress | null>
+  skipError: Ref<string>
+  chapterInjecting: Ref<boolean>
+  chapterInjectProgress: Ref<ChapterInjectProgress | null>
+  chapterInjectError: Ref<string>
+  chapterInjectResult: Ref<{
+    written: number
+    skipped: number
+    failed: number
+    total: number
+  } | null>
+  skipEpisodeInputs: ComputedRef<SkipEpisodeInput[]>
+  skipMkvEpisodeCount: ComputedRef<number>
+  skipProgressLabel: ComputedRef<string>
+  chapterInjectProgressLabel: ComputedRef<string>
+  formatSkipTime: (sec: number) => string
+  loadSkipDetections: () => Promise<void>
+  hydrateSkipStatus: () => Promise<void>
+  runSkipAnalysis: () => Promise<void>
+  cancelSkipAnalysis: () => Promise<void>
+  injectChaptersToMkv: () => Promise<void>
+  subscribeSkipDetectorProgress: () => Unsubscribe
+  subscribeSkipDetectorSignatureUpdated: () => Unsubscribe
+  subscribeChapterInjectProgress: () => Unsubscribe
+} {
+  const skipPanelCollapsed = ref(true)
+  const skipDetections = ref<ShowSkipDetections | null>(null)
+  const skipAnalyzing = ref(false)
+  const skipProgress = ref<SkipDetectorProgress | null>(null)
+  const skipError = ref('')
+  const chapterInjecting = ref(false)
+  const chapterInjectProgress = ref<ChapterInjectProgress | null>(null)
+  const chapterInjectError = ref('')
+  const chapterInjectResult = ref<{
+    written: number
+    skipped: number
+    failed: number
+    total: number
+  } | null>(null)
+
+  const skipEpisodeInputs = computed<SkipEpisodeInput[]>(() => {
+    const inputs: SkipEpisodeInput[] = []
+    const seen = new Set<string>()
+    // Walk filteredEpisodes to keep an ordered, label-aware list. fileStatus
+    // is keyed by episodeInt.
+    for (const ep of deps.filteredEpisodes.value) {
+      const files = deps.fileStatus.value[ep.episodeInt]
+      if (!files || files.length === 0) continue
+      // Prefer .mkv (merged) over .mp4 (raw); first match wins.
+      const mkv = files.find((f) => f.type === 'mkv')
+      const pick = mkv || files[0]
+      if (!pick || !pick.filePath) continue
+      if (seen.has(ep.episodeInt)) continue
+      seen.add(ep.episodeInt)
+      inputs.push({
+        episodeInt: ep.episodeInt,
+        episodeLabel: ep.episodeFull || `Episode ${ep.episodeInt}`,
+        filePath: pick.filePath
+      })
+    }
+    return inputs
+  })
+
+  const skipMkvEpisodeCount = computed<number>(
+    () => skipEpisodeInputs.value.filter((e) => e.filePath.toLowerCase().endsWith('.mkv')).length
+  )
+
+  const skipProgressLabel = computed<string>(() => {
+    const p = skipProgress.value
+    if (!p) return ''
+    if (p.phase === 'fingerprinting') {
+      const label = p.episodeLabel ? ` — ${p.episodeLabel}` : ''
+      return `Fingerprinting ${p.current}/${p.total}${label}`
+    }
+    if (p.phase === 'comparing') {
+      return `Comparing pairs ${p.current}/${p.total}`
+    }
+    return 'Done'
+  })
+
+  const chapterInjectProgressLabel = computed<string>(() => {
+    const p = chapterInjectProgress.value
+    if (!p) return ''
+    if (p.phase === 'analyzing') return 'Analyzing fingerprints…'
+    if (p.phase === 'writing') {
+      const label = p.episodeLabel ? ` — ${p.episodeLabel}` : ''
+      return `Writing chapters ${p.current + 1}/${p.total}${label}`
+    }
+    return 'Done'
+  })
+
+  function formatSkipTime(sec: number): string {
+    if (!Number.isFinite(sec) || sec < 0) return '—'
+    const total = Math.round(sec)
+    const m = Math.floor(total / 60)
+    const s = total % 60
+    return `${m}:${s.toString().padStart(2, '0')}`
+  }
+
+  async function loadSkipDetections(): Promise<void> {
+    try {
+      const res = await window.api.skipDetectorGetDetections(deps.getAnimeId())
+      skipDetections.value = res
+    } catch (err) {
+      console.error('Failed to load skip detections:', err)
+    }
+  }
+
+  // Recover the analyzing state if the user navigated away mid-analysis and
+  // came back. Without this, the panel would show idle even though main is
+  // still chewing on fingerprints — and a fresh "Analyze" click for this same
+  // animeId would dedupe onto the in-flight promise (good), while a click on
+  // a different anime's panel would now reject (also good).
+  async function hydrateSkipStatus(): Promise<void> {
+    try {
+      const status = await window.api.skipDetectorGetStatus()
+      if (status && status.animeId === deps.getAnimeId()) {
+        skipAnalyzing.value = true
+        skipProgress.value = status.lastProgress
+      }
+    } catch (err) {
+      console.error('Failed to hydrate skip status:', err)
+    }
+  }
+
+  async function runSkipAnalysis(): Promise<void> {
+    if (skipAnalyzing.value) return
+    const inputs = skipEpisodeInputs.value
+    if (inputs.length < 2) {
+      skipError.value = 'Need at least 2 downloaded episodes'
+      return
+    }
+    skipError.value = ''
+    skipAnalyzing.value = true
+    skipProgress.value = {
+      animeId: deps.getAnimeId(),
+      phase: 'fingerprinting',
+      current: 0,
+      total: inputs.length
+    }
+    try {
+      const result = await window.api.skipDetectorAnalyzeShow(deps.getAnimeId(), inputs)
+      skipDetections.value = result
+    } catch (err) {
+      skipError.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      skipAnalyzing.value = false
+      skipProgress.value = null
+    }
+  }
+
+  async function cancelSkipAnalysis(): Promise<void> {
+    try {
+      await window.api.skipDetectorCancel()
+    } catch (err) {
+      console.error('Failed to cancel skip analysis:', err)
+    }
+  }
+
+  async function injectChaptersToMkv(): Promise<void> {
+    if (chapterInjecting.value) return
+    if (skipMkvEpisodeCount.value < 3) {
+      chapterInjectError.value = 'Need at least 3 downloaded MKV episodes'
+      return
+    }
+    chapterInjectError.value = ''
+    chapterInjectResult.value = null
+    chapterInjecting.value = true
+    chapterInjectProgress.value = {
+      animeId: deps.getAnimeId(),
+      phase: 'writing',
+      current: 0,
+      total: skipMkvEpisodeCount.value
+    }
+    try {
+      const res = await window.api.injectChapters(deps.getAnimeId(), skipEpisodeInputs.value)
+      chapterInjectResult.value = res
+    } catch (err) {
+      chapterInjectError.value = err instanceof Error ? err.message : String(err)
+    } finally {
+      chapterInjecting.value = false
+      chapterInjectProgress.value = null
+    }
+  }
+
+  // Component-local subscriptions filtered by this anime's id. The main
+  // process broadcasts to all listeners, but only the panel for the active
+  // anime should react.
+  function subscribeSkipDetectorProgress(): Unsubscribe {
+    return window.api.onSkipDetectorProgress((data) => {
+      if (data.animeId !== deps.getAnimeId()) return
+      skipProgress.value = data
+      skipAnalyzing.value = data.phase !== 'done'
+    })
+  }
+
+  function subscribeSkipDetectorSignatureUpdated(): Unsubscribe {
+    return window.api.onSkipDetectorSignatureUpdated((data) => {
+      if (data.animeId !== deps.getAnimeId()) return
+      void loadSkipDetections()
+    })
+  }
+
+  function subscribeChapterInjectProgress(): Unsubscribe {
+    return window.api.onChapterInjectProgress((data) => {
+      if (data.animeId !== deps.getAnimeId()) return
+      chapterInjectProgress.value = data
+      chapterInjecting.value = data.phase !== 'done'
+    })
+  }
+
+  return {
+    skipPanelCollapsed,
+    skipDetections,
+    skipAnalyzing,
+    skipProgress,
+    skipError,
+    chapterInjecting,
+    chapterInjectProgress,
+    chapterInjectError,
+    chapterInjectResult,
+    skipEpisodeInputs,
+    skipMkvEpisodeCount,
+    skipProgressLabel,
+    chapterInjectProgressLabel,
+    formatSkipTime,
+    loadSkipDetections,
+    hydrateSkipStatus,
+    runSkipAnalysis,
+    cancelSkipAnalysis,
+    injectChaptersToMkv,
+    subscribeSkipDetectorProgress,
+    subscribeSkipDetectorSignatureUpdated,
+    subscribeChapterInjectProgress
+  }
+}

--- a/test/renderer/composables/use-shikimori.test.ts
+++ b/test/renderer/composables/use-shikimori.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useShikimoriStore } from '../../../src/renderer/src/stores/shikimori'
+import { useShikimori } from '../../../src/renderer/src/composables/use-shikimori'
+
+type Api = {
+  shikimoriGetUser: () => Promise<ShikiUser | null>
+  shikimoriGetRate: (malId: number) => Promise<ShikiUserRate | null>
+  shikimoriGetFriendsRates: (malId: number) => Promise<ShikiFriendRate[]>
+  shikimoriGetAnimeDetails: (malId: number) => Promise<ShikiAnimeDetails | null>
+  shikimoriUpdateRate: (
+    malId: number,
+    episodes: number,
+    status: ShikiUserRateStatus,
+    score: number,
+    rewatches: number
+  ) => Promise<ShikiUserRate>
+  shikimoriTriggerSync: () => Promise<void>
+  shikimoriGetSyncStatus: () => Promise<unknown>
+  shikimoriGetOfflineQueueLength: () => Promise<number>
+  shikimoriGetAnimeRates: () => Promise<unknown[]>
+  onShikimoriRateUpdated: (cb: (entry: unknown) => void) => Unsubscribe
+  onShikimoriRatesRefreshed: (cb: (entries: unknown[]) => void) => Unsubscribe
+  onShikimoriAnimeDetailsUpdated: (cb: (data: unknown) => void) => Unsubscribe
+  onShikimoriOfflineQueueChanged: (cb: (data: unknown) => void) => Unsubscribe
+  onShikimoriSyncStatus: (cb: (data: unknown) => void) => Unsubscribe
+}
+
+function noopSub(): Unsubscribe {
+  return () => {}
+}
+
+const STORE_BROADCAST_STUBS: Partial<Api> = {
+  onShikimoriRateUpdated: noopSub,
+  onShikimoriRatesRefreshed: noopSub,
+  onShikimoriAnimeDetailsUpdated: noopSub,
+  onShikimoriOfflineQueueChanged: noopSub,
+  onShikimoriSyncStatus: noopSub
+}
+
+function setApi(api: Partial<Api>): void {
+  const w = (globalThis as { window?: { api?: Partial<Api> } }).window
+  const prev = w?.api ?? {}
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: { ...prev, ...api } }
+}
+
+function installDefaultApi(): void {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = {
+    api: { ...STORE_BROADCAST_STUBS }
+  }
+}
+
+function mkAnime(
+  opts: { id?: number; malId?: number; numberOfEpisodes?: number } = {}
+): AnimeDetail {
+  return {
+    id: opts.id ?? 1,
+    myAnimeListId: opts.malId ?? 99,
+    numberOfEpisodes: opts.numberOfEpisodes ?? 12
+  } as unknown as AnimeDetail
+}
+
+function makeDeps(opts: { anime?: AnimeDetail | null } = {}) {
+  setActivePinia(createPinia())
+  return {
+    anime: ref<AnimeDetail | null>(opts.anime ?? null),
+    shikimoriStore: useShikimoriStore()
+  }
+}
+
+beforeEach(() => {
+  installDefaultApi()
+})
+
+describe('useShikimori — initial state', () => {
+  it('starts with idle defaults', () => {
+    const s = useShikimori(makeDeps())
+    expect(s.shikiUser.value).toBeNull()
+    expect(s.shikiRate.value).toBeNull()
+    expect(s.shikiStatus.value).toBe('planned')
+    expect(s.shikiEpisodes.value).toBe(0)
+    expect(s.shikiScore.value).toBe(0)
+    expect(s.shikiRewatches.value).toBe(0)
+    expect(s.shikiLoading.value).toBe(false)
+    expect(s.shikiSaving.value).toBe(false)
+    expect(s.shikiError.value).toBe('')
+    expect(s.shikiUserChecked.value).toBe(false)
+    expect(s.friendsRates.value).toEqual([])
+    expect(s.descExpanded.value).toBe(false)
+  })
+
+  it('shikiDetailsDescription strips BBCode tags', () => {
+    const s = useShikimori(makeDeps())
+    s.shikiDetails.value = {
+      description: '[b]Bold[/b] world [url=foo]link[/url]'
+    } as unknown as ShikiAnimeDetails
+    expect(s.shikiDetailsDescription.value).toBe('Bold world link')
+  })
+
+  it('shikiDetailsDescription strips HTML when description_html is the source', () => {
+    const s = useShikimori(makeDeps())
+    s.shikiDetails.value = {
+      description: '',
+      description_html: '<p>Hello <b>world</b></p>'
+    } as unknown as ShikiAnimeDetails
+    expect(s.shikiDetailsDescription.value).toBe('Hello world')
+  })
+})
+
+describe('useShikimori — auto-status from shikiEpisodes', () => {
+  it('flips to completed when reaching numberOfEpisodes', async () => {
+    const anime = ref<AnimeDetail | null>(mkAnime({ numberOfEpisodes: 12 }))
+    const s = useShikimori({ ...makeDeps(), anime })
+    s.shikiStatus.value = 'watching'
+    s.shikiEpisodes.value = 12
+    await nextTick()
+    expect(s.shikiStatus.value).toBe('completed')
+  })
+
+  it('flips planned → watching on first episode', async () => {
+    const s = useShikimori(makeDeps({ anime: mkAnime() }))
+    s.shikiStatus.value = 'planned'
+    s.shikiEpisodes.value = 1
+    await nextTick()
+    expect(s.shikiStatus.value).toBe('watching')
+  })
+
+  it('flips completed → rewatching when episodes change again', async () => {
+    const s = useShikimori(makeDeps({ anime: mkAnime() }))
+    s.shikiStatus.value = 'completed'
+    s.shikiEpisodes.value = 5
+    await nextTick()
+    expect(s.shikiStatus.value).toBe('rewatching')
+  })
+
+  it('does not nudge when status is dropped or on_hold', async () => {
+    const s = useShikimori(makeDeps({ anime: mkAnime() }))
+    s.shikiStatus.value = 'on_hold'
+    s.shikiEpisodes.value = 3
+    await nextTick()
+    expect(s.shikiStatus.value).toBe('on_hold')
+  })
+})
+
+describe('useShikimori — loadShikimoriData', () => {
+  it('loads user then short-circuits without MAL id', async () => {
+    setApi({ shikimoriGetUser: vi.fn().mockResolvedValue({ id: 1 } as ShikiUser) })
+    const loadRelated = vi.fn().mockResolvedValue(undefined)
+    const s = useShikimori(makeDeps({ anime: { id: 1 } as unknown as AnimeDetail }))
+    await s.loadShikimoriData(loadRelated)
+    expect(s.shikiUserChecked.value).toBe(true)
+    expect(s.shikiUser.value?.id).toBe(1)
+    expect(loadRelated).not.toHaveBeenCalled()
+  })
+
+  it('loads rate + friends + details + related when user is signed in', async () => {
+    const rate: ShikiUserRate = {
+      id: 10,
+      status: 'watching',
+      episodes: 3,
+      score: 7,
+      rewatches: 0,
+      target_id: 99,
+      target_type: 'Anime'
+    } as unknown as ShikiUserRate
+    const friends: ShikiFriendRate[] = [{ nickname: 'F' } as unknown as ShikiFriendRate]
+    const details = { description: 'd' } as unknown as ShikiAnimeDetails
+    setApi({
+      shikimoriGetUser: vi.fn().mockResolvedValue({ id: 1 } as ShikiUser),
+      shikimoriGetRate: vi.fn().mockResolvedValue(rate),
+      shikimoriGetFriendsRates: vi.fn().mockResolvedValue(friends),
+      shikimoriGetAnimeDetails: vi.fn().mockResolvedValue(details)
+    })
+    const loadRelated = vi.fn().mockResolvedValue(undefined)
+    const s = useShikimori(makeDeps({ anime: mkAnime({ malId: 99 }) }))
+    await s.loadShikimoriData(loadRelated)
+    expect(loadRelated).toHaveBeenCalledWith(99)
+    expect(s.shikiRate.value).toEqual(rate)
+    expect(s.shikiStatus.value).toBe('watching')
+    expect(s.shikiEpisodes.value).toBe(3)
+    expect(s.shikiScore.value).toBe(7)
+    expect(s.friendsRates.value).toEqual(friends)
+    expect(s.shikiDetails.value).toEqual(details)
+    expect(s.shikiLoading.value).toBe(false)
+    expect(s.friendsLoading.value).toBe(false)
+  })
+
+  it('clears shikiUserChecked even when getUser throws', async () => {
+    setApi({ shikimoriGetUser: vi.fn().mockRejectedValue(new Error('boom')) })
+    const consoleErr = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const s = useShikimori(makeDeps({ anime: { id: 1 } as unknown as AnimeDetail }))
+    await s.loadShikimoriData(vi.fn().mockResolvedValue(undefined))
+    expect(s.shikiUserChecked.value).toBe(true)
+    expect(s.shikiUser.value).toBeNull()
+    consoleErr.mockRestore()
+  })
+})
+
+describe('useShikimori — shikiSave', () => {
+  it('persists via IPC and updates rate/rewatches', async () => {
+    const rate: ShikiUserRate = {
+      id: 1,
+      status: 'watching',
+      episodes: 5,
+      score: 8,
+      rewatches: 2,
+      target_id: 99,
+      target_type: 'Anime'
+    } as unknown as ShikiUserRate
+    const update = vi.fn().mockResolvedValue(rate)
+    setApi({ shikimoriUpdateRate: update })
+    const s = useShikimori(makeDeps({ anime: mkAnime({ malId: 99 }) }))
+    s.shikiEpisodes.value = 5
+    s.shikiStatus.value = 'watching'
+    s.shikiScore.value = 8
+    s.shikiRewatches.value = 1
+    await s.shikiSave()
+    expect(update).toHaveBeenCalledWith(99, 5, 'watching', 8, 1)
+    expect(s.shikiRate.value).toEqual(rate)
+    expect(s.shikiRewatches.value).toBe(2)
+    expect(s.shikiError.value).toBe('')
+  })
+
+  it('captures error message on IPC failure', async () => {
+    setApi({ shikimoriUpdateRate: vi.fn().mockRejectedValue(new Error('network')) })
+    const s = useShikimori(makeDeps({ anime: mkAnime() }))
+    await s.shikiSave()
+    expect(s.shikiError.value).toMatch(/network/i)
+    expect(s.shikiSaving.value).toBe(false)
+  })
+
+  it('no-ops without a MAL id', async () => {
+    const update = vi.fn()
+    setApi({ shikimoriUpdateRate: update })
+    const s = useShikimori(makeDeps({ anime: { id: 1 } as unknown as AnimeDetail }))
+    await s.shikiSave()
+    expect(update).not.toHaveBeenCalled()
+  })
+})
+
+describe('useShikimori — triggerSyncNow', () => {
+  it('delegates to shikimoriStore.triggerSync', async () => {
+    setApi({ shikimoriTriggerSync: vi.fn().mockResolvedValue(undefined) })
+    const deps = makeDeps()
+    const spy = vi.spyOn(deps.shikimoriStore, 'triggerSync')
+    const s = useShikimori(deps)
+    await s.triggerSyncNow()
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/test/renderer/composables/use-skip-detection.test.ts
+++ b/test/renderer/composables/use-skip-detection.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, computed } from 'vue'
+import { useSkipDetection } from '../../../src/renderer/src/composables/use-skip-detection'
+
+type FileEntry = {
+  type: 'mkv' | 'mp4'
+  filePath: string
+  translationId?: number
+  author?: string
+}
+
+type Api = {
+  skipDetectorGetDetections: (animeId: number) => Promise<ShowSkipDetections | null>
+  skipDetectorGetStatus: () => Promise<{
+    animeId: number
+    lastProgress: SkipDetectorProgress
+  } | null>
+  skipDetectorAnalyzeShow: (animeId: number, inputs: unknown[]) => Promise<ShowSkipDetections>
+  skipDetectorCancel: () => Promise<void>
+  injectChapters: (
+    animeId: number,
+    inputs: unknown[]
+  ) => Promise<{ written: number; skipped: number; failed: number; total: number }>
+  onSkipDetectorProgress: (cb: (data: SkipDetectorProgress) => void) => Unsubscribe
+  onSkipDetectorSignatureUpdated: (cb: (data: { animeId: number }) => void) => Unsubscribe
+  onChapterInjectProgress: (cb: (data: ChapterInjectProgress) => void) => Unsubscribe
+}
+
+function setApi(api: Partial<Api>): void {
+  const w = (globalThis as { window?: { api?: Partial<Api> } }).window
+  const prev = w?.api ?? {}
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: { ...prev, ...api } }
+}
+
+beforeEach(() => {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: {} }
+})
+
+function mkEpisode(id: number, episodeInt: string): EpisodeSummary {
+  return {
+    id,
+    episodeInt,
+    episodeFull: `Episode ${episodeInt}`,
+    episodeType: 'tv',
+    isActive: 1
+  } as unknown as EpisodeSummary
+}
+
+function makeDeps(
+  opts: {
+    animeId?: number
+    episodes?: EpisodeSummary[]
+    fileStatus?: Record<string, FileEntry[]>
+  } = {}
+) {
+  return {
+    getAnimeId: () => opts.animeId ?? 1,
+    filteredEpisodes: computed(() => opts.episodes ?? []),
+    fileStatus: ref<Record<string, FileEntry[]>>(opts.fileStatus ?? {})
+  }
+}
+
+describe('useSkipDetection — skipEpisodeInputs projection', () => {
+  it('returns [] when no episodes have files', () => {
+    const s = useSkipDetection(makeDeps({ episodes: [mkEpisode(1, '1'), mkEpisode(2, '2')] }))
+    expect(s.skipEpisodeInputs.value).toEqual([])
+  })
+
+  it('prefers .mkv over .mp4 per episode', () => {
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1')],
+        fileStatus: {
+          '1': [
+            { type: 'mp4', filePath: '/x.mp4' },
+            { type: 'mkv', filePath: '/x.mkv' }
+          ]
+        }
+      })
+    )
+    expect(s.skipEpisodeInputs.value).toEqual([
+      { episodeInt: '1', episodeLabel: 'Episode 1', filePath: '/x.mkv' }
+    ])
+  })
+
+  it('falls back to first file when no .mkv exists', () => {
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1')],
+        fileStatus: { '1': [{ type: 'mp4', filePath: '/x.mp4' }] }
+      })
+    )
+    expect(s.skipEpisodeInputs.value[0].filePath).toBe('/x.mp4')
+  })
+
+  it('skipMkvEpisodeCount counts only .mkv inputs', () => {
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2'), mkEpisode(3, '3')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mp4', filePath: '/b.mp4' }],
+          '3': [{ type: 'mkv', filePath: '/c.mkv' }]
+        }
+      })
+    )
+    expect(s.skipMkvEpisodeCount.value).toBe(2)
+  })
+})
+
+describe('useSkipDetection — labels & helpers', () => {
+  it('formatSkipTime formats mm:ss with zero-pad', () => {
+    const s = useSkipDetection(makeDeps())
+    expect(s.formatSkipTime(125)).toBe('2:05')
+    expect(s.formatSkipTime(0)).toBe('0:00')
+    expect(s.formatSkipTime(-1)).toBe('—')
+    expect(s.formatSkipTime(NaN)).toBe('—')
+  })
+
+  it('skipProgressLabel formats fingerprinting phase with episode label', () => {
+    const s = useSkipDetection(makeDeps())
+    s.skipProgress.value = {
+      animeId: 1,
+      phase: 'fingerprinting',
+      current: 3,
+      total: 12,
+      episodeLabel: 'Episode 3'
+    } as unknown as SkipDetectorProgress
+    expect(s.skipProgressLabel.value).toBe('Fingerprinting 3/12 — Episode 3')
+  })
+
+  it('skipProgressLabel formats comparing phase', () => {
+    const s = useSkipDetection(makeDeps())
+    s.skipProgress.value = {
+      animeId: 1,
+      phase: 'comparing',
+      current: 4,
+      total: 10
+    } as unknown as SkipDetectorProgress
+    expect(s.skipProgressLabel.value).toBe('Comparing pairs 4/10')
+  })
+
+  it('chapterInjectProgressLabel for analyzing and writing phases', () => {
+    const s = useSkipDetection(makeDeps())
+    s.chapterInjectProgress.value = { phase: 'analyzing' } as unknown as ChapterInjectProgress
+    expect(s.chapterInjectProgressLabel.value).toBe('Analyzing fingerprints…')
+    s.chapterInjectProgress.value = {
+      phase: 'writing',
+      current: 2,
+      total: 5,
+      episodeLabel: 'Episode 3'
+    } as unknown as ChapterInjectProgress
+    expect(s.chapterInjectProgressLabel.value).toBe('Writing chapters 3/5 — Episode 3')
+  })
+})
+
+describe('useSkipDetection — runSkipAnalysis', () => {
+  it('refuses with fewer than 2 downloaded episodes', async () => {
+    const analyze = vi.fn()
+    setApi({ skipDetectorAnalyzeShow: analyze })
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1')],
+        fileStatus: { '1': [{ type: 'mkv', filePath: '/a.mkv' }] }
+      })
+    )
+    await s.runSkipAnalysis()
+    expect(analyze).not.toHaveBeenCalled()
+    expect(s.skipError.value).toMatch(/at least 2/i)
+  })
+
+  it('analyzes and stores result; transient flags toggle correctly', async () => {
+    const result = { perEpisode: {} } as unknown as ShowSkipDetections
+    const analyze = vi.fn().mockResolvedValue(result)
+    setApi({ skipDetectorAnalyzeShow: analyze })
+    const s = useSkipDetection(
+      makeDeps({
+        animeId: 42,
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mkv', filePath: '/b.mkv' }]
+        }
+      })
+    )
+    await s.runSkipAnalysis()
+    expect(analyze).toHaveBeenCalledWith(
+      42,
+      expect.arrayContaining([expect.objectContaining({ episodeInt: '1', filePath: '/a.mkv' })])
+    )
+    expect(s.skipDetections.value).toStrictEqual(result)
+    expect(s.skipAnalyzing.value).toBe(false)
+    expect(s.skipProgress.value).toBeNull()
+  })
+
+  it('captures error on analyze failure', async () => {
+    setApi({ skipDetectorAnalyzeShow: vi.fn().mockRejectedValue(new Error('boom')) })
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mkv', filePath: '/b.mkv' }]
+        }
+      })
+    )
+    await s.runSkipAnalysis()
+    expect(s.skipError.value).toMatch(/boom/)
+    expect(s.skipAnalyzing.value).toBe(false)
+  })
+
+  it('does not double-fire when already analyzing', async () => {
+    const analyze = vi.fn().mockResolvedValue({ perEpisode: {} } as ShowSkipDetections)
+    setApi({ skipDetectorAnalyzeShow: analyze })
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mkv', filePath: '/b.mkv' }]
+        }
+      })
+    )
+    s.skipAnalyzing.value = true
+    await s.runSkipAnalysis()
+    expect(analyze).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSkipDetection — injectChaptersToMkv', () => {
+  it('refuses with fewer than 3 MKV episodes', async () => {
+    const inject = vi.fn()
+    setApi({ injectChapters: inject })
+    const s = useSkipDetection(
+      makeDeps({
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mkv', filePath: '/b.mkv' }]
+        }
+      })
+    )
+    await s.injectChaptersToMkv()
+    expect(inject).not.toHaveBeenCalled()
+    expect(s.chapterInjectError.value).toMatch(/at least 3/i)
+  })
+
+  it('writes chapters and stores result', async () => {
+    const res = { written: 3, skipped: 0, failed: 0, total: 3 }
+    const inject = vi.fn().mockResolvedValue(res)
+    setApi({ injectChapters: inject })
+    const s = useSkipDetection(
+      makeDeps({
+        animeId: 7,
+        episodes: [mkEpisode(1, '1'), mkEpisode(2, '2'), mkEpisode(3, '3')],
+        fileStatus: {
+          '1': [{ type: 'mkv', filePath: '/a.mkv' }],
+          '2': [{ type: 'mkv', filePath: '/b.mkv' }],
+          '3': [{ type: 'mkv', filePath: '/c.mkv' }]
+        }
+      })
+    )
+    await s.injectChaptersToMkv()
+    expect(inject).toHaveBeenCalledWith(7, expect.any(Array))
+    expect(s.chapterInjectResult.value).toEqual(res)
+    expect(s.chapterInjecting.value).toBe(false)
+  })
+})
+
+describe('useSkipDetection — hydrateSkipStatus', () => {
+  it('resumes the analyzing flag if status matches the current anime', async () => {
+    setApi({
+      skipDetectorGetStatus: vi.fn().mockResolvedValue({
+        animeId: 5,
+        lastProgress: {
+          animeId: 5,
+          phase: 'fingerprinting',
+          current: 2,
+          total: 10
+        } as unknown as SkipDetectorProgress
+      })
+    })
+    const s = useSkipDetection(makeDeps({ animeId: 5 }))
+    await s.hydrateSkipStatus()
+    expect(s.skipAnalyzing.value).toBe(true)
+    expect(s.skipProgress.value?.current).toBe(2)
+  })
+
+  it('ignores status for a different anime', async () => {
+    setApi({
+      skipDetectorGetStatus: vi.fn().mockResolvedValue({
+        animeId: 999,
+        lastProgress: {} as SkipDetectorProgress
+      })
+    })
+    const s = useSkipDetection(makeDeps({ animeId: 5 }))
+    await s.hydrateSkipStatus()
+    expect(s.skipAnalyzing.value).toBe(false)
+  })
+})
+
+describe('useSkipDetection — subscriptions filter by animeId', () => {
+  it('subscribeSkipDetectorProgress ignores other anime ids', () => {
+    let captured: ((data: SkipDetectorProgress) => void) | null = null
+    setApi({
+      onSkipDetectorProgress: (cb) => {
+        captured = cb
+        return () => {}
+      }
+    })
+    const s = useSkipDetection(makeDeps({ animeId: 5 }))
+    s.subscribeSkipDetectorProgress()
+    captured!({
+      animeId: 7,
+      phase: 'fingerprinting',
+      current: 1,
+      total: 2
+    } as unknown as SkipDetectorProgress)
+    expect(s.skipProgress.value).toBeNull()
+    captured!({
+      animeId: 5,
+      phase: 'fingerprinting',
+      current: 1,
+      total: 2
+    } as unknown as SkipDetectorProgress)
+    expect(s.skipProgress.value?.animeId).toBe(5)
+    expect(s.skipAnalyzing.value).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Fourth sub-slice of **Phase 5 slice 5b** (#118 / epic #84). Stacked on top of #123. Finishes the sidebar-panel decomposition: two new composables + two new sub-components, the last extractions that don't touch the episode list itself.

`AnimeDetailView.vue`: **2441 → 1525 lines** (~916-line shrink in one PR).

> **Base branch is `phase5-slice-5b3-detail-panels`** — diff against `main` retargets itself once #123 lands. Per [[feedback_stacked_pr_base_branch]] I'll switch the base to `main` *before* each upstream branch is deleted on merge.

## What's in this slice

### Two new composables

#### `src/renderer/src/composables/use-shikimori.ts` (~260 L)

Shikimori panel state: rate edit form refs (status, episodes, score, rewatches), `shikiUser` + `shikiUserChecked`, `shikiLoading`/`Saving`/`Error`, `shikiDetails` + `descExpanded`, `friendsRates` + `friendsLoading` + `friendsCollapsed`, `syncState` + `lastSyncError`.

**Actions:** `loadShikimoriData(loadRelated)`, `shikiSave`, `triggerSyncNow`.

**Internal watchers:** the auto-status nudge on `shikiEpisodes` (completed when reaching `numberOfEpisodes`; rewatching/watching otherwise) and the two store-cache mirror watchers (`rateByMalId`, `animeDetailsByMalId`).

#### `src/renderer/src/composables/use-skip-detection.ts` (~270 L)

Local skip-detection state: `skipDetections`, `skipAnalyzing`, `skipProgress`, `skipError`, plus the chapter-inject lifecycle (`chapterInjecting`, `chapterInjectProgress`, `chapterInjectError`, `chapterInjectResult`).

**Computeds:** `skipEpisodeInputs` (filter to downloaded; prefer `.mkv`), `skipMkvEpisodeCount`, `skipProgressLabel`, `chapterInjectProgressLabel`.

**Helpers:** `formatSkipTime(sec)` for `mm:ss`.

**Actions:** `loadSkipDetections`, `hydrateSkipStatus`, `runSkipAnalysis`, `cancelSkipAnalysis`, `injectChaptersToMkv`.

**Subscription init:** `subscribeSkipDetectorProgress`, `subscribeSkipDetectorSignatureUpdated`, `subscribeChapterInjectProgress` — all filtered by `getAnimeId()`.

### Two new sub-components

#### `src/renderer/src/components/detail/ShikimoriPanel.vue` (354 L)

Rate edit form + offline indicator + sync state + details (genres + collapsible description). Props: `anime` (for `myAnimeListId` + `numberOfEpisodes`). Injects the `useShikimori` composable via `ShikimoriKey`; reads `offlineQueueLength` from `useShikimoriStore` directly.

#### `src/renderer/src/components/detail/SkipDetectionPanel.vue` (282 L)

Collapsible panel with run/cancel + chapter-inject + results table. Props: `filteredEpisodes` (for the per-episode results table). Injects the `useSkipDetection` composable via `SkipDetectionKey`.

#### `src/renderer/src/components/detail/keys.ts` (14 L)

Typed `InjectionKey` symbols (`ShikimoriKey`, `SkipDetectionKey`) — the parent calls `provide(key, composableInstance)` so the deeply-nested panels can `inject(key)` to read state + call actions without 20+ prop drilling per panel.

## Architecture decision: provide/inject for composables

`ChronologyPanel` and `FriendsPanel` (slice 5b.3) use props because each has 2-3 simple props and no editable state. `ShikimoriPanel` and `SkipDetectionPanel` would need ~20 props each (rate edit form + actions + details + sync state, or skip detections + analyzing flags + chapter inject lifecycle + actions). Threading these as props each time would be noise. Provide/inject is the standard Vue pattern for related components sharing a composable, and the typed `InjectionKey` keeps the contract checked.

The parent still owns the composable instances so `useEpisodeDownloads` can read `shikiRate` / `shikiUser` / `shikiEpisodes` / `shikiUserChecked` / `shikiLoading` refs for `continueTarget`.

## Behavior preserved (byte-identical)

- Rate edit form fields, Save button, error message, retry-now button.
- Auto-status nudge on `shikiEpisodes` change unchanged.
- Store-cache mirror watchers driven by the same broadcasts.
- Skip detection 4-broadcast subscription set filtered by `props.animeId`.
- Chapter-inject lifecycle + "Save chapters to MKV" button.
- Shikimori details (genres + collapsible description) with the same `> 320` char threshold.

### CSS preservation

The original parent CSS for `shiki-*` and `skip-*` classes is **copied verbatim** into the respective panel components' scoped styles. The deleted-from-parent CSS block matches the kept-in-component CSS exactly — every rule, including animation keyframe names like `shiki-offline-rotate`.

## Tests (31 new tests, 202 total)

### `test/renderer/composables/use-shikimori.test.ts` (14 tests)

- **Initial state (3)**: idle defaults; `shikiDetailsDescription` strips BBCode tags; strips HTML when `description_html` is the source.
- **Auto-status from shikiEpisodes (4)**: flips to `completed` at `numberOfEpisodes`; `planned → watching` on first ep; `completed → rewatching` on episode change; `on_hold` not nudged.
- **loadShikimoriData (3)**: short-circuits without MAL id; loads rate + friends + details + related when signed in; clears `shikiUserChecked` even on `getUser` failure.
- **shikiSave (3)**: persists via IPC + updates rate; captures error on failure; no-op without MAL id.
- **triggerSyncNow (1)**: delegates to `shikimoriStore.triggerSync`.

### `test/renderer/composables/use-skip-detection.test.ts` (17 tests)

- **skipEpisodeInputs projection (4)**: empty when no files; prefers `.mkv` over `.mp4`; falls back to first file; `skipMkvEpisodeCount` only counts `.mkv`.
- **Labels & helpers (3)**: `formatSkipTime` mm:ss with zero-pad; `skipProgressLabel` formatting for fingerprinting + comparing phases; `chapterInjectProgressLabel` for analyzing + writing.
- **runSkipAnalysis (4)**: refuses with fewer than 2 downloaded episodes; analyzes + stores result + flags toggle; captures error on failure; no double-fire when already analyzing.
- **injectChaptersToMkv (2)**: refuses with fewer than 3 MKV episodes; writes chapters + stores result.
- **hydrateSkipStatus (2)**: resumes analyzing flag on match; ignores status for a different anime.
- **Subscription filtering (1)**: `subscribeSkipDetectorProgress` ignores other anime IDs.

Total project tests: **171 → 202** passing (+31).

## Quality gate

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors; 7 pre-existing warnings unchanged from `main`)
- `npm run format:check` ✓
- `npm run test` ✓ — **202/202 passing**
- `npm run build` ✓
- `bash scripts/check-subscription-contract.sh` ✓ — no `removeAllListeners` / `window.api.off*`

## Test plan

- [ ] Open an anime with a Shikimori MAL entry; sign in.
  - **ShikimoriPanel** renders: status dropdown (6 options), Episodes input, Score select (0 + 1-10), Rewatches input, Save button.
  - Setting Episodes to `numberOfEpisodes` flips Status to `completed`.
  - First episode flips `planned` → `watching`. Edit again with status `completed` flips to `rewatching`.
  - Save persists + offline indicator shows when network is intercepted (queued change visible).
  - "Retry now" appears when sync state is `idle` and queue length > 0; clicking it triggers a sync.
  - Shikimori details (genres + description) render once the cache populates; "Show more" toggle works for descriptions > 320 chars.
- [ ] Open an anime with at least 2 downloaded episodes.
  - **SkipDetectionPanel** shows the count summary.
  - Expand → click Analyze → progress text updates → results table populates.
  - Cancel button mid-analysis stops it.
  - With ≥3 MKV episodes downloaded, "Save chapters to MKV" appears; clicking writes chapters.
- [ ] Switch between anime detail views — no leaked listeners; per-animeId subscription filter ignores broadcasts for other anime.
- [ ] Open an anime **without** a Shikimori MAL entry — Shikimori + Friends panels don't render; skip detection panel still works.

Out of scope for this slice (potential 5c): the episode list itself + per-episode row rendering + translation picker + the controls bar / pagination / download buttons. These are the highest-risk pieces because they're the densest reactivity surface.

## Cumulative Phase 5 slice 5b trajectory

`AnimeDetailView.vue`: **3624 (main) → 3260 (5b.1) → 2898 (5b.2) → 2441 (5b.3) → 1525 (5b.4)** — ~58% script reduction across 4 PRs.

| Slice | What | LoC delta |
|---|---|---:|
| 5b.1 (#121) | `useChronology` + `useAnimeDetailPrefs` + `useEpisodeList` | −365 |
| 5b.2 (#122) | `useEpisodeDownloads` | −362 |
| 5b.3 (#123) | `ChronologyPanel` + `FriendsPanel` | −457 |
| 5b.4 (this PR) | `useShikimori` + `useSkipDetection` + `ShikimoriPanel` + `SkipDetectionPanel` | −916 |

Plus: **6 composables** (~1593 LoC) + **4 sub-components** (~1164 LoC) + 91 composable unit tests.

Part of #84 (Phase 5 slice 5b.4). Stacked on #123.