### PR TITLE
refactor: Phase 5 slice 5d.2.a — useAnime4K + usePlayerKeyboard (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -489,6 +489,23 @@ Global app glue that doesn't belong on a Pinia store goes into
   `sb.timestampOffset` assignment throw `InvalidStateError` — the root
   cause of the rapid-back-to-back-seek stutter pattern. (Phase 5 slice
   5d.1)
+- `useAnime4K({ getVideoEl, getCanvasEl })` — Anime4K WebGPU upscaling
+  pipeline. Owns the GPU device + render-loop lifecycle, exposes
+  `anime4kPreset`/`webgpuAvailable`/`gpuName` refs, `anime4kActive` and
+  `presetLabel` computeds, plus `initWebGPU`, `startPipeline`,
+  `stopPipeline`, and `destroy` actions. The consumer wires the
+  preset-changed `watch` (persisting to settings + driving start/stop) and
+  the loadedmetadata-gated initial start. Lifecycle is caller-managed for
+  testability. (Phase 5 slice 5d.2.a)
+- `usePlayerKeyboard({ shortcuts, webgpuAvailable, onAction })` — owns the
+  PlayerView's document-level `keydown` listener and the binding-matching
+  logic (Space/k/Arrows/f/m/Escape + configurable prev/next episode +
+  shader presets). Dispatches `PlayerAction` strings via the `onAction`
+  callback so the consumer holds the component-local actions
+  (`togglePlay`, `seekRelative`, etc.). Registers `onMounted` /
+  `onBeforeUnmount` internally — like `keyboard-shortcuts.ts` for the App
+  shell. Shares `matchesBinding` + `isMac` with the App composable.
+  (Phase 5 slice 5d.2.a)
 
 Composables that own broadcast subscriptions or DOM listeners (like
 `useKeyboardShortcuts`) bind those inside themselves; pure-logic composables

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -3,6 +3,8 @@ import { ref, computed, onMounted, onBeforeUnmount, watch, nextTick } from 'vue'
 import SubtitlesOctopus from 'libass-wasm/dist/js/subtitles-octopus.js';
 import { formatSpeed } from '../utils';
 import { useMsePlayer } from '../composables/use-mse-player';
+import { useAnime4K } from '../composables/use-anime4k';
+import { usePlayerKeyboard, type PlayerAction } from '../composables/use-player-keyboard';
 
 const props = defineProps<{
   filePath: string;
@@ -47,11 +49,13 @@ const seekTooltipVisible = ref(false);
 const seekTooltipLeft = ref(0);
 const seekTooltipTime = ref('0:00');
 
-// Anime4K state
-const anime4kPreset = ref<'off' | 'mode-a' | 'mode-b' | 'mode-c'>('off');
-const webgpuAvailable = ref(false);
-const gpuName = ref('');
-const anime4kActive = computed(() => webgpuAvailable.value && anime4kPreset.value !== 'off');
+// Anime4K state — owned by useAnime4K composable, destructured here for
+// template bindings + the watcher below.
+const a4k = useAnime4K({
+  getVideoEl: () => videoRef.value,
+  getCanvasEl: () => canvasRef.value
+});
+const { anime4kPreset, webgpuAvailable, gpuName, anime4kActive, presetLabel } = a4k;
 
 // UI state
 const showControls = ref(true);
@@ -954,37 +958,8 @@ function maybeMarkPendingPrevWatched(): void {
   markEpisodeWatched(prev);
 }
 
-// WebGPU pipeline state
-let gpuDevice: GPUDevice | null = null;
-let pipelineActive = false;
-
 // ASS subtitle state (SubtitlesOctopus renderer)
 let octopusInstance: InstanceType<typeof SubtitlesOctopus> | null = null;
-
-// Fullscreen quad WGSL shaders for rendering pipeline output to canvas
-const FULLSCREEN_QUAD_VERT = `
-@vertex
-fn vert_main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4f {
-  var pos = array<vec2f, 6>(
-    vec2f(-1, -1), vec2f(1, -1), vec2f(-1, 1),
-    vec2f(-1, 1), vec2f(1, -1), vec2f(1, 1)
-  );
-  return vec4f(pos[idx], 0, 1);
-}
-`;
-
-const FULLSCREEN_QUAD_FRAG = `
-@group(0) @binding(0) var mySampler: sampler;
-@group(0) @binding(1) var myTexture: texture_2d<f32>;
-
-@fragment
-fn main(@builtin(position) coord: vec4f) -> @location(0) vec4f {
-  let dims = vec2f(textureDimensions(myTexture));
-  let tc = coord.xy / dims;
-  // Flip Y so video isn't upside down
-  return textureSample(myTexture, mySampler, vec2f(tc.x, tc.y));
-}
-`;
 
 const videoSrc = computed(() => {
   if (activeFilePath.value) {
@@ -1411,272 +1386,79 @@ function onAuxMouseDown(e: MouseEvent): void {
 }
 
 // Keyboard shortcuts
-const isMac = navigator.platform.toUpperCase().includes('MAC');
-
-function matchesBinding(e: KeyboardEvent, binding: string): boolean {
-  const parts = binding.split('+');
-  const key = parts[parts.length - 1];
-  const mods = parts.slice(0, -1).map((m) => m.toLowerCase());
-  const needCtrl = mods.includes('ctrl');
-  const needMeta = mods.includes('meta');
-  const needCmdOrCtrl = mods.includes('cmdorctrl');
-  const needShift = mods.includes('shift');
-  const needAlt = mods.includes('alt');
-  const wantCtrl = needCtrl || (needCmdOrCtrl && !isMac);
-  const wantMeta = needMeta || (needCmdOrCtrl && isMac);
-  if (e.ctrlKey !== wantCtrl) return false;
-  if (e.metaKey !== wantMeta) return false;
-  if (e.shiftKey !== needShift) return false;
-  if (e.altKey !== needAlt) return false;
-  return e.key.toLowerCase() === key.toLowerCase();
-}
-
-function onKeyDown(event: KeyboardEvent): void {
-  event.stopPropagation();
-  const target = event.target as HTMLElement | null;
-  const tag = target?.tagName;
-  if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable)
-    return;
-
-  const prevBinding = playerShortcuts.value.playerPrevEpisode || 'Shift+ArrowLeft';
-  const nextBinding = playerShortcuts.value.playerNextEpisode || 'Shift+ArrowRight';
-  if (matchesBinding(event, prevBinding)) {
-    event.preventDefault();
-    if (canPrev.value) goToEpisode('prev');
-    return;
-  }
-  if (matchesBinding(event, nextBinding)) {
-    event.preventDefault();
-    if (canNext.value) goToEpisode('next');
-    return;
-  }
-
-  if (webgpuAvailable.value) {
-    const shaderBindings: [string, 'mode-a' | 'mode-b' | 'mode-c' | 'off'][] = [
-      [playerShortcuts.value.shaderModeA || 'CmdOrCtrl+1', 'mode-a'],
-      [playerShortcuts.value.shaderModeB || 'CmdOrCtrl+2', 'mode-b'],
-      [playerShortcuts.value.shaderModeC || 'CmdOrCtrl+3', 'mode-c'],
-      [playerShortcuts.value.shaderOff || 'CmdOrCtrl+Backquote', 'off']
-    ];
-    for (const [binding, preset] of shaderBindings) {
-      if (matchesBinding(event, binding)) {
-        event.preventDefault();
-        selectPreset(preset);
-        showControlsBriefly();
-        return;
-      }
-    }
-  }
-
-  switch (event.key) {
-    case ' ':
-    case 'k':
-    case 'K':
-      event.preventDefault();
+// Keyboard handling — usePlayerKeyboard owns the document-level keydown
+// listener + binding matching; we map dispatched actions back to the
+// component-local helpers below.
+function onPlayerAction(action: PlayerAction): void {
+  switch (action) {
+    case 'prev-episode':
+      if (canPrev.value) goToEpisode('prev');
+      break;
+    case 'next-episode':
+      if (canNext.value) goToEpisode('next');
+      break;
+    case 'shader-mode-a':
+      selectPreset('mode-a');
+      showControlsBriefly();
+      break;
+    case 'shader-mode-b':
+      selectPreset('mode-b');
+      showControlsBriefly();
+      break;
+    case 'shader-mode-c':
+      selectPreset('mode-c');
+      showControlsBriefly();
+      break;
+    case 'shader-off':
+      selectPreset('off');
+      showControlsBriefly();
+      break;
+    case 'play-toggle':
       togglePlay();
       break;
-    case 'ArrowLeft':
-      event.preventDefault();
+    case 'seek-back':
       seekRelative(-5);
       showControlsBriefly();
       break;
-    case 'ArrowRight':
-      event.preventDefault();
+    case 'seek-forward':
       seekRelative(5);
       showControlsBriefly();
       break;
-    case 'ArrowUp':
-      event.preventDefault();
+    case 'volume-up':
       setVolume(volume.value + 0.05);
       showControlsBriefly();
       break;
-    case 'ArrowDown':
-      event.preventDefault();
+    case 'volume-down':
       setVolume(volume.value - 0.05);
       showControlsBriefly();
       break;
-    case 'f':
-    case 'F':
-      event.preventDefault();
+    case 'fullscreen':
       toggleFullscreen();
       break;
-    case 'm':
-    case 'M':
-      event.preventDefault();
+    case 'mute-toggle':
       toggleMute();
       showControlsBriefly();
       break;
-    case 'Escape':
-      event.preventDefault();
+    case 'close':
       handleClose();
       break;
   }
 }
+usePlayerKeyboard({
+  shortcuts: playerShortcuts,
+  webgpuAvailable,
+  onAction: onPlayerAction
+});
 
-// Anime4K WebGPU setup
-async function initWebGPU(): Promise<void> {
-  try {
-    if (!navigator.gpu) return;
-    const adapter = await navigator.gpu.requestAdapter();
-    if (!adapter) return;
-    const info = adapter.info;
-    gpuName.value = info.device || info.description || info.vendor || 'Unknown GPU';
-    gpuDevice = await adapter.requestDevice();
-    webgpuAvailable.value = true;
-  } catch (e) {
-    console.warn('[player] WebGPU init failed:', e);
-  }
-}
-
-async function startAnime4KPipeline(): Promise<void> {
-  stopAnime4KPipeline();
-
-  const video = videoRef.value;
-  const canvas = canvasRef.value;
-  if (!video || !canvas || !gpuDevice || anime4kPreset.value === 'off') return;
-  if (!video.videoWidth || !video.videoHeight) return;
-
-  try {
-    const { ModeA, ModeB, ModeC } = await import('anime4k-webgpu');
-    const device = gpuDevice;
-
-    const PresetClass = {
-      'mode-a': ModeA,
-      'mode-b': ModeB,
-      'mode-c': ModeC
-    }[anime4kPreset.value];
-    if (!PresetClass) return;
-
-    const WIDTH = video.videoWidth;
-    const HEIGHT = video.videoHeight;
-
-    // Create input texture for video frames
-    const videoFrameTexture = device.createTexture({
-      size: [WIDTH, HEIGHT, 1],
-      format: 'rgba16float',
-      usage:
-        GPUTextureUsage.TEXTURE_BINDING |
-        GPUTextureUsage.COPY_DST |
-        GPUTextureUsage.RENDER_ATTACHMENT
-    });
-
-    // Target dimensions: use screen size (capped to avoid excessive GPU load)
-    const screenW = Math.round(window.screen.width * window.devicePixelRatio);
-    const screenH = Math.round(window.screen.height * window.devicePixelRatio);
-    // Don't upscale beyond screen resolution
-    const targetW = Math.min(screenW, WIDTH * 2);
-    const targetH = Math.min(screenH, HEIGHT * 2);
-
-    // Create the Anime4K pipeline
-    const pipeline = new PresetClass({
-      device,
-      inputTexture: videoFrameTexture,
-      nativeDimensions: { width: WIDTH, height: HEIGHT },
-      targetDimensions: { width: targetW, height: targetH }
-    });
-
-    // Set canvas size to pipeline output
-    const outputTex = pipeline.getOutputTexture();
-    canvas.width = outputTex.width;
-    canvas.height = outputTex.height;
-
-    // Configure canvas WebGPU context
-    const context = canvas.getContext('webgpu') as GPUCanvasContext;
-    const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
-    context.configure({ device, format: presentationFormat, alphaMode: 'premultiplied' });
-
-    // Create render pipeline (fullscreen quad to display output texture)
-    const bindGroupLayout = device.createBindGroupLayout({
-      entries: [
-        { binding: 0, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
-        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: {} }
-      ]
-    });
-
-    const renderPipeline = device.createRenderPipeline({
-      layout: device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] }),
-      vertex: {
-        module: device.createShaderModule({ code: FULLSCREEN_QUAD_VERT }),
-        entryPoint: 'vert_main'
-      },
-      fragment: {
-        module: device.createShaderModule({ code: FULLSCREEN_QUAD_FRAG }),
-        entryPoint: 'main',
-        targets: [{ format: presentationFormat }]
-      },
-      primitive: { topology: 'triangle-list' }
-    });
-
-    const sampler = device.createSampler({ magFilter: 'linear', minFilter: 'linear' });
-    const bindGroup = device.createBindGroup({
-      layout: bindGroupLayout,
-      entries: [
-        { binding: 0, resource: sampler },
-        { binding: 1, resource: outputTex.createView() }
-      ]
-    });
-
-    pipelineActive = true;
-
-    function frame(): void {
-      if (!pipelineActive) return;
-
-      try {
-        // Copy current video frame to input texture
-        device.queue.copyExternalImageToTexture(
-          { source: video! },
-          { texture: videoFrameTexture },
-          [WIDTH, HEIGHT]
-        );
-
-        const commandEncoder = device.createCommandEncoder();
-
-        // Run Anime4K compute shaders
-        pipeline.pass(commandEncoder);
-
-        // Render output to canvas
-        const passEncoder = commandEncoder.beginRenderPass({
-          colorAttachments: [
-            {
-              view: context.getCurrentTexture().createView(),
-              clearValue: { r: 0, g: 0, b: 0, a: 1 },
-              loadOp: 'clear',
-              storeOp: 'store'
-            }
-          ]
-        });
-        passEncoder.setPipeline(renderPipeline);
-        passEncoder.setBindGroup(0, bindGroup);
-        passEncoder.draw(6);
-        passEncoder.end();
-
-        device.queue.submit([commandEncoder.finish()]);
-      } catch (e) {
-        console.warn('[player] Anime4K frame error:', e);
-        pipelineActive = false;
-        return;
-      }
-
-      video!.requestVideoFrameCallback(frame);
-    }
-
-    video.requestVideoFrameCallback(frame);
-  } catch (e) {
-    console.error('[player] Anime4K pipeline error:', e);
-  }
-}
-
-function stopAnime4KPipeline(): void {
-  pipelineActive = false;
-}
-
-// Watch preset changes
+// Anime4K WebGPU pipeline is owned by `a4k` (useAnime4K composable) above.
+// Persist the preset change + drive the pipeline lifecycle from here, since
+// only the component knows about IPC + the loadedmetadata-gated start.
 watch(anime4kPreset, async (newPreset) => {
   await window.api.setSetting('anime4kPreset', newPreset);
   if (newPreset === 'off') {
-    stopAnime4KPipeline();
+    a4k.stopPipeline();
   } else if (webgpuAvailable.value && videoRef.value?.videoWidth) {
-    await startAnime4KPipeline();
+    await a4k.startPipeline();
   }
 });
 
@@ -1684,16 +1466,6 @@ function selectPreset(preset: 'off' | 'mode-a' | 'mode-b' | 'mode-c'): void {
   anime4kPreset.value = preset;
   showPresetMenu.value = false;
 }
-
-const presetLabel = computed(() => {
-  const labels: Record<string, string> = {
-    off: 'A4K Off',
-    'mode-a': 'A4K: A',
-    'mode-b': 'A4K: B',
-    'mode-c': 'A4K: C'
-  };
-  return labels[anime4kPreset.value] || 'A4K';
-});
 
 function qualityLabel(height: number): string {
   return height + 'p';
@@ -2133,7 +1905,8 @@ function onPrefetchSettingChanged(ev: Event): void {
 }
 
 onMounted(async () => {
-  document.addEventListener('keydown', onKeyDown);
+  // The document-level keydown listener is owned by usePlayerKeyboard
+  // (lifecycle wired inside the composable).
   document.addEventListener('fullscreenchange', onFullscreenChange);
   window.addEventListener('mouseup', onAuxMouseUp, true);
   window.addEventListener('mousedown', onAuxMouseDown, true);
@@ -2346,7 +2119,7 @@ onMounted(async () => {
   await nextTick();
   suppressVolumePersist = false;
 
-  await initWebGPU();
+  await a4k.initWebGPU();
 
   // Wait for video to be ready, then start pipeline if needed
   await nextTick();
@@ -2356,7 +2129,7 @@ onMounted(async () => {
     video.muted = muted.value;
     const onVideoReady = async (): Promise<void> => {
       if (anime4kPreset.value !== 'off' && webgpuAvailable.value) {
-        await startAnime4KPipeline();
+        await a4k.startPipeline();
       }
       if (activeSubtitleContent.value) {
         initSubtitles(video);
@@ -2395,7 +2168,8 @@ onBeforeUnmount(() => {
   }
   if (prefetchToastTimer) clearTimeout(prefetchToastTimer);
   if (resumeToastTimer) clearTimeout(resumeToastTimer);
-  document.removeEventListener('keydown', onKeyDown);
+  // The document keydown listener is removed by usePlayerKeyboard's
+  // onBeforeUnmount hook.
   document.removeEventListener('fullscreenchange', onFullscreenChange);
   window.removeEventListener('mouseup', onAuxMouseUp, true);
   window.removeEventListener('mousedown', onAuxMouseDown, true);
@@ -2423,7 +2197,7 @@ onBeforeUnmount(() => {
     fn('cancel');
   }
   cancelAutoAdvance();
-  stopAnime4KPipeline();
+  a4k.destroy();
   destroySubtitles();
   // Pause and release video
   const video = videoRef.value;
@@ -2431,10 +2205,6 @@ onBeforeUnmount(() => {
     video.pause();
     video.src = '';
     video.load();
-  }
-  if (gpuDevice) {
-    gpuDevice.destroy();
-    gpuDevice = null;
   }
   // Stop listening for stream events
   unsubPlayerStreamSubtitles?.();

--- a/src/renderer/src/composables/keyboard-shortcuts.ts
+++ b/src/renderer/src/composables/keyboard-shortcuts.ts
@@ -12,9 +12,13 @@
 import { onBeforeUnmount, onMounted } from 'vue'
 import type { Ref } from 'vue'
 
-const isMac = navigator.platform.toUpperCase().includes('MAC')
+// Module is imported transitively by composable tests under
+// `environment: 'node'`, where `navigator` may be undefined — guard the
+// platform probe rather than crashing at import time.
+export const isMac =
+  typeof navigator !== 'undefined' && navigator.platform.toUpperCase().includes('MAC')
 
-function matchesBinding(e: KeyboardEvent, binding: string): boolean {
+export function matchesBinding(e: KeyboardEvent, binding: string): boolean {
   const parts = binding.split('+')
   const key = parts[parts.length - 1]
   const mods = parts.slice(0, -1).map((m) => m.toLowerCase())

--- a/src/renderer/src/composables/use-anime4k.ts
+++ b/src/renderer/src/composables/use-anime4k.ts
@@ -1,0 +1,245 @@
+// Anime4K WebGPU upscaling pipeline for PlayerView (Phase 5 slice 5d.2.a, #118).
+//
+// Owns the WebGPU device + pipeline lifecycle that runs the `anime4k-webgpu`
+// compute shaders against the active <video> frame and presents the result on
+// a `<canvas>`. The preset ref drives which mode the pipeline uses; consumers
+// drive start/stop via the preset watcher + lifecycle hooks (so the
+// composable is testable without a Vue runtime / GPU adapter).
+//
+// Does NOT own: the preset-changed `watch` (caller persists to settings +
+// drives start/stop), the menu UI state (`showPresetMenu`), or the keyboard
+// dispatch for shader presets (that lives in `usePlayerKeyboard`).
+
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+
+const FULLSCREEN_QUAD_VERT = `
+@vertex
+fn vert_main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4f {
+  var pos = array<vec2f, 6>(
+    vec2f(-1, -1), vec2f(1, -1), vec2f(-1, 1),
+    vec2f(-1, 1), vec2f(1, -1), vec2f(1, 1)
+  );
+  return vec4f(pos[idx], 0, 1);
+}
+`
+
+const FULLSCREEN_QUAD_FRAG = `
+@group(0) @binding(0) var mySampler: sampler;
+@group(0) @binding(1) var myTexture: texture_2d<f32>;
+
+@fragment
+fn main(@builtin(position) coord: vec4f) -> @location(0) vec4f {
+  let dims = vec2f(textureDimensions(myTexture));
+  let tc = coord.xy / dims;
+  // Flip Y so video isn't upside down
+  return textureSample(myTexture, mySampler, vec2f(tc.x, tc.y));
+}
+`
+
+export type Anime4KPreset = 'off' | 'mode-a' | 'mode-b' | 'mode-c'
+
+export function useAnime4K(deps: {
+  /** Live <video> element getter — re-resolved at start time, not captured. */
+  getVideoEl: () => HTMLVideoElement | null
+  /** Live <canvas> element getter — the WebGPU pipeline output sink. */
+  getCanvasEl: () => HTMLCanvasElement | null
+}): {
+  anime4kPreset: Ref<Anime4KPreset>
+  webgpuAvailable: Ref<boolean>
+  gpuName: Ref<string>
+  anime4kActive: ComputedRef<boolean>
+  presetLabel: ComputedRef<string>
+  initWebGPU: () => Promise<void>
+  startPipeline: () => Promise<void>
+  stopPipeline: () => void
+  destroy: () => void
+} {
+  const anime4kPreset = ref<Anime4KPreset>('off')
+  const webgpuAvailable = ref(false)
+  const gpuName = ref('')
+
+  const anime4kActive = computed(() => webgpuAvailable.value && anime4kPreset.value !== 'off')
+
+  const presetLabel = computed(() => {
+    const labels: Record<string, string> = {
+      off: 'A4K Off',
+      'mode-a': 'A4K: A',
+      'mode-b': 'A4K: B',
+      'mode-c': 'A4K: C'
+    }
+    return labels[anime4kPreset.value] || 'A4K'
+  })
+
+  let gpuDevice: GPUDevice | null = null
+  let pipelineActive = false
+
+  async function initWebGPU(): Promise<void> {
+    try {
+      if (!navigator.gpu) return
+      const adapter = await navigator.gpu.requestAdapter()
+      if (!adapter) return
+      const info = adapter.info
+      gpuName.value = info.device || info.description || info.vendor || 'Unknown GPU'
+      gpuDevice = await adapter.requestDevice()
+      webgpuAvailable.value = true
+    } catch (e) {
+      console.warn('[player] WebGPU init failed:', e)
+    }
+  }
+
+  async function startPipeline(): Promise<void> {
+    stopPipeline()
+
+    const video = deps.getVideoEl()
+    const canvas = deps.getCanvasEl()
+    if (!video || !canvas || !gpuDevice || anime4kPreset.value === 'off') return
+    if (!video.videoWidth || !video.videoHeight) return
+
+    try {
+      const { ModeA, ModeB, ModeC } = await import('anime4k-webgpu')
+      const device = gpuDevice
+
+      const PresetClass = {
+        'mode-a': ModeA,
+        'mode-b': ModeB,
+        'mode-c': ModeC
+      }[anime4kPreset.value]
+      if (!PresetClass) return
+
+      const WIDTH = video.videoWidth
+      const HEIGHT = video.videoHeight
+
+      const videoFrameTexture = device.createTexture({
+        size: [WIDTH, HEIGHT, 1],
+        format: 'rgba16float',
+        usage:
+          GPUTextureUsage.TEXTURE_BINDING |
+          GPUTextureUsage.COPY_DST |
+          GPUTextureUsage.RENDER_ATTACHMENT
+      })
+
+      // Cap upscale at screen resolution so GPU load stays bounded.
+      const screenW = Math.round(window.screen.width * window.devicePixelRatio)
+      const screenH = Math.round(window.screen.height * window.devicePixelRatio)
+      const targetW = Math.min(screenW, WIDTH * 2)
+      const targetH = Math.min(screenH, HEIGHT * 2)
+
+      const pipeline = new PresetClass({
+        device,
+        inputTexture: videoFrameTexture,
+        nativeDimensions: { width: WIDTH, height: HEIGHT },
+        targetDimensions: { width: targetW, height: targetH }
+      })
+
+      const outputTex = pipeline.getOutputTexture()
+      canvas.width = outputTex.width
+      canvas.height = outputTex.height
+
+      const context = canvas.getContext('webgpu') as GPUCanvasContext
+      const presentationFormat = navigator.gpu.getPreferredCanvasFormat()
+      context.configure({ device, format: presentationFormat, alphaMode: 'premultiplied' })
+
+      const bindGroupLayout = device.createBindGroupLayout({
+        entries: [
+          { binding: 0, visibility: GPUShaderStage.FRAGMENT, sampler: {} },
+          { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: {} }
+        ]
+      })
+
+      const renderPipeline = device.createRenderPipeline({
+        layout: device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] }),
+        vertex: {
+          module: device.createShaderModule({ code: FULLSCREEN_QUAD_VERT }),
+          entryPoint: 'vert_main'
+        },
+        fragment: {
+          module: device.createShaderModule({ code: FULLSCREEN_QUAD_FRAG }),
+          entryPoint: 'main',
+          targets: [{ format: presentationFormat }]
+        },
+        primitive: { topology: 'triangle-list' }
+      })
+
+      const sampler = device.createSampler({ magFilter: 'linear', minFilter: 'linear' })
+      const bindGroup = device.createBindGroup({
+        layout: bindGroupLayout,
+        entries: [
+          { binding: 0, resource: sampler },
+          { binding: 1, resource: outputTex.createView() }
+        ]
+      })
+
+      pipelineActive = true
+
+      function frame(): void {
+        if (!pipelineActive) return
+
+        try {
+          device.queue.copyExternalImageToTexture(
+            { source: video! },
+            { texture: videoFrameTexture },
+            [WIDTH, HEIGHT]
+          )
+
+          const commandEncoder = device.createCommandEncoder()
+          pipeline.pass(commandEncoder)
+
+          const passEncoder = commandEncoder.beginRenderPass({
+            colorAttachments: [
+              {
+                view: context.getCurrentTexture().createView(),
+                clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                loadOp: 'clear',
+                storeOp: 'store'
+              }
+            ]
+          })
+          passEncoder.setPipeline(renderPipeline)
+          passEncoder.setBindGroup(0, bindGroup)
+          passEncoder.draw(6)
+          passEncoder.end()
+
+          device.queue.submit([commandEncoder.finish()])
+        } catch (e) {
+          console.warn('[player] Anime4K frame error:', e)
+          pipelineActive = false
+          return
+        }
+
+        video!.requestVideoFrameCallback(frame)
+      }
+
+      video.requestVideoFrameCallback(frame)
+    } catch (e) {
+      console.error('[player] Anime4K pipeline error:', e)
+    }
+  }
+
+  function stopPipeline(): void {
+    pipelineActive = false
+  }
+
+  function destroy(): void {
+    stopPipeline()
+    if (gpuDevice) {
+      try {
+        gpuDevice.destroy()
+      } catch {
+        /* ignore */
+      }
+      gpuDevice = null
+    }
+  }
+
+  return {
+    anime4kPreset,
+    webgpuAvailable,
+    gpuName,
+    anime4kActive,
+    presetLabel,
+    initWebGPU,
+    startPipeline,
+    stopPipeline,
+    destroy
+  }
+}

--- a/src/renderer/src/composables/use-player-keyboard.ts
+++ b/src/renderer/src/composables/use-player-keyboard.ts
@@ -1,0 +1,137 @@
+// PlayerView keyboard dispatch (Phase 5 slice 5d.2.a, #118).
+//
+// Owns the `document`-level keydown listener that powers in-player shortcuts:
+// space/k toggles playback, arrows seek + adjust volume, f / m / Escape, and
+// the configurable bindings for prev/next episode + Anime4K shader presets.
+// The composable dispatches via an `onAction` callback rather than reaching
+// into PlayerView state directly — keeps it testable + matches the
+// `keyboard-shortcuts.ts` precedent for App-level shortcuts.
+//
+// `document` not `window` because PlayerView is a modal-style overlay and
+// expects to swallow keys even when focus isn't strictly inside the player.
+
+import { onBeforeUnmount, onMounted, type Ref } from 'vue'
+import { matchesBinding } from './keyboard-shortcuts'
+
+export type PlayerAction =
+  | 'prev-episode'
+  | 'next-episode'
+  | 'shader-mode-a'
+  | 'shader-mode-b'
+  | 'shader-mode-c'
+  | 'shader-off'
+  | 'play-toggle'
+  | 'seek-back'
+  | 'seek-forward'
+  | 'volume-up'
+  | 'volume-down'
+  | 'fullscreen'
+  | 'mute-toggle'
+  | 'close'
+
+export type PlayerKeyboardDeps = {
+  /** Resolved shortcut bindings (action name → "CmdOrCtrl+1" etc.). */
+  shortcuts: Ref<Record<string, string>>
+  /** Gate shader actions — when false, they're skipped entirely. */
+  webgpuAvailable: Ref<boolean>
+  /** Action dispatcher — receives the action plus the original event. */
+  onAction: (action: PlayerAction, event: KeyboardEvent) => void
+}
+
+const SHADER_BINDING_DEFAULTS: Record<string, string> = {
+  shaderModeA: 'CmdOrCtrl+1',
+  shaderModeB: 'CmdOrCtrl+2',
+  shaderModeC: 'CmdOrCtrl+3',
+  shaderOff: 'CmdOrCtrl+Backquote'
+}
+
+const SHADER_ACTION_FOR: Record<string, PlayerAction> = {
+  shaderModeA: 'shader-mode-a',
+  shaderModeB: 'shader-mode-b',
+  shaderModeC: 'shader-mode-c',
+  shaderOff: 'shader-off'
+}
+
+export function usePlayerKeyboard({ shortcuts, webgpuAvailable, onAction }: PlayerKeyboardDeps): {
+  handleKeyDown: (e: KeyboardEvent) => void
+} {
+  function handleKeyDown(event: KeyboardEvent): void {
+    event.stopPropagation()
+    const target = event.target as HTMLElement | null
+    const tag = target?.tagName
+    if (tag === 'SELECT' || tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable)
+      return
+
+    const prevBinding = shortcuts.value.playerPrevEpisode || 'Shift+ArrowLeft'
+    const nextBinding = shortcuts.value.playerNextEpisode || 'Shift+ArrowRight'
+    if (matchesBinding(event, prevBinding)) {
+      event.preventDefault()
+      onAction('prev-episode', event)
+      return
+    }
+    if (matchesBinding(event, nextBinding)) {
+      event.preventDefault()
+      onAction('next-episode', event)
+      return
+    }
+
+    if (webgpuAvailable.value) {
+      for (const key of Object.keys(SHADER_ACTION_FOR)) {
+        const binding = shortcuts.value[key] || SHADER_BINDING_DEFAULTS[key]
+        if (matchesBinding(event, binding)) {
+          event.preventDefault()
+          onAction(SHADER_ACTION_FOR[key], event)
+          return
+        }
+      }
+    }
+
+    switch (event.key) {
+      case ' ':
+      case 'k':
+      case 'K':
+        event.preventDefault()
+        onAction('play-toggle', event)
+        break
+      case 'ArrowLeft':
+        event.preventDefault()
+        onAction('seek-back', event)
+        break
+      case 'ArrowRight':
+        event.preventDefault()
+        onAction('seek-forward', event)
+        break
+      case 'ArrowUp':
+        event.preventDefault()
+        onAction('volume-up', event)
+        break
+      case 'ArrowDown':
+        event.preventDefault()
+        onAction('volume-down', event)
+        break
+      case 'f':
+      case 'F':
+        event.preventDefault()
+        onAction('fullscreen', event)
+        break
+      case 'm':
+      case 'M':
+        event.preventDefault()
+        onAction('mute-toggle', event)
+        break
+      case 'Escape':
+        event.preventDefault()
+        onAction('close', event)
+        break
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('keydown', handleKeyDown)
+  })
+  onBeforeUnmount(() => {
+    document.removeEventListener('keydown', handleKeyDown)
+  })
+
+  return { handleKeyDown }
+}

--- a/test/renderer/composables/use-anime4k.test.ts
+++ b/test/renderer/composables/use-anime4k.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAnime4K } from '../../../src/renderer/src/composables/use-anime4k'
+
+function makeDeps(overrides: Partial<Parameters<typeof useAnime4K>[0]> = {}) {
+  return {
+    getVideoEl: () => null,
+    getCanvasEl: () => null,
+    ...overrides
+  } as Parameters<typeof useAnime4K>[0]
+}
+
+function stubGpu(gpu: unknown): void {
+  const g = globalThis as { navigator?: { gpu?: unknown } }
+  if (typeof g.navigator === 'undefined') {
+    g.navigator = { gpu }
+    return
+  }
+  Object.defineProperty(g.navigator, 'gpu', {
+    value: gpu,
+    configurable: true,
+    writable: true
+  })
+}
+
+beforeEach(() => {
+  // Ensure WebGPU is unavailable by default. Vitest runs under
+  // `environment: 'node'` where `navigator` may not exist at all.
+  stubGpu(undefined)
+})
+
+describe('useAnime4K — initial state', () => {
+  it('starts with preset off, no WebGPU, no GPU name', () => {
+    const a = useAnime4K(makeDeps())
+    expect(a.anime4kPreset.value).toBe('off')
+    expect(a.webgpuAvailable.value).toBe(false)
+    expect(a.gpuName.value).toBe('')
+    expect(a.anime4kActive.value).toBe(false)
+  })
+})
+
+describe('useAnime4K — anime4kActive computed', () => {
+  it('is false while webgpuAvailable is false even if preset is set', () => {
+    const a = useAnime4K(makeDeps())
+    a.anime4kPreset.value = 'mode-a'
+    expect(a.anime4kActive.value).toBe(false)
+  })
+
+  it('becomes true once webgpuAvailable + non-off preset', () => {
+    const a = useAnime4K(makeDeps())
+    a.webgpuAvailable.value = true
+    a.anime4kPreset.value = 'mode-b'
+    expect(a.anime4kActive.value).toBe(true)
+  })
+
+  it('flips back to false when preset returns to off', () => {
+    const a = useAnime4K(makeDeps())
+    a.webgpuAvailable.value = true
+    a.anime4kPreset.value = 'mode-c'
+    expect(a.anime4kActive.value).toBe(true)
+    a.anime4kPreset.value = 'off'
+    expect(a.anime4kActive.value).toBe(false)
+  })
+})
+
+describe('useAnime4K — presetLabel computed', () => {
+  it('formats each preset label', () => {
+    const a = useAnime4K(makeDeps())
+    expect(a.presetLabel.value).toBe('A4K Off')
+    a.anime4kPreset.value = 'mode-a'
+    expect(a.presetLabel.value).toBe('A4K: A')
+    a.anime4kPreset.value = 'mode-b'
+    expect(a.presetLabel.value).toBe('A4K: B')
+    a.anime4kPreset.value = 'mode-c'
+    expect(a.presetLabel.value).toBe('A4K: C')
+  })
+})
+
+describe('useAnime4K — initWebGPU', () => {
+  it('leaves webgpuAvailable false when navigator.gpu is missing', async () => {
+    const a = useAnime4K(makeDeps())
+    await a.initWebGPU()
+    expect(a.webgpuAvailable.value).toBe(false)
+    expect(a.gpuName.value).toBe('')
+  })
+
+  it('leaves webgpuAvailable false when adapter request returns null', async () => {
+    stubGpu({ requestAdapter: vi.fn().mockResolvedValue(null) })
+    const a = useAnime4K(makeDeps())
+    await a.initWebGPU()
+    expect(a.webgpuAvailable.value).toBe(false)
+  })
+
+  it('captures gpu name + sets webgpuAvailable when adapter + device resolve', async () => {
+    const fakeDevice = { destroy: vi.fn() }
+    stubGpu({
+      requestAdapter: vi.fn().mockResolvedValue({
+        info: { device: 'NVIDIA RTX 9999' },
+        requestDevice: vi.fn().mockResolvedValue(fakeDevice)
+      })
+    })
+    const a = useAnime4K(makeDeps())
+    await a.initWebGPU()
+    expect(a.webgpuAvailable.value).toBe(true)
+    expect(a.gpuName.value).toBe('NVIDIA RTX 9999')
+  })
+
+  it('swallows exceptions and stays unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubGpu({ requestAdapter: vi.fn().mockRejectedValue(new Error('boom')) })
+    const a = useAnime4K(makeDeps())
+    await a.initWebGPU()
+    expect(a.webgpuAvailable.value).toBe(false)
+    warn.mockRestore()
+  })
+})
+
+describe('useAnime4K — startPipeline guards', () => {
+  it('is a no-op when video element is null', async () => {
+    const a = useAnime4K(makeDeps({ getVideoEl: () => null }))
+    await expect(a.startPipeline()).resolves.toBeUndefined()
+  })
+
+  it('is a no-op when canvas element is null', async () => {
+    const a = useAnime4K(
+      makeDeps({ getVideoEl: () => ({ videoWidth: 1920, videoHeight: 1080 }) as HTMLVideoElement })
+    )
+    await expect(a.startPipeline()).resolves.toBeUndefined()
+  })
+
+  it('is a no-op when preset is off', async () => {
+    const a = useAnime4K(makeDeps())
+    a.anime4kPreset.value = 'off'
+    await expect(a.startPipeline()).resolves.toBeUndefined()
+  })
+})
+
+describe('useAnime4K — destroy', () => {
+  it('is safe to call without ever calling initWebGPU', () => {
+    const a = useAnime4K(makeDeps())
+    expect(() => a.destroy()).not.toThrow()
+  })
+
+  it('destroys the GPU device after init', async () => {
+    const destroySpy = vi.fn()
+    stubGpu({
+      requestAdapter: vi.fn().mockResolvedValue({
+        info: { vendor: 'TestVendor' },
+        requestDevice: vi.fn().mockResolvedValue({ destroy: destroySpy })
+      })
+    })
+    const a = useAnime4K(makeDeps())
+    await a.initWebGPU()
+    a.destroy()
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useAnime4K — stopPipeline', () => {
+  it('is safe to call when no pipeline is running', () => {
+    const a = useAnime4K(makeDeps())
+    expect(() => a.stopPipeline()).not.toThrow()
+  })
+
+  it('is idempotent', () => {
+    const a = useAnime4K(makeDeps())
+    a.stopPipeline()
+    a.stopPipeline()
+    a.stopPipeline()
+    expect(true).toBe(true)
+  })
+})

--- a/test/renderer/composables/use-player-keyboard.test.ts
+++ b/test/renderer/composables/use-player-keyboard.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref } from 'vue'
+import {
+  usePlayerKeyboard,
+  type PlayerAction
+} from '../../../src/renderer/src/composables/use-player-keyboard'
+
+type SpyDispatcher = {
+  fn: ReturnType<typeof vi.fn>
+  calls: PlayerAction[]
+}
+
+function makeKeyboard(overrides: {
+  shortcuts?: Record<string, string>
+  webgpuAvailable?: boolean
+}) {
+  const dispatcher: SpyDispatcher = {
+    fn: vi.fn(),
+    calls: []
+  }
+  dispatcher.fn.mockImplementation((action: PlayerAction) => {
+    dispatcher.calls.push(action)
+  })
+  const shortcuts = ref(overrides.shortcuts ?? {})
+  const webgpuAvailable = ref(overrides.webgpuAvailable ?? false)
+  const { handleKeyDown } = usePlayerKeyboard({
+    shortcuts,
+    webgpuAvailable,
+    onAction: dispatcher.fn
+  })
+  return { handleKeyDown, dispatcher, shortcuts, webgpuAvailable }
+}
+
+function fakeEvent(opts: {
+  key: string
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+  alt?: boolean
+  target?: { tagName: string; isContentEditable?: boolean } | null
+}): KeyboardEvent {
+  const ev: Partial<KeyboardEvent> & {
+    preventDefault: ReturnType<typeof vi.fn>
+    stopPropagation: ReturnType<typeof vi.fn>
+  } = {
+    key: opts.key,
+    ctrlKey: !!opts.ctrl,
+    metaKey: !!opts.meta,
+    shiftKey: !!opts.shift,
+    altKey: !!opts.alt,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn()
+  }
+  Object.defineProperty(ev, 'target', {
+    value: opts.target ?? null,
+    enumerable: true,
+    configurable: true
+  })
+  return ev as KeyboardEvent
+}
+
+beforeEach(() => {
+  // jsdom's document is fine — composable's onMounted call just won't fire
+  // outside of a real Vue component context, which is what we want for unit
+  // tests of the inner handler.
+})
+
+describe('usePlayerKeyboard — input suppression', () => {
+  it('does not dispatch when target is INPUT', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: ' ', target: { tagName: 'INPUT' } }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+
+  it('does not dispatch when target is TEXTAREA', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: ' ', target: { tagName: 'TEXTAREA' } }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+
+  it('does not dispatch when target is SELECT', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: ' ', target: { tagName: 'SELECT' } }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+
+  it('does not dispatch when target is contentEditable', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: ' ', target: { tagName: 'DIV', isContentEditable: true } }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+})
+
+describe('usePlayerKeyboard — episode navigation', () => {
+  it('dispatches prev-episode on default Shift+ArrowLeft', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'ArrowLeft', shift: true }))
+    expect(dispatcher.calls).toEqual(['prev-episode'])
+  })
+
+  it('dispatches next-episode on default Shift+ArrowRight', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'ArrowRight', shift: true }))
+    expect(dispatcher.calls).toEqual(['next-episode'])
+  })
+
+  it('respects custom prev binding', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({
+      shortcuts: { playerPrevEpisode: 'Alt+p' }
+    })
+    handleKeyDown(fakeEvent({ key: 'p', alt: true }))
+    expect(dispatcher.calls).toEqual(['prev-episode'])
+  })
+})
+
+describe('usePlayerKeyboard — shader bindings', () => {
+  it('dispatches shader-mode-a on default Ctrl+1 when WebGPU is available', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({ webgpuAvailable: true })
+    handleKeyDown(fakeEvent({ key: '1', ctrl: true }))
+    expect(dispatcher.calls).toEqual(['shader-mode-a'])
+  })
+
+  it('dispatches shader-off on Ctrl+Backquote', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({ webgpuAvailable: true })
+    handleKeyDown(fakeEvent({ key: 'Backquote', ctrl: true }))
+    expect(dispatcher.calls).toEqual(['shader-off'])
+  })
+
+  it('skips shader bindings entirely when webgpu is unavailable', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({ webgpuAvailable: false })
+    handleKeyDown(fakeEvent({ key: '1', ctrl: true }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+
+  it('respects custom shader binding override', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({
+      webgpuAvailable: true,
+      shortcuts: { shaderModeB: 'Alt+b' }
+    })
+    handleKeyDown(fakeEvent({ key: 'b', alt: true }))
+    expect(dispatcher.calls).toEqual(['shader-mode-b'])
+  })
+})
+
+describe('usePlayerKeyboard — built-in keys', () => {
+  it('Space → play-toggle', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: ' ' }))
+    expect(dispatcher.calls).toEqual(['play-toggle'])
+  })
+
+  it('k → play-toggle (lowercase + uppercase)', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'k' }))
+    handleKeyDown(fakeEvent({ key: 'K' }))
+    expect(dispatcher.calls).toEqual(['play-toggle', 'play-toggle'])
+  })
+
+  it('ArrowLeft (no shift) → seek-back', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'ArrowLeft' }))
+    expect(dispatcher.calls).toEqual(['seek-back'])
+  })
+
+  it('ArrowRight (no shift) → seek-forward', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'ArrowRight' }))
+    expect(dispatcher.calls).toEqual(['seek-forward'])
+  })
+
+  it('ArrowUp / ArrowDown → volume', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'ArrowUp' }))
+    handleKeyDown(fakeEvent({ key: 'ArrowDown' }))
+    expect(dispatcher.calls).toEqual(['volume-up', 'volume-down'])
+  })
+
+  it('f / F → fullscreen', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'f' }))
+    handleKeyDown(fakeEvent({ key: 'F' }))
+    expect(dispatcher.calls).toEqual(['fullscreen', 'fullscreen'])
+  })
+
+  it('m / M → mute-toggle', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'm' }))
+    handleKeyDown(fakeEvent({ key: 'M' }))
+    expect(dispatcher.calls).toEqual(['mute-toggle', 'mute-toggle'])
+  })
+
+  it('Escape → close', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'Escape' }))
+    expect(dispatcher.calls).toEqual(['close'])
+  })
+
+  it('unhandled keys are ignored', () => {
+    const { handleKeyDown, dispatcher } = makeKeyboard({})
+    handleKeyDown(fakeEvent({ key: 'q' }))
+    handleKeyDown(fakeEvent({ key: 'Home' }))
+    expect(dispatcher.calls).toHaveLength(0)
+  })
+})
+
+describe('usePlayerKeyboard — preventDefault + stopPropagation', () => {
+  it('always calls stopPropagation, even when no action fires', () => {
+    const { handleKeyDown } = makeKeyboard({})
+    const ev = fakeEvent({ key: 'q' })
+    handleKeyDown(ev)
+    expect((ev.stopPropagation as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
+  })
+
+  it('calls preventDefault when an action matches', () => {
+    const { handleKeyDown } = makeKeyboard({})
+    const ev = fakeEvent({ key: 'Escape' })
+    handleKeyDown(ev)
+    expect((ev.preventDefault as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
+  })
+
+  it('does NOT call preventDefault on unhandled keys', () => {
+    const { handleKeyDown } = makeKeyboard({})
+    const ev = fakeEvent({ key: 'q' })
+    handleKeyDown(ev)
+    expect((ev.preventDefault as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
+  })
+
+  it('does not run handler at all when target is INPUT (returns before stop+prevent)', () => {
+    const { handleKeyDown } = makeKeyboard({})
+    const ev = fakeEvent({ key: 'Escape', target: { tagName: 'INPUT' } })
+    handleKeyDown(ev)
+    // stopPropagation always runs (it's the first line), but preventDefault doesn't.
+    expect((ev.stopPropagation as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
+    expect((ev.preventDefault as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 5 slice **5d.2.a** — the first of four sub-slices that finish decomposing `PlayerView.vue`. Extracts two small, low-risk pieces of state into composables + unit tests:

- **`useAnime4K`** — WebGPU device + render-pipeline lifecycle, preset state, `webgpuAvailable` + `gpuName` refs, `anime4kActive` + `presetLabel` computeds. (245 lines)
- **`usePlayerKeyboard`** — document-level `keydown` listener + binding matching + `PlayerAction` dispatch via callback. (137 lines)

`PlayerView.vue` shrinks **3840 → 3610 (-230 lines)** and the extracted code now has **40 unit tests** covering the parts that were unreachable from Vitest before.

This is the first step of the post–#126 PlayerView decomposition. Subsequent slices: `5d.2.b` Subtitles + Remux fallback, `5d.2.c` Skip markers, `5d.2.d` Syncplay client.

## Behavior

No user-visible change. Same keyboard shortcuts, same Anime4K preset menu, same `showControlsBriefly()` side-effects on the same set of actions that triggered them before. All current PlayerView behavior is byte-for-byte preserved.

## Changes

### New: `src/renderer/src/composables/use-anime4k.ts`

- Owns: the GPU device + Anime4K render-pipeline lifecycle (WGSL shaders, `anime4k-webgpu` dynamic import, `ModeA`/`B`/`C` selection, render loop via `requestVideoFrameCallback`).
- Reactive state: `anime4kPreset` (`'off' | 'mode-a' | 'mode-b' | 'mode-c'`), `webgpuAvailable`, `gpuName`, `anime4kActive` (gated on both), `presetLabel` (`A4K Off` / `A4K: A` / `A4K: B` / `A4K: C`).
- Actions: `initWebGPU()` (probe + request adapter + device), `startPipeline()` (build + run the pipeline), `stopPipeline()`, `destroy()` (stops pipeline + destroys GPU device).
- Lifecycle is **caller-managed** — the component owns the `watch(anime4kPreset)` that persists to settings + drives `startPipeline()` / `stopPipeline()` based on the `loadedmetadata`-gated readiness of the `<video>` element. Keeps the composable callable from Vitest without a real GPU adapter.

### New: `src/renderer/src/composables/use-player-keyboard.ts`

- Owns: the `document`-level `keydown` listener and binding-matching logic. Lifecycle is **composable-managed** (`onMounted` / `onBeforeUnmount`) following the precedent set by `composables/keyboard-shortcuts.ts` for the App shell.
- Suppresses dispatch when the event target is `INPUT` / `TEXTAREA` / `SELECT` / `contentEditable`.
- Default + customizable bindings:
  - `Shift+ArrowLeft` / `Shift+ArrowRight` → `prev-episode` / `next-episode`
  - `CmdOrCtrl+1` / `+2` / `+3` / `+Backquote` → `shader-mode-a` / `-b` / `-c` / `shader-off` (gated on `webgpuAvailable`)
  - Raw keys: Space/k → `play-toggle`, Arrows → `seek-back`/`seek-forward`/`volume-up`/`volume-down`, f → `fullscreen`, m → `mute-toggle`, Escape → `close`
- Dispatches the `PlayerAction` enum via an `onAction` callback so the consumer keeps the component-local helpers (`togglePlay`, `seekRelative`, `setVolume`, `toggleFullscreen`, `toggleMute`, `handleClose`, `goToEpisode`, `selectPreset`, `showControlsBriefly`).
- Reuses `matchesBinding` + `isMac` from `composables/keyboard-shortcuts.ts` (now exported).

### Tests

- **`test/renderer/composables/use-anime4k.test.ts`** (16 cases): initial state, `anime4kActive` gating, `presetLabel` formatting, `initWebGPU` with mocked adapters (missing/null/throwing/successful), `startPipeline` no-op guards (null video / null canvas / preset off), `destroy` lifecycle (with + without prior init), idempotent `stopPipeline`.
- **`test/renderer/composables/use-player-keyboard.test.ts`** (24 cases): input-suppression on every focusable target type, default + custom prev/next bindings, shader bindings gated on `webgpuAvailable`, every built-in key (Space + k/K, Arrows, f/F, m/M, Escape), `preventDefault` only on matches, `stopPropagation` always.

### Modified: `src/renderer/src/components/PlayerView.vue`

- Replaces the inline `anime4kPreset` / `webgpuAvailable` / `gpuName` / `anime4kActive` declarations with a destructure from `useAnime4K({ getVideoEl, getCanvasEl })`.
- Deletes the inline `gpuDevice` / `pipelineActive` lets, the `FULLSCREEN_QUAD_VERT` / `FULLSCREEN_QUAD_FRAG` WGSL constants, the `initWebGPU` / `startAnime4KPipeline` / `stopAnime4KPipeline` functions, the `presetLabel` computed.
- Deletes inline `isMac` / `matchesBinding` / `onKeyDown`.
- Adds a small `onPlayerAction` switch that maps `PlayerAction`s to the component-local helpers, preserving exact prior `showControlsBriefly()` side-effects on the same set of actions.
- `onMounted`: `a4k.initWebGPU()` in place of inline; `document.addEventListener('keydown', onKeyDown)` is gone (composable owns it).
- `onBeforeUnmount`: `a4k.destroy()` in place of `stopAnime4KPipeline()` + `gpuDevice` cleanup block; `document.removeEventListener('keydown', onKeyDown)` is gone.

### Modified: `src/renderer/src/composables/keyboard-shortcuts.ts`

- Exports `matchesBinding` + `isMac` so `usePlayerKeyboard` can reuse them without duplication.

### Modified: `DESIGN.md`

- Adds the two new composables to the renderer composables section.

### Unchanged

- `src/main/**`, `src/preload/**`, every Pinia store.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (6 pre-existing warnings in `src/main/index.ts`)
- [x] `npm run format:check` clean
- [x] `npm run test` — 262 tests pass (was 222, +40 new)
- [x] `npm run build` clean
- [x] `bash scripts/check-subscription-contract.sh` clean
- [ ] **Manual smoke (pending user retest on native Windows)**: Anime4K preset toggle (Off / A / B / C); `CmdOrCtrl+1..3` + `CmdOrCtrl+Backquote` shortcuts switch presets; `Shift+ArrowLeft/Right` navigates episodes; Space/k toggles play; Arrows seek/volume; f fullscreen; m mute; Escape closes.

Stacked on #126 (slice 5d.1). Retarget to `main` before #126 merges per stacked-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
