### PR TITLE
fix: auto-downloader picks most-recent downloaded translation, not oldest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "scripts": {

--- a/src/main/auto-downloader.ts
+++ b/src/main/auto-downloader.ts
@@ -196,7 +196,9 @@ function mostRecentDownloadedTranslation(
 ): { type: string; author: string } | null {
   const all = store.get('downloadedEpisodes') as Record<string, DownloadedEpisodeMeta>
   const prefix = `${animeId}:`
-  for (const [key, meta] of Object.entries(all)) {
+  const entries = Object.entries(all)
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const [key, meta] = entries[i]
     if (!key.startsWith(prefix)) continue
     if (!meta?.translationType) continue
     return { type: meta.translationType, author: meta.author ?? '' }


### PR DESCRIPTION
## Summary
- `mostRecentDownloadedTranslation` was iterating `Object.entries(downloadedEpisodes)` forward, returning the *oldest* entry for the anime instead of the most recent one
- This caused the auto-downloader to ignore the user's latest translation choice (e.g. preferring an old English sub over the current Russian default)
- Fix: iterate the entries array in reverse so the last-inserted (most recent) entry wins

## Test plan
- [ ] Download an episode with `subEn`, then download a later episode with `subRu`. Trigger the auto-downloader — it should now queue the next episode with `subRu`.
- [ ] Verify the auto-downloader still respects the global `translationType` setting when no prior downloads exist for a show.

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)