### PR TITLE
refactor: Phase 5 slice 5d.2.c — useSkipMarkers composable (#118)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -521,6 +521,25 @@ Global app glue that doesn't belong on a Pinia store goes into
   `player:remux-mkv` IPC + `clear()` for resets between sessions. Only
   used when MSE rejects the codecs and `prepareMkvForPlayback` falls back
   to a one-shot ffmpeg stream-copy to MP4. (Phase 5 slice 5d.2.b)
+- `useSkipMarkers({ getAnimeId, getCurrentEpisodeInt, getCurrentTime, isStreaming, activeStreamUrl, onSeek })`
+  — OP/ED skip-marker detection + skip button visibility for PlayerView.
+  Owns the dual-mode detection (local playback reads stored per-episode
+  boundaries via `skipDetectorGetDetections`; streamed playback runs
+  `skipDetectorDetectStream` to fingerprint the live stream and match it
+  against the locally-derived show signatures), the skip-button grace
+  timer (debounces flicker when scrubbing through a band), the
+  per-session "already-skipped" guard (so rewinding doesn't re-show the
+  button), the request-id race guard on stream detection, the streaming
+  reactivity watch (5-source: `isStreaming` / `activeStreamUrl` /
+  episode-int / signature analyzedAt / source), and the
+  `skip-detector:signature-updated` IPC subscription. `onMounted` +
+  `onBeforeUnmount` are registered inside the composable (handles signature
+  sub + cancel-in-flight on teardown). Exposes `loadSkipDetections`,
+  `refreshStreamSkipDetection`, `cancelStreamDetection`, `onSkipClick`,
+  `resetSkipUiState`. The consumer (PlayerView) only wires the
+  episode-change reset because that path also touches prefetch state.
+  Constants: `SKIP_GRACE_MS = 250`, `SKIP_LEAD_IN_SEC = 0.25`. (Phase 5
+  slice 5d.2.c)
 
 Composables that own broadcast subscriptions or DOM listeners (like
 `useKeyboardShortcuts`) bind those inside themselves; pure-logic composables

--- a/src/renderer/src/components/PlayerView.vue
+++ b/src/renderer/src/components/PlayerView.vue
@@ -6,6 +6,7 @@ import { useAnime4K } from '../composables/use-anime4k';
 import { usePlayerKeyboard, type PlayerAction } from '../composables/use-player-keyboard';
 import { useSubtitles } from '../composables/use-subtitles';
 import { useRemux } from '../composables/use-remux';
+import { useSkipMarkers } from '../composables/use-skip-markers';
 
 const props = defineProps<{
   filePath: string;
@@ -163,143 +164,34 @@ const currentEpisodeInt = computed(
   () => props.allEpisodes[activeEpisodeIndex.value]?.episodeInt || ''
 );
 
-// Skip Detection: local playback uses stored per-episode boundaries from
-// `skipDetectorGetDetections(animeId)`. Streamed playback asks main to fingerprint
-// the current stream and only surfaces ranges when it confidently matches the
-// locally-derived show signatures.
-const showSkipDetections = ref<ShowSkipDetections | null>(null);
-const streamSkipDetection = ref<EpisodeSkipDetection | null>(null);
-const streamSkipDetecting = ref(false);
-const skippedRanges = ref<Set<string>>(new Set());
-const skipButtonVisible = ref(false);
-let skipButtonGraceTimer: ReturnType<typeof setTimeout> | null = null;
-const SKIP_GRACE_MS = 250;
-const SKIP_LEAD_IN_SEC = 0.25;
-let streamSkipRequestId = 0;
-
-const currentEpisodeSkip = computed<EpisodeSkipDetection | null>(() => {
-  if (isStreaming.value) {
-    return streamSkipDetection.value;
-  }
-  const det = showSkipDetections.value;
-  const epInt = currentEpisodeInt.value;
-  if (!det || !epInt) return null;
-  return det.perEpisode[epInt] ?? null;
+// Skip Detection — useSkipMarkers owns the dual-mode detection (local
+// playback uses stored per-episode boundaries; streamed playback asks
+// main to fingerprint + match the live stream), the skip-button grace
+// timer, the per-session "already-skipped" guard, and the
+// `skip-detector:signature-updated` IPC subscription.
+const skipMarkers = useSkipMarkers({
+  getAnimeId: () => props.animeId,
+  getCurrentEpisodeInt: () => currentEpisodeInt.value,
+  getCurrentTime: () => currentTime.value,
+  isStreaming,
+  activeStreamUrl,
+  onSeek: (t) => seek(t)
 });
-
-// Returns 'op' | 'ed' | null based on current playback time. The lead-in
-// tolerance handles the case where the seek bar lands a few hundred ms before
-// the band edge.
-const activeSkipRange = computed<'op' | 'ed' | null>(() => {
-  const ep = currentEpisodeSkip.value;
-  if (!ep) return null;
-  const t = currentTime.value;
-  if (ep.op && t >= ep.op.startSec - SKIP_LEAD_IN_SEC && t < ep.op.endSec) return 'op';
-  if (ep.ed && t >= ep.ed.startSec - SKIP_LEAD_IN_SEC && t < ep.ed.endSec) return 'ed';
-  return null;
-});
-
-function skipRangeKey(kind: 'op' | 'ed'): string {
-  return `${props.animeId}:${currentEpisodeInt.value}:${kind}`;
-}
-
-function activeSkipBounds(): { startSec: number; endSec: number; kind: 'op' | 'ed' } | null {
-  const kind = activeSkipRange.value;
-  const ep = currentEpisodeSkip.value;
-  if (!ep || !kind) return null;
-  const range = kind === 'op' ? ep.op : ep.ed;
-  if (!range) return null;
-  return { startSec: range.startSec, endSec: range.endSec, kind };
-}
-
-function onSkipClick(): void {
-  const bounds = activeSkipBounds();
-  if (!bounds) return;
-  skippedRanges.value.add(skipRangeKey(bounds.kind));
-  skipButtonVisible.value = false;
-  if (skipButtonGraceTimer) {
-    clearTimeout(skipButtonGraceTimer);
-    skipButtonGraceTimer = null;
-  }
-  seek(bounds.endSec);
-}
-
-watch(activeSkipRange, (kind) => {
-  if (skipButtonGraceTimer) {
-    clearTimeout(skipButtonGraceTimer);
-    skipButtonGraceTimer = null;
-  }
-  if (!kind) {
-    skipButtonVisible.value = false;
-    return;
-  }
-  if (skippedRanges.value.has(skipRangeKey(kind))) {
-    // User already skipped this range this session; don't re-show on rewind.
-    skipButtonVisible.value = false;
-    return;
-  }
-  // Brief grace timer prevents flicker when scrubbing through the range.
-  skipButtonGraceTimer = setTimeout(() => {
-    skipButtonVisible.value = true;
-    skipButtonGraceTimer = null;
-  }, SKIP_GRACE_MS);
-});
-
-async function loadSkipDetections(): Promise<void> {
-  if (!props.animeId) {
-    showSkipDetections.value = null;
-    return;
-  }
-  try {
-    showSkipDetections.value = await window.api.skipDetectorGetDetections(props.animeId);
-  } catch (err) {
-    console.error('Failed to load skip detections:', err);
-    showSkipDetections.value = null;
-  }
-}
-
-function resetSkipUiState(): void {
-  skippedRanges.value = new Set();
-  if (skipButtonGraceTimer) {
-    clearTimeout(skipButtonGraceTimer);
-    skipButtonGraceTimer = null;
-  }
-  skipButtonVisible.value = false;
-}
-
-async function refreshStreamSkipDetection(): Promise<void> {
-  const requestId = ++streamSkipRequestId;
-  streamSkipDetection.value = null;
-  streamSkipDetecting.value = false;
-  if (!isStreaming.value || !props.animeId || !currentEpisodeInt.value || !activeStreamUrl.value)
-    return;
-  if (!showSkipDetections.value) return;
-  const source = showSkipDetections.value.algorithm?.source ?? 'local';
-  if (source !== 'local') return;
-  try {
-    await window.api.skipDetectorCancelStreamDetect();
-  } catch {
-    // ignore best-effort cancel races before starting a fresh request
-  }
-  streamSkipDetecting.value = true;
-  try {
-    const result = await window.api.skipDetectorDetectStream(
-      props.animeId,
-      currentEpisodeInt.value,
-      activeStreamUrl.value
-    );
-    if (requestId !== streamSkipRequestId) return;
-    streamSkipDetection.value = result;
-  } catch (err) {
-    if (requestId !== streamSkipRequestId) return;
-    console.error('Failed to detect streamed skip ranges:', err);
-    streamSkipDetection.value = null;
-  } finally {
-    if (requestId === streamSkipRequestId) {
-      streamSkipDetecting.value = false;
-    }
-  }
-}
+const {
+  showSkipDetections,
+  streamSkipDetection,
+  streamSkipDetecting,
+  skipButtonVisible,
+  currentEpisodeSkip,
+  activeSkipRange,
+  loadSkipDetections,
+  onSkipClick,
+  resetSkipUiState
+} = skipMarkers;
+// Suppress "value referenced but never read" warning for unused destructured
+// fields (kept for template/use-site consumers).
+void showSkipDetections;
+void streamSkipDetection;
 
 // Reset the per-range "already skipped" guard when the episode changes so the
 // button appears for the new episode's OP/ED. Detections themselves come from
@@ -311,31 +203,6 @@ watch(currentEpisodeInt, (epInt) => {
     stopPrefetchPolling();
   }
 });
-
-const streamSkipSignatureVersion = computed(() => {
-  if (!isStreaming.value) return 0;
-  return showSkipDetections.value?.analyzedAt ?? 0;
-});
-
-const streamSkipSource = computed(() => {
-  if (!isStreaming.value) return '';
-  return showSkipDetections.value?.algorithm?.source ?? '';
-});
-
-watch(
-  [isStreaming, activeStreamUrl, currentEpisodeInt, streamSkipSignatureVersion, streamSkipSource],
-  () => {
-    if (!isStreaming.value) {
-      streamSkipRequestId++;
-      streamSkipDetection.value = null;
-      streamSkipDetecting.value = false;
-      void window.api.skipDetectorCancelStreamDetect();
-      return;
-    }
-    resetSkipUiState();
-    void refreshStreamSkipDetection();
-  }
-);
 let cumulativePlayTime = 0;
 let lastTimeUpdateAt = 0;
 let lastSaveAt = 0;
@@ -431,7 +298,6 @@ const syncplayPausedBy = ref<string | null>(null);
 // dedicated listener and returns an Unsubscribe that removes only that one,
 // so independent subscribers on the same channel (e.g. SettingsView's
 // "Test connection") don't clobber each other.
-let unsubSkipDetectorSignatureUpdated: Unsubscribe | null = null;
 let unsubPlayerStreamSubtitles: Unsubscribe | null = null;
 let unsubPlayerStream: Unsubscribe | null = null;
 let unsubSyncplayConnectionStatus: Unsubscribe | null = null;
@@ -1884,11 +1750,9 @@ onMounted(async () => {
     prefetchSetting.value = savedPrefetch;
   }
 
+  // useSkipMarkers already wires the signature-updated subscription via its
+  // own onMounted hook — we just need to kick off the initial load.
   loadSkipDetections();
-  unsubSkipDetectorSignatureUpdated = window.api.onSkipDetectorSignatureUpdated((data) => {
-    if (data.animeId !== props.animeId) return;
-    loadSkipDetections();
-  });
 
   // Subtitles extracted from MKV streams arrive asynchronously via IPC —
   // useSubtitles owns the filter + apply logic.
@@ -2099,9 +1963,8 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  streamSkipRequestId++;
-  streamSkipDetecting.value = false;
-  void window.api.skipDetectorCancelStreamDetect();
+  // Stream-skip detection cancel + signature-updated unsub + grace timer
+  // cleanup all live inside useSkipMarkers' onBeforeUnmount.
   saveProgress(true);
   stopPrefetchPolling();
   if (prefetchSeekResumeTimer) clearTimeout(prefetchSeekResumeTimer);
@@ -2130,12 +1993,6 @@ onBeforeUnmount(() => {
     clearTimeout(persistVolumeTimer);
     persistVolumeTimer = null;
   }
-  if (skipButtonGraceTimer) {
-    clearTimeout(skipButtonGraceTimer);
-    skipButtonGraceTimer = null;
-  }
-  unsubSkipDetectorSignatureUpdated?.();
-  unsubSkipDetectorSignatureUpdated = null;
   // Unblock any awaiter of askHevcChoice() so prepareMkvForPlayback unwinds.
   if (hevcPromptResolver) {
     const fn = hevcPromptResolver;

--- a/src/renderer/src/composables/use-skip-markers.ts
+++ b/src/renderer/src/composables/use-skip-markers.ts
@@ -1,0 +1,254 @@
+// OP/ED skip-marker detection + skip button state for PlayerView (Phase 5
+// slice 5d.2.c, #118).
+//
+// Owns the dual-mode skip detection:
+//   - Local playback uses stored per-episode boundaries from
+//     `skipDetectorGetDetections(animeId)`.
+//   - Streamed playback asks main to fingerprint the current stream and
+//     only surfaces ranges that match the locally-derived show signatures.
+//
+// Also owns the skip button visibility state (with a small grace timer so
+// scrubbing through a band doesn't flicker the button) and the
+// per-session "already skipped" set so rewinding past a band doesn't
+// re-show the button.
+//
+// Does NOT own: the seek action (caller supplies `onSeek` so the button
+// click can drive the same seek path the rest of PlayerView uses), the
+// episode change reset trigger (caller wires that because it also touches
+// prefetch state).
+
+import { computed, ref, watch, onMounted, onBeforeUnmount, type ComputedRef, type Ref } from 'vue'
+
+const SKIP_GRACE_MS = 250
+const SKIP_LEAD_IN_SEC = 0.25
+
+export function useSkipMarkers(deps: {
+  /** Live anime id getter (props pass-through). */
+  getAnimeId: () => number
+  /** Live episode int getter (computed from active episode index). */
+  getCurrentEpisodeInt: () => string
+  /** Live currentTime getter (the player progress ref). */
+  getCurrentTime: () => number
+  /** Reactive: are we playing a stream URL (vs a local file)? */
+  isStreaming: Ref<boolean>
+  /** Reactive: the active stream URL (when streaming). */
+  activeStreamUrl: Ref<string>
+  /** Caller-supplied seek action; called with the OP/ED end time on click. */
+  onSeek: (timeSec: number) => void
+}): {
+  showSkipDetections: Ref<ShowSkipDetections | null>
+  streamSkipDetection: Ref<EpisodeSkipDetection | null>
+  streamSkipDetecting: Ref<boolean>
+  skipButtonVisible: Ref<boolean>
+  currentEpisodeSkip: ComputedRef<EpisodeSkipDetection | null>
+  activeSkipRange: ComputedRef<'op' | 'ed' | null>
+  loadSkipDetections: () => Promise<void>
+  refreshStreamSkipDetection: () => Promise<void>
+  cancelStreamDetection: () => void
+  onSkipClick: () => void
+  resetSkipUiState: () => void
+} {
+  const showSkipDetections = ref<ShowSkipDetections | null>(null)
+  const streamSkipDetection = ref<EpisodeSkipDetection | null>(null)
+  const streamSkipDetecting = ref(false)
+  const skippedRanges = ref<Set<string>>(new Set())
+  const skipButtonVisible = ref(false)
+
+  let skipButtonGraceTimer: ReturnType<typeof setTimeout> | null = null
+  let streamSkipRequestId = 0
+  let unsubSignatureUpdated: Unsubscribe | null = null
+
+  const currentEpisodeSkip = computed<EpisodeSkipDetection | null>(() => {
+    if (deps.isStreaming.value) {
+      return streamSkipDetection.value
+    }
+    const det = showSkipDetections.value
+    const epInt = deps.getCurrentEpisodeInt()
+    if (!det || !epInt) return null
+    return det.perEpisode[epInt] ?? null
+  })
+
+  // Lead-in tolerance handles the case where the seek bar lands a few
+  // hundred ms before the band edge.
+  const activeSkipRange = computed<'op' | 'ed' | null>(() => {
+    const ep = currentEpisodeSkip.value
+    if (!ep) return null
+    const t = deps.getCurrentTime()
+    if (ep.op && t >= ep.op.startSec - SKIP_LEAD_IN_SEC && t < ep.op.endSec) return 'op'
+    if (ep.ed && t >= ep.ed.startSec - SKIP_LEAD_IN_SEC && t < ep.ed.endSec) return 'ed'
+    return null
+  })
+
+  function skipRangeKey(kind: 'op' | 'ed'): string {
+    return `${deps.getAnimeId()}:${deps.getCurrentEpisodeInt()}:${kind}`
+  }
+
+  function activeSkipBounds(): { startSec: number; endSec: number; kind: 'op' | 'ed' } | null {
+    const kind = activeSkipRange.value
+    const ep = currentEpisodeSkip.value
+    if (!ep || !kind) return null
+    const range = kind === 'op' ? ep.op : ep.ed
+    if (!range) return null
+    return { startSec: range.startSec, endSec: range.endSec, kind }
+  }
+
+  function onSkipClick(): void {
+    const bounds = activeSkipBounds()
+    if (!bounds) return
+    skippedRanges.value.add(skipRangeKey(bounds.kind))
+    skipButtonVisible.value = false
+    if (skipButtonGraceTimer) {
+      clearTimeout(skipButtonGraceTimer)
+      skipButtonGraceTimer = null
+    }
+    deps.onSeek(bounds.endSec)
+  }
+
+  // Grace-timer-gated button visibility — debounces flicker when scrubbing
+  // through a band.
+  watch(activeSkipRange, (kind) => {
+    if (skipButtonGraceTimer) {
+      clearTimeout(skipButtonGraceTimer)
+      skipButtonGraceTimer = null
+    }
+    if (!kind) {
+      skipButtonVisible.value = false
+      return
+    }
+    if (skippedRanges.value.has(skipRangeKey(kind))) {
+      // User already skipped this range this session; don't re-show on rewind.
+      skipButtonVisible.value = false
+      return
+    }
+    skipButtonGraceTimer = setTimeout(() => {
+      skipButtonVisible.value = true
+      skipButtonGraceTimer = null
+    }, SKIP_GRACE_MS)
+  })
+
+  async function loadSkipDetections(): Promise<void> {
+    if (!deps.getAnimeId()) {
+      showSkipDetections.value = null
+      return
+    }
+    try {
+      showSkipDetections.value = await window.api.skipDetectorGetDetections(deps.getAnimeId())
+    } catch (err) {
+      console.error('Failed to load skip detections:', err)
+      showSkipDetections.value = null
+    }
+  }
+
+  function resetSkipUiState(): void {
+    skippedRanges.value = new Set()
+    if (skipButtonGraceTimer) {
+      clearTimeout(skipButtonGraceTimer)
+      skipButtonGraceTimer = null
+    }
+    skipButtonVisible.value = false
+  }
+
+  async function refreshStreamSkipDetection(): Promise<void> {
+    const requestId = ++streamSkipRequestId
+    streamSkipDetection.value = null
+    streamSkipDetecting.value = false
+    const animeId = deps.getAnimeId()
+    const epInt = deps.getCurrentEpisodeInt()
+    if (!deps.isStreaming.value || !animeId || !epInt || !deps.activeStreamUrl.value) return
+    if (!showSkipDetections.value) return
+    const source = showSkipDetections.value.algorithm?.source ?? 'local'
+    if (source !== 'local') return
+    try {
+      await window.api.skipDetectorCancelStreamDetect()
+    } catch {
+      // ignore best-effort cancel races before starting a fresh request
+    }
+    streamSkipDetecting.value = true
+    try {
+      const result = await window.api.skipDetectorDetectStream(
+        animeId,
+        epInt,
+        deps.activeStreamUrl.value
+      )
+      if (requestId !== streamSkipRequestId) return
+      streamSkipDetection.value = result
+    } catch (err) {
+      if (requestId !== streamSkipRequestId) return
+      console.error('Failed to detect streamed skip ranges:', err)
+      streamSkipDetection.value = null
+    } finally {
+      if (requestId === streamSkipRequestId) {
+        streamSkipDetecting.value = false
+      }
+    }
+  }
+
+  function cancelStreamDetection(): void {
+    streamSkipRequestId++
+    streamSkipDetecting.value = false
+    void window.api.skipDetectorCancelStreamDetect()
+  }
+
+  // Stream-mode reactivity: when the streaming inputs or the show signature
+  // change, reset UI + retry detection. On the way out (no longer streaming),
+  // tear down the in-flight request.
+  const streamSkipSignatureVersion = computed(() => {
+    if (!deps.isStreaming.value) return 0
+    return showSkipDetections.value?.analyzedAt ?? 0
+  })
+  const streamSkipSource = computed(() => {
+    if (!deps.isStreaming.value) return ''
+    return showSkipDetections.value?.algorithm?.source ?? ''
+  })
+  watch(
+    [
+      deps.isStreaming,
+      deps.activeStreamUrl,
+      () => deps.getCurrentEpisodeInt(),
+      streamSkipSignatureVersion,
+      streamSkipSource
+    ],
+    () => {
+      if (!deps.isStreaming.value) {
+        cancelStreamDetection()
+        streamSkipDetection.value = null
+        return
+      }
+      resetSkipUiState()
+      void refreshStreamSkipDetection()
+    }
+  )
+
+  onMounted(() => {
+    // Re-load detections whenever main broadcasts that the show's signatures
+    // changed (e.g. after a backfill or chapter inject).
+    unsubSignatureUpdated = window.api.onSkipDetectorSignatureUpdated((data) => {
+      if (data.animeId !== deps.getAnimeId()) return
+      void loadSkipDetections()
+    })
+  })
+
+  onBeforeUnmount(() => {
+    cancelStreamDetection()
+    if (skipButtonGraceTimer) {
+      clearTimeout(skipButtonGraceTimer)
+      skipButtonGraceTimer = null
+    }
+    unsubSignatureUpdated?.()
+    unsubSignatureUpdated = null
+  })
+
+  return {
+    showSkipDetections,
+    streamSkipDetection,
+    streamSkipDetecting,
+    skipButtonVisible,
+    currentEpisodeSkip,
+    activeSkipRange,
+    loadSkipDetections,
+    refreshStreamSkipDetection,
+    cancelStreamDetection,
+    onSkipClick,
+    resetSkipUiState
+  }
+}

--- a/test/renderer/composables/use-skip-markers.test.ts
+++ b/test/renderer/composables/use-skip-markers.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { ref } from 'vue'
+import { useSkipMarkers } from '../../../src/renderer/src/composables/use-skip-markers'
+
+type Api = {
+  skipDetectorGetDetections: (animeId: number) => Promise<ShowSkipDetections | null>
+  skipDetectorDetectStream: (
+    animeId: number,
+    episodeInt: string,
+    streamUrl: string
+  ) => Promise<EpisodeSkipDetection | null>
+  skipDetectorCancelStreamDetect: () => Promise<void>
+  onSkipDetectorSignatureUpdated: (
+    cb: (data: { animeId: number; perEpisode: Record<string, EpisodeSkipDetection> }) => void
+  ) => Unsubscribe
+}
+
+function noopSub(): Unsubscribe {
+  return () => {}
+}
+
+function setApi(api: Partial<Api>): void {
+  const w = (globalThis as { window?: { api?: Partial<Api> } }).window
+  const prev = w?.api ?? {}
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = { api: { ...prev, ...api } }
+}
+
+beforeEach(() => {
+  ;(globalThis as { window?: { api: Partial<Api> } }).window = {
+    api: {
+      onSkipDetectorSignatureUpdated: noopSub,
+      skipDetectorCancelStreamDetect: vi.fn().mockResolvedValue(undefined),
+      skipDetectorGetDetections: vi.fn().mockResolvedValue(null),
+      skipDetectorDetectStream: vi.fn().mockResolvedValue(null)
+    }
+  }
+})
+
+function fakeShow(perEpisode: Record<string, EpisodeSkipDetection>): ShowSkipDetections {
+  return {
+    animeId: 42,
+    perEpisode,
+    analyzedAt: 1234567890,
+    episodeCount: Object.keys(perEpisode).length,
+    algorithm: {
+      source: 'local',
+      sampleRate: 1,
+      matchBitThreshold: 1,
+      minRunSec: 1,
+      windowSec: 1,
+      refineBitThreshold: 1,
+      refineSustainHashes: 1
+    }
+  }
+}
+
+function fakeEp(
+  episodeInt: string,
+  op: { startSec: number; endSec: number } | null,
+  ed: { startSec: number; endSec: number } | null = null
+): EpisodeSkipDetection {
+  return {
+    episodeInt,
+    episodeLabel: `Ep ${episodeInt}`,
+    filePath: `/fake/${episodeInt}.mkv`,
+    durationSec: 1440,
+    hashesPerSec: 1,
+    op: op ? { ...op, pairCount: 3 } : null,
+    ed: ed ? { ...ed, pairCount: 3 } : null
+  }
+}
+
+type Deps = Parameters<typeof useSkipMarkers>[0]
+
+function makeDeps(overrides: {
+  animeId?: number
+  epInt?: string
+  time?: number
+  isStreaming?: boolean
+  streamUrl?: string
+  onSeek?: (t: number) => void
+}): Deps {
+  const isStreaming = ref(overrides.isStreaming ?? false)
+  const activeStreamUrl = ref(overrides.streamUrl ?? '')
+  return {
+    getAnimeId: () => overrides.animeId ?? 42,
+    getCurrentEpisodeInt: () => overrides.epInt ?? '1',
+    getCurrentTime: () => overrides.time ?? 0,
+    isStreaming,
+    activeStreamUrl,
+    onSeek: overrides.onSeek ?? (() => {})
+  }
+}
+
+describe('useSkipMarkers — initial state', () => {
+  it('starts empty', () => {
+    const s = useSkipMarkers(makeDeps({}))
+    expect(s.showSkipDetections.value).toBeNull()
+    expect(s.streamSkipDetection.value).toBeNull()
+    expect(s.streamSkipDetecting.value).toBe(false)
+    expect(s.skipButtonVisible.value).toBe(false)
+    expect(s.currentEpisodeSkip.value).toBeNull()
+    expect(s.activeSkipRange.value).toBeNull()
+  })
+})
+
+describe('useSkipMarkers — currentEpisodeSkip switching', () => {
+  it('returns local per-episode payload when not streaming', () => {
+    const s = useSkipMarkers(makeDeps({ epInt: '2' }))
+    s.showSkipDetections.value = fakeShow({
+      '2': fakeEp('2', { startSec: 60, endSec: 150 })
+    })
+    expect(s.currentEpisodeSkip.value?.episodeInt).toBe('2')
+  })
+
+  it('returns stream detection ref when streaming, even if local exists', () => {
+    const deps = makeDeps({ isStreaming: true, epInt: '2' })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '2': fakeEp('2', { startSec: 60, endSec: 150 })
+    })
+    s.streamSkipDetection.value = fakeEp('2', { startSec: 30, endSec: 90 })
+    expect(s.currentEpisodeSkip.value?.op?.startSec).toBe(30)
+  })
+})
+
+describe('useSkipMarkers — activeSkipRange', () => {
+  it('reports op when time is inside op band (with lead-in)', () => {
+    const deps = makeDeps({ epInt: '1', time: 60 })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60.1, endSec: 150 })
+    })
+    // 60 is within SKIP_LEAD_IN_SEC = 0.25 of 60.1
+    expect(s.activeSkipRange.value).toBe('op')
+  })
+
+  it('reports ed when time is inside ed band', () => {
+    const deps = makeDeps({ epInt: '1', time: 1300 })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', null, { startSec: 1290, endSec: 1380 })
+    })
+    expect(s.activeSkipRange.value).toBe('ed')
+  })
+
+  it('returns null when time is outside both bands', () => {
+    const deps = makeDeps({ epInt: '1', time: 500 })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60, endSec: 150 }, { startSec: 1290, endSec: 1380 })
+    })
+    expect(s.activeSkipRange.value).toBeNull()
+  })
+})
+
+describe('useSkipMarkers — loadSkipDetections', () => {
+  it('clears showSkipDetections when animeId is 0', async () => {
+    const s = useSkipMarkers(makeDeps({ animeId: 0 }))
+    s.showSkipDetections.value = fakeShow({ '1': fakeEp('1', null) })
+    await s.loadSkipDetections()
+    expect(s.showSkipDetections.value).toBeNull()
+  })
+
+  it('populates showSkipDetections from IPC', async () => {
+    const payload = fakeShow({ '1': fakeEp('1', { startSec: 60, endSec: 150 }) })
+    setApi({ skipDetectorGetDetections: vi.fn().mockResolvedValue(payload) })
+    const s = useSkipMarkers(makeDeps({}))
+    await s.loadSkipDetections()
+    expect(s.showSkipDetections.value).toEqual(payload)
+  })
+
+  it('logs + sets null on IPC error', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setApi({ skipDetectorGetDetections: vi.fn().mockRejectedValue(new Error('boom')) })
+    const s = useSkipMarkers(makeDeps({}))
+    await s.loadSkipDetections()
+    expect(s.showSkipDetections.value).toBeNull()
+    err.mockRestore()
+  })
+})
+
+describe('useSkipMarkers — onSkipClick', () => {
+  it('seeks to the end of the active band and hides the button', async () => {
+    vi.useFakeTimers()
+    const seek = vi.fn()
+    const deps = makeDeps({ epInt: '1', time: 60, onSeek: seek })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60, endSec: 150 })
+    })
+    // Activate the band first: time is 60, in op band → grace timer fires
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    s.onSkipClick()
+    expect(seek).toHaveBeenCalledWith(150)
+    expect(s.skipButtonVisible.value).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('is a no-op when no active band', () => {
+    const seek = vi.fn()
+    const deps = makeDeps({ epInt: '1', time: 500, onSeek: seek })
+    const s = useSkipMarkers(deps)
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60, endSec: 150 })
+    })
+    s.onSkipClick()
+    expect(seek).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSkipMarkers — already-skipped dedup', () => {
+  it('does not re-show the button after a skip click on the same range', async () => {
+    vi.useFakeTimers()
+    // Use a reactive time ref so changing it triggers the activeSkipRange
+    // computed + the grace-timer watcher.
+    const time = ref(0)
+    const isStreaming = ref(false)
+    const activeStreamUrl = ref('')
+    const seek = vi.fn()
+    const s = useSkipMarkers({
+      getAnimeId: () => 42,
+      getCurrentEpisodeInt: () => '1',
+      getCurrentTime: () => time.value,
+      isStreaming,
+      activeStreamUrl,
+      onSeek: seek
+    })
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60, endSec: 150 })
+    })
+    // Cross into the op band.
+    time.value = 60
+    await Promise.resolve() // flush computed/watch
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    expect(s.skipButtonVisible.value).toBe(true)
+    s.onSkipClick()
+    expect(s.skipButtonVisible.value).toBe(false)
+    expect(seek).toHaveBeenCalledWith(150)
+
+    // Step outside the band and back in — button stays hidden because the
+    // range was already skipped this session.
+    time.value = 500
+    await Promise.resolve()
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    expect(s.skipButtonVisible.value).toBe(false)
+    time.value = 60
+    await Promise.resolve()
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    expect(s.skipButtonVisible.value).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('shows the button again after resetSkipUiState (episode change)', async () => {
+    vi.useFakeTimers()
+    const time = ref(0)
+    const isStreaming = ref(false)
+    const activeStreamUrl = ref('')
+    const s = useSkipMarkers({
+      getAnimeId: () => 42,
+      getCurrentEpisodeInt: () => '1',
+      getCurrentTime: () => time.value,
+      isStreaming,
+      activeStreamUrl,
+      onSeek: () => {}
+    })
+    s.showSkipDetections.value = fakeShow({
+      '1': fakeEp('1', { startSec: 60, endSec: 150 })
+    })
+    time.value = 60
+    await Promise.resolve()
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    s.onSkipClick()
+    // Now reset (simulating an episode change) and re-enter the band.
+    s.resetSkipUiState()
+    time.value = 500
+    await Promise.resolve()
+    time.value = 60
+    await Promise.resolve()
+    vi.advanceTimersByTime(SKIP_GRACE_MS_TEST)
+    expect(s.skipButtonVisible.value).toBe(true)
+    vi.useRealTimers()
+  })
+})
+
+describe('useSkipMarkers — resetSkipUiState', () => {
+  it('clears skippedRanges + cancels grace timer + hides button', () => {
+    const s = useSkipMarkers(makeDeps({}))
+    s.skipButtonVisible.value = true
+    s.resetSkipUiState()
+    expect(s.skipButtonVisible.value).toBe(false)
+  })
+
+  it('is idempotent', () => {
+    const s = useSkipMarkers(makeDeps({}))
+    s.resetSkipUiState()
+    s.resetSkipUiState()
+    expect(s.skipButtonVisible.value).toBe(false)
+  })
+})
+
+describe('useSkipMarkers — refreshStreamSkipDetection', () => {
+  it('is a no-op when not streaming', async () => {
+    const detectSpy = vi.fn().mockResolvedValue(null)
+    setApi({ skipDetectorDetectStream: detectSpy })
+    const s = useSkipMarkers(makeDeps({ isStreaming: false }))
+    await s.refreshStreamSkipDetection()
+    expect(detectSpy).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op without showSkipDetections (no local payload to gate on)', async () => {
+    const detectSpy = vi.fn().mockResolvedValue(null)
+    setApi({ skipDetectorDetectStream: detectSpy })
+    const s = useSkipMarkers(makeDeps({ isStreaming: true, streamUrl: 'https://x/y.m3u8' }))
+    await s.refreshStreamSkipDetection()
+    expect(detectSpy).not.toHaveBeenCalled()
+  })
+
+  it('runs detection when streaming + local payload present', async () => {
+    const result = fakeEp('1', { startSec: 40, endSec: 110 })
+    const detectSpy = vi.fn().mockResolvedValue(result)
+    setApi({ skipDetectorDetectStream: detectSpy })
+    const s = useSkipMarkers(
+      makeDeps({ isStreaming: true, streamUrl: 'https://x/y.m3u8', epInt: '1' })
+    )
+    s.showSkipDetections.value = fakeShow({ '1': fakeEp('1', null) })
+    await s.refreshStreamSkipDetection()
+    expect(detectSpy).toHaveBeenCalledWith(42, '1', 'https://x/y.m3u8')
+    expect(s.streamSkipDetection.value).toEqual(result)
+    expect(s.streamSkipDetecting.value).toBe(false)
+  })
+
+  it('drops late results from a superseded request', async () => {
+    let resolveFirst!: (v: EpisodeSkipDetection | null) => void
+    const firstP = new Promise<EpisodeSkipDetection | null>((res) => {
+      resolveFirst = res
+    })
+    let call = 0
+    setApi({
+      skipDetectorDetectStream: vi.fn().mockImplementation(() => {
+        call++
+        return call === 1 ? firstP : Promise.resolve(fakeEp('1', { startSec: 999, endSec: 1000 }))
+      })
+    })
+    const s = useSkipMarkers(
+      makeDeps({ isStreaming: true, streamUrl: 'https://x/y.m3u8', epInt: '1' })
+    )
+    s.showSkipDetections.value = fakeShow({ '1': fakeEp('1', null) })
+    const firstPromise = s.refreshStreamSkipDetection()
+    const secondPromise = s.refreshStreamSkipDetection()
+    resolveFirst(fakeEp('1', { startSec: 1, endSec: 2 }))
+    await Promise.all([firstPromise, secondPromise])
+    // The second result (startSec: 999) wins; the first is dropped.
+    expect(s.streamSkipDetection.value?.op?.startSec).toBe(999)
+  })
+
+  it('clears detection when IPC throws', async () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setApi({
+      skipDetectorDetectStream: vi.fn().mockRejectedValue(new Error('boom'))
+    })
+    const s = useSkipMarkers(
+      makeDeps({ isStreaming: true, streamUrl: 'https://x/y.m3u8', epInt: '1' })
+    )
+    s.showSkipDetections.value = fakeShow({ '1': fakeEp('1', null) })
+    await s.refreshStreamSkipDetection()
+    expect(s.streamSkipDetection.value).toBeNull()
+    expect(s.streamSkipDetecting.value).toBe(false)
+    err.mockRestore()
+  })
+})
+
+describe('useSkipMarkers — cancelStreamDetection', () => {
+  it('clears detecting flag + calls IPC cancel', () => {
+    const cancel = vi.fn().mockResolvedValue(undefined)
+    setApi({ skipDetectorCancelStreamDetect: cancel })
+    const s = useSkipMarkers(makeDeps({}))
+    s.streamSkipDetecting.value = true
+    s.cancelStreamDetection()
+    expect(s.streamSkipDetecting.value).toBe(false)
+    expect(cancel).toHaveBeenCalled()
+  })
+})
+
+// Constant mirror so the test reads naturally; the composable's internal
+// constant isn't exported.
+const SKIP_GRACE_MS_TEST = 251
+
+afterEach(() => {
+  vi.useRealTimers()
+})


### PR DESCRIPTION
## Summary

Phase 5 slice **5d.2.c** — third of four PlayerView decomposition sub-slices. Extracts the OP/ED skip-detection cluster (the biggest single subsystem in PlayerView after MSE) into a dedicated composable + unit tests.

- **`useSkipMarkers`** — dual-mode (local + streamed) OP/ED detection, skip-button visibility, grace timer, already-skipped guard, IPC subscription, request-race guard. (254 lines)

`PlayerView.vue` shrinks **3557 → 3414 (-143 lines)** and gains **+21 unit tests** (now 301 total, was 280).

## Behavior

No user-visible change. Skip button still appears with the same lead-in + grace-timer + dedup semantics; streamed skip detection still races the IPC + drops stale results; signature-update broadcasts still trigger a re-load.

## Changes

### New: `src/renderer/src/composables/use-skip-markers.ts`

- **Dual-mode detection**:
  - Local playback reads stored per-episode boundaries via `skipDetectorGetDetections(animeId)`.
  - Streamed playback runs `skipDetectorDetectStream` to fingerprint the live stream and only surfaces ranges that match the locally-derived show signatures (`source === 'local'`).
- **Reactive state**: `showSkipDetections`, `streamSkipDetection`, `streamSkipDetecting`, `skipButtonVisible`.
- **Computeds**: `currentEpisodeSkip` (switches by `isStreaming`), `activeSkipRange` (`'op' | 'ed' | null` with `SKIP_LEAD_IN_SEC = 0.25` tolerance).
- **Actions**: `loadSkipDetections`, `refreshStreamSkipDetection`, `cancelStreamDetection`, `onSkipClick` (drives caller-supplied `onSeek` to `bounds.endSec`), `resetSkipUiState`.
- **Internals**:
  - Skip-button grace timer (`SKIP_GRACE_MS = 250`) debounces flicker when scrubbing through a band.
  - Per-session `skippedRanges` set so rewinding past a band doesn't re-show the button.
  - Request-id race guard on stream detection (in-flight result is dropped if a newer request started).
  - Streaming reactivity watch (5-source: `isStreaming` / `activeStreamUrl` / episode-int / signature `analyzedAt` / source) — resets UI + retries detection on any change.
- **Lifecycle**: `onMounted` wires the `skip-detector:signature-updated` IPC subscription; `onBeforeUnmount` cancels in-flight stream detection + clears the grace timer + unsubs.

### New: `test/renderer/composables/use-skip-markers.test.ts`

21 cases covering:
- Initial state.
- `currentEpisodeSkip` switching by `isStreaming` (stream ref takes precedence over local).
- `activeSkipRange` band detection with lead-in tolerance + outside-band null.
- `loadSkipDetections` IPC paths (animeId=0, success, error).
- `onSkipClick` seek + UI hide + no-op outside band.
- Already-skipped dedup: button stays hidden after a click even on rewind (uses reactive time `ref` to trigger the activeSkipRange computed + grace-timer watcher).
- `resetSkipUiState` allows the button to re-show after an episode change.
- `refreshStreamSkipDetection` guards (not streaming / no local payload), happy path, race guard (late result from a superseded request is dropped), error path.
- `cancelStreamDetection` clears detecting flag + calls IPC.

### Modified: `src/renderer/src/components/PlayerView.vue`

- Replaces ~170 lines of inline skip state (refs, computeds, two watch handlers, four IPC-touching functions) with a `useSkipMarkers({...})` call + destructure.
- The remaining `episode-change` watch stays in PlayerView because it also touches prefetch state (`prefetchInFlight` + `stopPrefetchPolling`).
- `onMounted`: `loadSkipDetections()` now just kicks off the initial load — the signature-updated subscription is owned by the composable.
- `onBeforeUnmount`: drops the inline `streamSkipRequestId++` / cancel-stream block, the `skipButtonGraceTimer` clear block, and the `unsubSkipDetectorSignatureUpdated` cleanup — all of those live inside `useSkipMarkers`' own `onBeforeUnmount`.

### Modified: `DESIGN.md`

- Adds the composable to the renderer composables section.

### Unchanged

- `src/main/**`, `src/preload/**`, every Pinia store.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (6 pre-existing warnings in `src/main/index.ts`)
- [x] `npm run format:check` clean
- [x] `npm run test` — 301 tests pass (was 280, +21 new)
- [x] `npm run build` clean
- [x] `bash scripts/check-subscription-contract.sh` clean
- [ ] **Manual smoke (pending user retest on native Windows)**: play a local MKV with stored OP/ED detection (verify skip button appears at OP start, click to skip, verify it doesn't re-appear on rewind); play a streamed source with the show's signatures loaded (verify "Detecting OP/ED markers…" toast then skip button when a range matches); switch episodes mid-playback (verify per-episode dedup resets); switch from local to stream playback (verify the watcher swap).

Stacked on #131 (slice 5d.2.b). Retarget to `main` once parent merges per stacked-PR rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
