### PR TITLE
test(phase 7): test infra + IPC contract round-trip (#140)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anime-dl-app",
-  "version": "3.25.0",
+  "version": "3.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anime-dl-app",
-      "version": "3.25.0",
+      "version": "3.25.1",
       "license": "ISC",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -26,6 +26,7 @@
         "@playwright/test": "^1.59.1",
         "@types/fluent-ffmpeg": "^2.1.28",
         "@vitejs/plugin-vue": "^6.0.5",
+        "@vitest/coverage-v8": "^3.2.4",
         "electron": "^41.1.0",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
@@ -41,6 +42,20 @@
         "vitest": "^3.2.4",
         "vue-eslint-parser": "^9.4.3",
         "vue-tsc": "^3.2.6"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -303,6 +318,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1566,6 +1591,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2568,6 +2603,40 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -3257,6 +3326,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -6168,6 +6266,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -6464,6 +6569,60 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -6777,6 +6936,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8630,6 +8830,76 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/throughput": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "check:subscription-contract": "bash scripts/check-subscription-contract.sh",
     "screenshot": "node scripts/screenshot.js"
@@ -67,6 +68,7 @@
     "@playwright/test": "^1.59.1",
     "@types/fluent-ffmpeg": "^2.1.28",
     "@vitejs/plugin-vue": "^6.0.5",
+    "@vitest/coverage-v8": "^3.2.4",
     "electron": "^41.1.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",

--- a/src/main/auto-downloader.ts
+++ b/src/main/auto-downloader.ts
@@ -1,3 +1,4 @@
+import { EVENT_CHANNELS } from '@shared/ipc/channels'
 import type { StorageService } from './store/types'
 import type { SmotretApi, EpisodeDetail, Translation } from './smotret-api'
 import type { DownloadManager, DownloadRequest } from './download-manager'
@@ -261,7 +262,7 @@ export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlT
   try {
     if (!deps.store.get('autoDownloadEnabled')) {
       lastTickResult = result
-      deps.broadcast('auto-dl:tick-result', result)
+      deps.broadcast(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, result)
       return result
     }
 
@@ -271,13 +272,13 @@ export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlT
     const subscriptions = Object.values(map)
     if (subscriptions.length === 0) {
       lastTickResult = result
-      deps.broadcast('auto-dl:tick-result', result)
+      deps.broadcast(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, result)
       return result
     }
 
     if (!deps.isShikimoriLoggedIn()) {
       lastTickResult = result
-      deps.broadcast('auto-dl:tick-result', result)
+      deps.broadcast(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, result)
       return result
     }
 
@@ -408,7 +409,7 @@ export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlT
             episodeInt,
             outcome: 'enqueued'
           })
-          deps.broadcast('auto-dl:enqueued', {
+          deps.broadcast(EVENT_CHANNELS.AUTO_DL_ENQUEUED, {
             animeId: sub.animeId,
             episodeInt,
             animeName: sub.animeName
@@ -436,7 +437,7 @@ export async function runAutoDownloadTick(reason: AutoDlReason): Promise<AutoDlT
     }
 
     lastTickResult = result
-    deps.broadcast('auto-dl:tick-result', result)
+    deps.broadcast(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, result)
     return result
   } finally {
     tickRunning = false

--- a/src/main/download-manager.ts
+++ b/src/main/download-manager.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron'
+import { EVENT_CHANNELS } from '@shared/ipc/channels'
 import * as fs from 'fs'
 import * as path from 'path'
 import { Readable } from 'stream'
@@ -1082,7 +1083,7 @@ export class DownloadManager {
     if (windows.length === 0) return
     const data = this.getEpisodeGroups()
     for (const win of windows) {
-      win.webContents.send('download:progress', data)
+      win.webContents.send(EVENT_CHANNELS.DOWNLOAD_PROGRESS, data)
     }
     // Periodic persist every 10 ticks (5s) while downloads are active
     this.broadcastTick++

--- a/src/main/fpcalc-binaries.ts
+++ b/src/main/fpcalc-binaries.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow } from 'electron'
+import { EVENT_CHANNELS } from '@shared/ipc/channels'
 import * as fs from 'fs'
 import * as fsPromises from 'fs/promises'
 import * as path from 'path'
@@ -131,7 +132,7 @@ export async function ensureFpcalc(win?: BrowserWindow): Promise<string> {
 
   const sendProgress = (status: string, progress?: number): void => {
     if (win && !win.isDestroyed()) {
-      win.webContents.send('fpcalc:download-progress', { status, progress })
+      win.webContents.send(EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS, { status, progress })
     }
   }
 

--- a/test/ipc-channels.test.ts
+++ b/test/ipc-channels.test.ts
@@ -4,7 +4,6 @@ import { resolve } from 'path'
 import { CHANNELS, EVENT_CHANNELS } from '../src/shared/ipc/channels'
 
 const read = (p: string) => readFileSync(resolve(__dirname, '..', p), 'utf8')
-const MAIN = read('src/main/index.ts')
 const PRELOAD = read('src/preload/index.ts')
 // Phase 3 splits `registerIpcHandlers()` into per-domain `src/main/ipc/*.ipc.ts`
 // routers. Include every router so channels referenced from them count as
@@ -13,6 +12,15 @@ const IPC_DIR = resolve(__dirname, '..', 'src/main/ipc')
 const ROUTERS = readdirSync(IPC_DIR)
   .filter((f) => f.endsWith('.ts'))
   .map((f) => readFileSync(resolve(IPC_DIR, f), 'utf8'))
+  .join('\n')
+// Top-level `src/main/*.ts` files (download-manager, auto-downloader,
+// fpcalc-binaries, …) also emit events. Without scanning them, raw-string
+// emit sites bypass both the literal-leftover check and the new
+// emitter-presence check added for Phase 7.
+const MAIN_DIR = resolve(__dirname, '..', 'src/main')
+const MAIN = readdirSync(MAIN_DIR)
+  .filter((f) => f.endsWith('.ts'))
+  .map((f) => readFileSync(resolve(MAIN_DIR, f), 'utf8'))
   .join('\n')
 const SOURCES = MAIN + '\n' + PRELOAD + '\n' + ROUTERS
 
@@ -61,5 +69,47 @@ describe('IPC channel contract', () => {
       }
     )
     expect(unreferenced).toEqual([])
+  })
+
+  // Round-trip checks (Phase 7 PR 1, #140). The symbol-reference check above
+  // only proves the constant is *mentioned*; these prove it's actually wired
+  // on both ends of the IPC bridge.
+  it('every request CHANNEL has a registered ipcMain.handle in some router', () => {
+    const unhandled = Object.keys(CHANNELS).filter((key) => {
+      const sym = `CHANNELS.${key}`
+      const handlePattern = new RegExp(`ipcMain\\.(?:handle|on)\\(\\s*${sym}\\b`)
+      return !handlePattern.test(ROUTERS) && !handlePattern.test(MAIN)
+    })
+    expect(unhandled).toEqual([])
+  })
+
+  it('every request CHANNEL has a matching preload binding (ipcRenderer.invoke/send)', () => {
+    const unbound = Object.keys(CHANNELS).filter((key) => {
+      const sym = `CHANNELS.${key}`
+      const invokePattern = new RegExp(`ipcRenderer\\.(?:invoke|send)\\(\\s*${sym}\\b`)
+      return !invokePattern.test(PRELOAD)
+    })
+    expect(unbound).toEqual([])
+  })
+
+  it('every EVENT_CHANNEL is referenced in main (emitter or service config) and subscribed in preload', () => {
+    // Direct emission (webContents.send / broadcast / sender.send) is one way
+    // a channel reaches the renderer; the other is passing the symbol into a
+    // service constructor as a config field (e.g. `rateUpdatedChannel:
+    // EVENT_CHANNELS.X`) which then emits internally. Both forms count.
+    const unwired = Object.keys(EVENT_CHANNELS).filter((key) => {
+      const sym = `EVENT_CHANNELS.${key}`
+      // Subscriber forms in preload: `subscribe(EVENT_CHANNELS.X)` with optional
+      // (possibly nested) generic args, or a bespoke `ipcRenderer.on(EVENT_CHANNELS.X, …)`
+      // for multi-arg payloads. `[^(]*` skips over generic blocks since type
+      // params never contain `(` — robust to nesting like `Record<a, b>`.
+      const subscribePattern = new RegExp(
+        `(?:subscribe\\b[^(]*\\(|ipcRenderer\\.(?:on|once)\\()\\s*${sym}\\b`
+      )
+      const hasMainReference = MAIN.includes(sym) || ROUTERS.includes(sym)
+      const hasSubscriber = subscribePattern.test(PRELOAD)
+      return !hasMainReference || !hasSubscriber
+    })
+    expect(unwired).toEqual([])
   })
 })

--- a/test/preload/subscribe.test.ts
+++ b/test/preload/subscribe.test.ts
@@ -1,47 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-
-type Listener = (event: unknown, ...args: unknown[]) => void
-
-const listenersByChannel = new Map<string, Set<Listener>>()
-
-vi.mock('electron', () => ({
-  ipcRenderer: {
-    on(channel: string, listener: Listener): void {
-      let bucket = listenersByChannel.get(channel)
-      if (!bucket) {
-        bucket = new Set()
-        listenersByChannel.set(channel, bucket)
-      }
-      bucket.add(listener)
-    },
-    removeListener(channel: string, listener: Listener): void {
-      listenersByChannel.get(channel)?.delete(listener)
-    },
-    removeAllListeners(channel: string): void {
-      // The contract forbids using this; the mock still implements it so tests
-      // can assert "no caller of subscribe() touches it indirectly."
-      listenersByChannel.get(channel)?.clear()
-    }
-  }
-}))
-
+import { __emit, __reset } from '../setup/electron-mock'
 import { subscribe } from '../../src/preload/subscribe'
 
-function emit(channel: string, payload: unknown): void {
-  const bucket = listenersByChannel.get(channel)
-  if (!bucket) return
-  for (const listener of [...bucket]) listener({}, payload)
-}
-
 beforeEach(() => {
-  listenersByChannel.clear()
+  __reset()
 })
 
 describe('preload subscribe<T>', () => {
   it('delivers the payload to the listener', () => {
     const cb = vi.fn()
     subscribe<{ x: number }>('test:channel')(cb)
-    emit('test:channel', { x: 1 })
+    __emit('test:channel', { x: 1 })
     expect(cb).toHaveBeenCalledTimes(1)
     expect(cb).toHaveBeenCalledWith({ x: 1 })
   })
@@ -52,15 +21,15 @@ describe('preload subscribe<T>', () => {
     const unsubA = subscribe<number>('test:channel')(cbA)
     subscribe<number>('test:channel')(cbB)
 
-    emit('test:channel', 1)
+    __emit('test:channel', 1)
     expect(cbA).toHaveBeenCalledTimes(1)
     expect(cbB).toHaveBeenCalledTimes(1)
 
     unsubA()
 
-    emit('test:channel', 2)
-    expect(cbA).toHaveBeenCalledTimes(1) // unchanged — disposer removed it
-    expect(cbB).toHaveBeenCalledTimes(2) // still firing
+    __emit('test:channel', 2)
+    expect(cbA).toHaveBeenCalledTimes(1)
+    expect(cbB).toHaveBeenCalledTimes(2)
   })
 
   it('keeps subscriptions isolated per channel', () => {
@@ -69,7 +38,7 @@ describe('preload subscribe<T>', () => {
     subscribe<string>('chan:a')(cbA)
     subscribe<string>('chan:b')(cbB)
 
-    emit('chan:a', 'hello')
+    __emit('chan:a', 'hello')
     expect(cbA).toHaveBeenCalledTimes(1)
     expect(cbB).not.toHaveBeenCalled()
   })

--- a/test/setup/electron-mock.ts
+++ b/test/setup/electron-mock.ts
@@ -1,0 +1,101 @@
+/**
+ * Global Vitest mock for the `electron` module (Phase 7 PR 1, #140).
+ *
+ * Wired via `vitest.config.ts` → `test.setupFiles`. Provides the minimal
+ * surface main-process services touch so any test that pulls `electron` in
+ * (directly or transitively) doesn't have to re-implement a local stub.
+ *
+ * Per-test `vi.mock('electron', ...)` calls still override this — the global
+ * mock is a sensible default, not a hard floor.
+ */
+import { vi } from 'vitest'
+
+type Listener = (event: unknown, ...args: unknown[]) => void
+
+// Renderer-side listener registry. Mirrors the per-test mock that
+// `test/preload/subscribe.test.ts` used to carry; exposing __emit + __reset
+// lets tests drive events deterministically.
+const rendererListeners = new Map<string, Set<Listener>>()
+
+export function __emit(channel: string, ...args: unknown[]): void {
+  const bucket = rendererListeners.get(channel)
+  if (!bucket) return
+  for (const listener of [...bucket]) listener({}, ...args)
+}
+
+export function __reset(): void {
+  rendererListeners.clear()
+}
+
+vi.mock('electron', () => {
+  return {
+    ipcRenderer: {
+      on(channel: string, listener: Listener): void {
+        let bucket = rendererListeners.get(channel)
+        if (!bucket) {
+          bucket = new Set()
+          rendererListeners.set(channel, bucket)
+        }
+        bucket.add(listener)
+      },
+      removeListener(channel: string, listener: Listener): void {
+        rendererListeners.get(channel)?.delete(listener)
+      },
+      removeAllListeners(channel: string): void {
+        rendererListeners.get(channel)?.clear()
+      },
+      invoke: vi.fn(),
+      send: vi.fn()
+    },
+    ipcMain: {
+      handle: vi.fn(),
+      on: vi.fn(),
+      removeHandler: vi.fn(),
+      removeAllListeners: vi.fn()
+    },
+    app: {
+      getPath: vi.fn((name: string) => `/tmp/electron-mock/${name}`),
+      getAppPath: vi.fn(() => '/tmp/electron-mock'),
+      getName: vi.fn(() => 'anime-downloader-test'),
+      getVersion: vi.fn(() => '0.0.0-test'),
+      on: vi.fn(),
+      once: vi.fn(),
+      quit: vi.fn(),
+      whenReady: vi.fn(() => Promise.resolve()),
+      commandLine: { appendSwitch: vi.fn() }
+    },
+    BrowserWindow: class {
+      static getAllWindows = vi.fn(() => [] as unknown[])
+      static getFocusedWindow = vi.fn(() => null)
+      webContents = { send: vi.fn() }
+      on = vi.fn()
+      loadFile = vi.fn()
+      loadURL = vi.fn()
+      close = vi.fn()
+    },
+    Notification: class {
+      static isSupported = vi.fn(() => true)
+      show = vi.fn()
+      on = vi.fn()
+    },
+    shell: {
+      openExternal: vi.fn(),
+      openPath: vi.fn(() => Promise.resolve('')),
+      showItemInFolder: vi.fn(),
+      trashItem: vi.fn(() => Promise.resolve())
+    },
+    protocol: {
+      registerSchemesAsPrivileged: vi.fn(),
+      handle: vi.fn(),
+      registerStreamProtocol: vi.fn()
+    },
+    net: {
+      fetch: vi.fn()
+    },
+    dialog: {
+      showOpenDialog: vi.fn(),
+      showSaveDialog: vi.fn(),
+      showMessageBox: vi.fn()
+    }
+  }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,18 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts', 'src/**/*.test.ts'],
-    exclude: ['node_modules/**', 'out/**', 'dist/**', 'e2e/**']
+    exclude: ['node_modules/**', 'out/**', 'dist/**', 'e2e/**'],
+    setupFiles: ['./test/setup/electron-mock.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+      include: ['src/**/*.ts', 'src/**/*.vue'],
+      exclude: [
+        'src/**/*.d.ts',
+        'src/**/*.test.ts',
+        'src/renderer/src/main.ts',
+        'src/main/index.ts'
+      ]
+    }
   }
 })


### PR DESCRIPTION
## Summary

First PR of Phase 7 — comprehensive test coverage (#140), part of the structure-refactor epic #84. Bundles the original 7a (test infrastructure) and 7d (IPC contract round-trip) slices into one foundational PR that unblocks the four remaining PRs (unit gap-fill, integration, e2e, CI gate).

## Changes

### Test infrastructure

- **`test/setup/electron-mock.ts`** — global `electron` module mock wired via `vitest.config.ts` `setupFiles`. Stubs `ipcRenderer` (with a real listener registry), `ipcMain`, `app`, `BrowserWindow`, `Notification`, `shell`, `protocol`, `net`, `dialog`. Exports `__emit`/`__reset` for tests that drive events. Removes per-file `vi.mock('electron', ...)` boilerplate.
- **`npm run test:coverage`** — `vitest run --coverage` with the v8 provider (text + HTML reporter). No threshold yet — that lands in PR 5 (CI gate) once PRs 2–4 establish the floor. Adds `@vitest/coverage-v8` dev dep.
- **`test/preload/subscribe.test.ts`** — migrated off the local `vi.mock` to use the shared mock. Behavior unchanged.

### IPC contract round-trip

`test/ipc-channels.test.ts` gains three new assertions on top of the existing five drift-guard checks:

1. Every `CHANNELS.X` has a registered `ipcMain.handle` (or `.on`) somewhere in main or the per-domain routers.
2. Every `CHANNELS.X` has a matching preload binding (`ipcRenderer.invoke` / `.send`).
3. Every `EVENT_CHANNELS.X` is referenced in main (either emitted directly or passed into a service as a config field) **and** subscribed in preload (`subscribe<…>(…)` or bespoke `ipcRenderer.on(…)` for multi-arg payloads).

Source scope expanded from `main/index.ts` + `preload/index.ts` + `ipc/*.ts` to **all** `src/main/*.ts` files. Without this, raw-string emit sites in top-level main files bypass the contract.

### Phase 1 leftover bugs surfaced by the new test

The expanded scope immediately caught three files that had been emitting raw string literals instead of `EVENT_CHANNELS.X` symbols since before the Phase 1 contract migration:

- `src/main/auto-downloader.ts` — 5 `deps.broadcast('auto-dl:*')` call sites now use `EVENT_CHANNELS.AUTO_DL_TICK_RESULT` / `EVENT_CHANNELS.AUTO_DL_ENQUEUED`.
- `src/main/download-manager.ts` — `webContents.send('download:progress', …)` → `EVENT_CHANNELS.DOWNLOAD_PROGRESS`.
- `src/main/fpcalc-binaries.ts` — `webContents.send('fpcalc:download-progress', …)` → `EVENT_CHANNELS.FPCALC_DOWNLOAD_PROGRESS`.

## Behavior

No user-visible change. The raw strings and the `EVENT_CHANNELS.X` constants resolve to identical channel names; renderer subscribers were already correct.

## Out of scope (later Phase 7 PRs)

- `test/helpers/app-harness.ts` — PR 3 (integration) where it has a consumer.
- Coverage threshold in `vitest.config.ts` — PR 5 (CI gate).
- New service/store/composable tests — PR 2.
- CI workflow changes (`npm run test:coverage` step, e2e promotion) — PR 5.
- `docs/testing.md` — PR 5.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (only pre-existing warnings)
- [x] `npm run format:check` — green
- [x] `npm run check:subscription-contract` — green
- [x] `npm run test` — 321 / 321 pass
- [x] `npm run test:coverage` — produces report (no threshold gate yet)
- [x] `npm run build` — green
- [x] Mutation check: removed an `ipcMain.handle(CHANNELS.X, …)` line in a router → new contract test fails listing that channel name. Restored.
- [x] Mutation check: removed a `window.api.X = ipcRenderer.invoke(CHANNELS.X, …)` line in preload → new contract test fails listing that channel name. Restored.

Refs #140 (Phase 7 PR 1 of 5). Part of #84.
