### PR TITLE
test(phase 7): integration — auto-download + Shikimori offline drain (#140)

### DIFF
--- a/test/helpers/app-harness.ts
+++ b/test/helpers/app-harness.ts
@@ -1,0 +1,130 @@
+/**
+ * Integration test harness (Phase 7 PR 3, #140).
+ *
+ * Builds the minimum surface — in-memory storage, broadcast spy, stub HTTP
+ * clients, stub download manager — needed to drive multi-service flows
+ * without booting Electron. Each integration test composes only what it
+ * needs from these helpers.
+ *
+ * This is intentionally NOT a full `App` controller reconstruction. Wiring
+ * every service + router into a single fake makes the harness as complex as
+ * the production it stands in for. The helpers below are small, targeted,
+ * and composable — each integration test wires what it needs explicitly.
+ */
+import { vi } from 'vitest'
+import { InMemoryStorage } from './in-memory-storage'
+
+export type BroadcastSpy = ReturnType<typeof vi.fn>
+
+export interface Harness {
+  store: InMemoryStorage
+  broadcast: BroadcastSpy
+  /** Returns the list of `(channel, ...args)` calls in arrival order. */
+  broadcasts(): Array<{ channel: string; args: unknown[] }>
+}
+
+/**
+ * Construct a fresh `Harness` with an empty in-memory store + a broadcast spy.
+ * Tests then layer in services and stubs as needed.
+ */
+export function makeHarness(initialStore: Record<string, unknown> = {}): Harness {
+  const store = new InMemoryStorage(initialStore)
+  const broadcast = vi.fn()
+  function broadcasts(): Array<{ channel: string; args: unknown[] }> {
+    return broadcast.mock.calls.map(([channel, ...args]) => ({
+      channel: channel as string,
+      args
+    }))
+  }
+  return { store, broadcast, broadcasts }
+}
+
+/**
+ * Minimal stub for `SmotretApi`. Tests override the methods they care about;
+ * un-overridden methods reject with a clear `not stubbed` error so missing
+ * coverage is loud.
+ */
+export interface SmotretApiStub {
+  searchAnime: ReturnType<typeof vi.fn>
+  getAnime: ReturnType<typeof vi.fn>
+  getEpisode: ReturnType<typeof vi.fn>
+  getEmbed: ReturnType<typeof vi.fn>
+  getSubtitlesUrl: ReturnType<typeof vi.fn>
+  getFallbackVideoUrl: ReturnType<typeof vi.fn>
+  fetchSubtitleContent: ReturnType<typeof vi.fn>
+  fetchPoster: ReturnType<typeof vi.fn>
+  validateToken: ReturnType<typeof vi.fn>
+  lookupByMalIds: ReturnType<typeof vi.fn>
+}
+
+function notStubbed(name: string): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => {
+    throw new Error(`SmotretApi.${name} not stubbed for this integration test`)
+  })
+}
+
+export function makeSmotretApiStub(): SmotretApiStub {
+  return {
+    searchAnime: notStubbed('searchAnime'),
+    getAnime: notStubbed('getAnime'),
+    getEpisode: notStubbed('getEpisode'),
+    getEmbed: notStubbed('getEmbed'),
+    getSubtitlesUrl: vi.fn((id: number) => `https://stub/subs/${id}`),
+    getFallbackVideoUrl: vi.fn(
+      (id: number, height: number) => `https://stub/fallback/${id}/${height}`
+    ),
+    fetchSubtitleContent: notStubbed('fetchSubtitleContent'),
+    fetchPoster: notStubbed('fetchPoster'),
+    validateToken: notStubbed('validateToken'),
+    lookupByMalIds: notStubbed('lookupByMalIds')
+  }
+}
+
+/**
+ * Minimal stub for `DownloadManager`. Covers the surface auto-downloader +
+ * shikimori-sync use; expand as more integration coverage lands.
+ */
+export interface DownloadManagerStub {
+  enqueue: ReturnType<typeof vi.fn>
+  getEpisodeGroups: ReturnType<typeof vi.fn>
+}
+
+export function makeDownloadManagerStub(
+  initialGroups: Array<{ animeId: number; episodeInt: string }> = []
+): DownloadManagerStub {
+  return {
+    enqueue: vi.fn(async () => undefined),
+    getEpisodeGroups: vi.fn(() => initialGroups)
+  }
+}
+
+/**
+ * Minimal stub of the shikimori HTTP module (`src/main/shikimori.ts`).
+ * Integration tests that exercise services depending on shikimori HTTP
+ * should `vi.mock('../../src/main/shikimori', ...)` and route through this.
+ */
+export interface ShikimoriClientStub {
+  ensureFreshToken: ReturnType<typeof vi.fn>
+  getUser: ReturnType<typeof vi.fn>
+  getUserRate: ReturnType<typeof vi.fn>
+  createUserRate: ReturnType<typeof vi.fn>
+  updateUserRate: ReturnType<typeof vi.fn>
+  getUserAnimeRates: ReturnType<typeof vi.fn>
+  getAnimeDetails: ReturnType<typeof vi.fn>
+  getFriends: ReturnType<typeof vi.fn>
+  getFriendsRatesForAnime: ReturnType<typeof vi.fn>
+}
+
+export function makeShikimoriClientStub(): ShikimoriClientStub {
+  return {
+    ensureFreshToken: vi.fn(async () => 'access-token'),
+    getUser: vi.fn(async () => ({ id: 1, nickname: 'a', avatar: '' })),
+    getUserRate: vi.fn(async () => null),
+    createUserRate: vi.fn(),
+    updateUserRate: vi.fn(),
+    getUserAnimeRates: vi.fn(async () => []),
+    getAnimeDetails: vi.fn(),
+    getFriends: vi.fn(async () => []),
+    getFriendsRatesForAnime: vi.fn(async () => [])
+  }
+}

--- a/test/integration/auto-download-tick.test.ts
+++ b/test/integration/auto-download-tick.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Auto-downloader integration tests (Phase 7 PR 3, #140).
+ *
+ * Drives `runAutoDownloadTick` end-to-end with an in-memory `StorageService`,
+ * a stub `SmotretApi`, and a stub `DownloadManager`. Resets the
+ * `auto-downloader` module per test because it carries module-level
+ * state (`deps`, `tickRunning`, `lockReleaseAt`).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { EVENT_CHANNELS } from '../../src/shared/ipc/channels'
+import {
+  makeHarness,
+  makeSmotretApiStub,
+  makeDownloadManagerStub,
+  type SmotretApiStub,
+  type DownloadManagerStub
+} from '../helpers/app-harness'
+import type { InMemoryStorage } from '../helpers/in-memory-storage'
+
+type AutoDownloaderModule = typeof import('../../src/main/auto-downloader')
+
+interface Ctx {
+  store: InMemoryStorage
+  broadcast: ReturnType<typeof vi.fn>
+  smotret: SmotretApiStub
+  dlMgr: DownloadManagerStub
+  refreshShikimoriDetails: ReturnType<typeof vi.fn>
+  isShikimoriLoggedIn: ReturnType<typeof vi.fn>
+  autoDl: AutoDownloaderModule
+}
+
+async function bootCtx(
+  opts: {
+    initialStore?: Record<string, unknown>
+    loggedIn?: boolean
+    refreshReturns?: unknown
+  } = {}
+): Promise<Ctx> {
+  vi.resetModules()
+  const harness = makeHarness({
+    autoDownloadEnabled: true,
+    autoDownloadSubscriptions: {},
+    shikimoriAnimeDetails: {},
+    downloadedEpisodes: {},
+    translationType: 'subRu',
+    ...opts.initialStore
+  })
+  const smotret = makeSmotretApiStub()
+  const dlMgr = makeDownloadManagerStub()
+  const refreshShikimoriDetails = vi.fn(async () => opts.refreshReturns ?? null)
+  const isShikimoriLoggedIn = vi.fn(() => opts.loggedIn ?? true)
+  const autoDl: AutoDownloaderModule = await import('../../src/main/auto-downloader')
+  autoDl.initAutoDownloader({
+    store: harness.store as unknown as Parameters<typeof autoDl.initAutoDownloader>[0]['store'],
+    smotretApi: smotret as unknown as Parameters<typeof autoDl.initAutoDownloader>[0]['smotretApi'],
+    downloadManager: dlMgr as unknown as Parameters<
+      typeof autoDl.initAutoDownloader
+    >[0]['downloadManager'],
+    broadcast: harness.broadcast,
+    isShikimoriLoggedIn,
+    refreshShikimoriDetails
+  })
+  return {
+    store: harness.store,
+    broadcast: harness.broadcast,
+    smotret,
+    dlMgr,
+    refreshShikimoriDetails,
+    isShikimoriLoggedIn,
+    autoDl
+  }
+}
+
+function sub(opts: { animeId: number; malId: number; lastEnqueued?: number; name?: string }) {
+  return {
+    [String(opts.animeId)]: {
+      animeId: opts.animeId,
+      malId: opts.malId,
+      animeName: opts.name ?? 'Anime',
+      subscribedAt: 0,
+      lastEnqueuedEpisodeInt: opts.lastEnqueued ?? 0,
+      lastCheckedAt: 0,
+      initialEpisodesAired: opts.lastEnqueued ?? 0
+    }
+  }
+}
+
+function detailsCache(malId: number, opts: { aired: number; total: number }) {
+  return {
+    [String(malId)]: {
+      details: { episodes_aired: opts.aired, episodes: opts.total },
+      fetchedAt: Date.now()
+    }
+  }
+}
+
+describe('runAutoDownloadTick — gating', () => {
+  it('emits an empty result + AUTO_DL_TICK_RESULT when autoDownloadEnabled is false', async () => {
+    const ctx = await bootCtx({ initialStore: { autoDownloadEnabled: false } })
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(ctx.dlMgr.enqueue).not.toHaveBeenCalled()
+    expect(ctx.broadcast).toHaveBeenCalledWith(EVENT_CHANNELS.AUTO_DL_TICK_RESULT, result)
+  })
+
+  it('returns immediately with no subscriptions', async () => {
+    const ctx = await bootCtx({ initialStore: { autoDownloadSubscriptions: {} } })
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(0)
+    expect(ctx.smotret.getAnime).not.toHaveBeenCalled()
+  })
+
+  it('returns immediately when not logged in to Shikimori', async () => {
+    const ctx = await bootCtx({
+      loggedIn: false,
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 5, total: 12 })
+      }
+    })
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(0)
+    expect(ctx.smotret.getAnime).not.toHaveBeenCalled()
+  })
+
+  it('skips a subscription when episodes_aired is 0', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 0, total: 12 })
+      }
+    })
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.details).toContainEqual(
+      expect.objectContaining({ animeId: 1, outcome: 'no-episodes-aired' })
+    )
+    expect(ctx.dlMgr.enqueue).not.toHaveBeenCalled()
+  })
+})
+
+describe('runAutoDownloadTick — enqueue flow', () => {
+  it('enqueues a single new episode end-to-end', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 1, total: 12 })
+      }
+    })
+    ctx.smotret.getAnime.mockResolvedValue({
+      data: { episodes: [{ id: 100, episodeInt: '1' }] }
+    })
+    ctx.smotret.getEpisode.mockResolvedValue({
+      data: {
+        id: 100,
+        episodeFull: '1',
+        translations: [
+          {
+            id: 1001,
+            type: 'subRu',
+            isActive: 1,
+            height: 1080,
+            authorsSummary: 'Subber'
+          }
+        ]
+      }
+    })
+    ctx.smotret.getEmbed.mockResolvedValue({
+      stream: [{ height: 1080, urls: ['https://x'] }]
+    })
+
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(1)
+    expect(ctx.dlMgr.enqueue).toHaveBeenCalledTimes(1)
+    const req = ctx.dlMgr.enqueue.mock.calls[0][0][0] as { translationId: number; height: number }
+    expect(req.translationId).toBe(1001)
+    expect(req.height).toBe(1080)
+    expect(ctx.broadcast).toHaveBeenCalledWith(
+      EVENT_CHANNELS.AUTO_DL_ENQUEUED,
+      expect.objectContaining({ animeId: 1, episodeInt: '1' })
+    )
+  })
+
+  it('skips episodes that are already downloaded but advances lastEnqueued', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 2, total: 12 }),
+        downloadedEpisodes: { '1:1': { translationType: 'subRu' } }
+      }
+    })
+    ctx.smotret.getAnime.mockResolvedValue({
+      data: { episodes: [{ id: 101, episodeInt: '2' }] }
+    })
+    ctx.smotret.getEpisode.mockResolvedValue({
+      data: {
+        id: 101,
+        episodeFull: '2',
+        translations: [{ id: 2001, type: 'subRu', isActive: 1, height: 720, authorsSummary: 'A' }]
+      }
+    })
+    ctx.smotret.getEmbed.mockResolvedValue({ stream: [{ height: 720, urls: ['x'] }] })
+
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    // Episode 1 was already downloaded → skipped; episode 2 was enqueued
+    expect(result.enqueued).toBe(1)
+    expect(result.details).toContainEqual(
+      expect.objectContaining({ episodeInt: '1', outcome: 'already-downloaded' })
+    )
+    expect(result.details).toContainEqual(
+      expect.objectContaining({ episodeInt: '2', outcome: 'enqueued' })
+    )
+  })
+
+  it('caps at MAX_ENQUEUES_PER_TICK = 10 and surfaces cap-reached', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 20, total: 24 })
+      }
+    })
+    ctx.smotret.getAnime.mockResolvedValue({
+      data: {
+        episodes: Array.from({ length: 20 }, (_, i) => ({ id: 100 + i, episodeInt: String(i + 1) }))
+      }
+    })
+    ctx.smotret.getEpisode.mockImplementation(async (id: number) => ({
+      data: {
+        id,
+        episodeFull: String(id - 99),
+        translations: [
+          { id: id * 10, type: 'subRu', isActive: 1, height: 720, authorsSummary: 'A' }
+        ]
+      }
+    }))
+    ctx.smotret.getEmbed.mockResolvedValue({ stream: [{ height: 720, urls: ['x'] }] })
+
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(10)
+    expect(result.details).toContainEqual(expect.objectContaining({ outcome: 'cap-reached' }))
+  })
+
+  it('marks no-translation outcome when active translations do not match user preference', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 1, total: 12 })
+      }
+    })
+    ctx.smotret.getAnime.mockResolvedValue({
+      data: { episodes: [{ id: 100, episodeInt: '1' }] }
+    })
+    ctx.smotret.getEpisode.mockResolvedValue({
+      data: {
+        id: 100,
+        episodeFull: '1',
+        translations: [
+          // Only voice translations available, but user preference is subRu (the global default)
+          { id: 999, type: 'voiceEn', isActive: 1, height: 720, authorsSummary: 'B' }
+        ]
+      }
+    })
+
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.enqueued).toBe(0)
+    expect(result.skipped).toBe(1)
+    expect(result.details).toContainEqual(
+      expect.objectContaining({ animeId: 1, outcome: 'no-translation' })
+    )
+  })
+
+  it('records error outcome when smotret API throws', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 1, total: 12 })
+      }
+    })
+    ctx.smotret.getAnime.mockRejectedValue(new Error('smotret-api-down'))
+
+    const result = await ctx.autoDl.runAutoDownloadTick('manual')
+    expect(result.errors).toBe(1)
+    expect(result.details).toContainEqual(
+      expect.objectContaining({ animeId: 1, outcome: 'error', message: 'smotret-api-down' })
+    )
+  })
+
+  it('persists updated lastEnqueuedEpisodeInt after a successful enqueue', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 3, total: 12 })
+      }
+    })
+    ctx.smotret.getAnime.mockResolvedValue({
+      data: {
+        episodes: [
+          { id: 100, episodeInt: '1' },
+          { id: 101, episodeInt: '2' },
+          { id: 102, episodeInt: '3' }
+        ]
+      }
+    })
+    ctx.smotret.getEpisode.mockImplementation(async (id: number) => ({
+      data: {
+        id,
+        episodeFull: String(id - 99),
+        translations: [
+          { id: id * 10, type: 'subRu', isActive: 1, height: 720, authorsSummary: 'A' }
+        ]
+      }
+    }))
+    ctx.smotret.getEmbed.mockResolvedValue({ stream: [{ height: 720, urls: ['x'] }] })
+
+    await ctx.autoDl.runAutoDownloadTick('manual')
+    const subs = ctx.store.get('autoDownloadSubscriptions') as Record<
+      string,
+      { lastEnqueuedEpisodeInt: number }
+    >
+    expect(subs['1'].lastEnqueuedEpisodeInt).toBe(3)
+  })
+
+  it('respects reentrancy lock — a second concurrent tick is a no-op', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 1, malId: 9, lastEnqueued: 0 }),
+        shikimoriAnimeDetails: detailsCache(9, { aired: 1, total: 12 })
+      }
+    })
+    let resolveFirst!: () => void
+    ctx.smotret.getAnime.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveFirst = () => r({ data: { episodes: [{ id: 100, episodeInt: '1' }] } } as never)
+        })
+    )
+    ctx.smotret.getEpisode.mockResolvedValue({
+      data: {
+        id: 100,
+        episodeFull: '1',
+        translations: [{ id: 1001, type: 'subRu', isActive: 1, height: 720, authorsSummary: 'A' }]
+      }
+    })
+    ctx.smotret.getEmbed.mockResolvedValue({ stream: [{ height: 720, urls: ['x'] }] })
+
+    const p1 = ctx.autoDl.runAutoDownloadTick('manual')
+    const p2 = ctx.autoDl.runAutoDownloadTick('manual')
+    resolveFirst()
+    const [r1, r2] = await Promise.all([p1, p2])
+    // r2 ran while r1 still held the lock → r2 should be a no-op
+    expect(r1.enqueued).toBe(1)
+    expect(r2.enqueued).toBe(0)
+    expect(ctx.dlMgr.enqueue).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('setSubscription', () => {
+  it('removes the subscription when enabled=false', async () => {
+    const ctx = await bootCtx({
+      initialStore: {
+        autoDownloadSubscriptions: sub({ animeId: 5, malId: 9 })
+      }
+    })
+    const result = await ctx.autoDl.setSubscription(5, false)
+    expect(result).toBeNull()
+    const map = ctx.store.get('autoDownloadSubscriptions') as Record<string, unknown>
+    expect(map['5']).toBeUndefined()
+  })
+
+  it('refuses to subscribe when cache is missing AND refreshShikimoriDetails returns null', async () => {
+    const ctx = await bootCtx({ refreshReturns: null })
+    const result = await ctx.autoDl.setSubscription(5, true, { malId: 9, animeName: 'X' })
+    expect(result).toBeNull()
+    expect(ctx.refreshShikimoriDetails).toHaveBeenCalledWith(9)
+  })
+
+  it('stamps lastEnqueuedEpisodeInt to episodes_aired so it does not backfill', async () => {
+    const ctx = await bootCtx({
+      refreshReturns: { episodes_aired: 7, episodes: 12 }
+    })
+    const result = await ctx.autoDl.setSubscription(5, true, { malId: 9, animeName: 'X' })
+    expect(result?.lastEnqueuedEpisodeInt).toBe(7)
+    expect(result?.initialEpisodesAired).toBe(7)
+  })
+})

--- a/test/integration/shikimori-offline-sync.test.ts
+++ b/test/integration/shikimori-offline-sync.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Shikimori offline-queue drain integration tests (Phase 7 PR 3, #140).
+ *
+ * Exercises `ShikimoriSyncService.syncShikimoriQueue` end-to-end across
+ * multiple queued malIds with mixed server states — consolidation, drift
+ * reconciliation, partial-failure abort, and store + broadcast side effects
+ * all observed together (vs the per-branch unit tests in
+ * test/services/shikimori-sync.test.ts).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
+
+const ensureFreshToken = vi.fn()
+const getUserRate = vi.fn()
+const createUserRate = vi.fn()
+const updateUserRate = vi.fn()
+
+vi.mock('../../src/main/shikimori', async () => {
+  const actual = await vi.importActual<typeof import('../../src/main/shikimori')>(
+    '../../src/main/shikimori'
+  )
+  return {
+    ...actual,
+    ensureFreshToken: (...a: unknown[]) => ensureFreshToken(...a),
+    getUserRate: (...a: unknown[]) => getUserRate(...a),
+    createUserRate: (...a: unknown[]) => createUserRate(...a),
+    updateUserRate: (...a: unknown[]) => updateUserRate(...a)
+  }
+})
+
+import { createShikimoriSyncService } from '../../src/main/services/shikimori-sync'
+
+const CH = {
+  syncStatus: 'shikimori:sync-status',
+  offlineQueueChanged: 'shikimori:offline-queue-changed',
+  rateUpdated: 'shikimori:rate-updated',
+  animeDetailsUpdated: 'shikimori:anime-details-updated'
+}
+
+function cacheEntry(malId: number, episodes: number) {
+  return {
+    rate: { id: malId, target_id: malId, episodes, status: 'watching', score: 0 },
+    shikiAnime: { id: malId, name: `Anime ${malId}` },
+    smotretAnime: null
+  }
+}
+
+function queued(malId: number, beforeEp: number, afterEp: number, queuedAt: number) {
+  return {
+    malId,
+    rateId: malId,
+    before: { episodes: beforeEp, status: 'watching', score: 0, rewatches: 0 },
+    after: { episodes: afterEp, status: 'watching', score: 0, rewatches: 0 },
+    queuedAt
+  }
+}
+
+function boot(initial: Record<string, unknown>) {
+  const store = new InMemoryStorage({
+    shikimoriUpdateQueue: [],
+    shikimoriCredentials: { access_token: 't', refresh_token: 'r' },
+    shikimoriUser: { id: 1, nickname: 'a' },
+    shikimoriUserRates: [],
+    shikimoriAnimeDetails: {},
+    ...initial
+  })
+  const broadcast = vi.fn()
+  const svc = createShikimoriSyncService({
+    store: store as unknown as Parameters<typeof createShikimoriSyncService>[0]['store'],
+    broadcast,
+    syncStatusChannel: CH.syncStatus,
+    offlineQueueChangedChannel: CH.offlineQueueChanged,
+    rateUpdatedChannel: CH.rateUpdated,
+    animeDetailsUpdatedChannel: CH.animeDetailsUpdated
+  })
+  return { store, broadcast, svc }
+}
+
+beforeEach(() => {
+  ensureFreshToken.mockReset().mockResolvedValue('access-token')
+  getUserRate.mockReset()
+  createUserRate.mockReset()
+  updateUserRate.mockReset()
+})
+
+describe('Shikimori offline drain — multi-item integration', () => {
+  it('drains three independent malIds in one run and clears the queue', async () => {
+    const { store, broadcast, svc } = boot({
+      shikimoriUserRates: [cacheEntry(10, 0), cacheEntry(20, 0), cacheEntry(30, 0)],
+      shikimoriUpdateQueue: [queued(10, 0, 1, 1), queued(20, 0, 2, 2), queued(30, 0, 3, 3)]
+    })
+    getUserRate.mockImplementation(async (_t: string, _u: number, malId: number) => ({
+      id: malId,
+      target_id: malId,
+      episodes: 0,
+      status: 'watching',
+      score: 0
+    }))
+    updateUserRate.mockImplementation(async (_t: string, rateId: number, episodes: number) => ({
+      id: rateId,
+      target_id: rateId,
+      episodes,
+      status: 'watching',
+      score: 0,
+      rewatches: 0
+    }))
+
+    await svc.syncShikimoriQueue()
+
+    expect(updateUserRate).toHaveBeenCalledTimes(3)
+    expect((store.get('shikimoriUpdateQueue') as unknown[]).length).toBe(0)
+    // Each rate reconciled into cache
+    const rates = store.get('shikimoriUserRates') as {
+      rate: { target_id: number; episodes: number }
+    }[]
+    expect(rates.find((r) => r.rate.target_id === 10)?.rate.episodes).toBe(1)
+    expect(rates.find((r) => r.rate.target_id === 30)?.rate.episodes).toBe(3)
+    // Final offline-queue-changed broadcast reports 0
+    const lastQueueEvent = broadcast.mock.calls.filter((c) => c[0] === CH.offlineQueueChanged).pop()
+    expect(lastQueueEvent?.[1]).toEqual({ length: 0 })
+  })
+
+  it('consolidates multiple queued edits to the same malId into one server write', async () => {
+    const { store, svc } = boot({
+      shikimoriUserRates: [cacheEntry(10, 0)],
+      // Three edits to malId 10, latest wins (episodes → 5)
+      shikimoriUpdateQueue: [queued(10, 0, 1, 1), queued(10, 1, 3, 2), queued(10, 3, 5, 3)]
+    })
+    getUserRate.mockResolvedValue({
+      id: 10,
+      target_id: 10,
+      episodes: 0,
+      status: 'watching',
+      score: 0
+    })
+    updateUserRate.mockResolvedValue({
+      id: 10,
+      target_id: 10,
+      episodes: 5,
+      status: 'watching',
+      score: 0,
+      rewatches: 0
+    })
+
+    await svc.syncShikimoriQueue()
+
+    expect(updateUserRate).toHaveBeenCalledTimes(1)
+    expect(updateUserRate).toHaveBeenCalledWith('access-token', 10, 5, 'watching', 0, 0)
+    expect((store.get('shikimoriUpdateQueue') as unknown[]).length).toBe(0)
+  })
+
+  it('stops the drain at the first network failure, preserving remaining items', async () => {
+    const { store, svc } = boot({
+      shikimoriUserRates: [cacheEntry(10, 0), cacheEntry(20, 0)],
+      shikimoriUpdateQueue: [queued(10, 0, 1, 1), queued(20, 0, 2, 2)]
+    })
+    let call = 0
+    getUserRate.mockImplementation(async () => {
+      call += 1
+      if (call === 1) {
+        return { id: 10, target_id: 10, episodes: 0, status: 'watching', score: 0 }
+      }
+      // Second item: network drop
+      throw Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    })
+    updateUserRate.mockResolvedValue({
+      id: 10,
+      target_id: 10,
+      episodes: 1,
+      status: 'watching',
+      score: 0,
+      rewatches: 0
+    })
+
+    await svc.syncShikimoriQueue()
+
+    // First item drained; second left in queue for the next attempt
+    const remaining = store.get('shikimoriUpdateQueue') as { malId: number }[]
+    expect(remaining.length).toBe(1)
+    expect(remaining[0].malId).toBe(20)
+  })
+
+  it('adjusts the sync timer + reports idle once the queue empties', async () => {
+    const { svc } = boot({
+      shikimoriUserRates: [cacheEntry(10, 0)],
+      shikimoriUpdateQueue: [queued(10, 0, 1, 1)]
+    })
+    getUserRate.mockResolvedValue({
+      id: 10,
+      target_id: 10,
+      episodes: 0,
+      status: 'watching',
+      score: 0
+    })
+    updateUserRate.mockResolvedValue({
+      id: 10,
+      target_id: 10,
+      episodes: 1,
+      status: 'watching',
+      score: 0,
+      rewatches: 0
+    })
+
+    await svc.syncShikimoriQueue()
+
+    const status = svc.getSyncStatus()
+    expect(status.state).toBe('idle')
+    expect(status.queueLength).toBe(0)
+    expect(status.lastSyncError).toBeNull()
+    expect(status.lastSyncAt).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Third PR of Phase 7 (#140), slice 7e. Adds an **integration test layer** that drives multi-service flows with an in-memory store + stubbed external seams — no Electron boot. **18 new tests** (suite 424 → 442).

**Stacked on #143.** Will be retargeted to `main` once #143 (and #142 before it) merge (per [[feedback_stacked_pr_base_branch]]).

## The harness — `test/helpers/app-harness.ts`

Composable test doubles rather than a full `App`/`Core` reconstruction (rationale documented in the file header — reconstructing the whole controller makes the harness as complex as the production it stands in for):

- `makeHarness` — in-memory `StorageService` + a broadcast spy with an ordered `broadcasts()` accessor.
- `makeSmotretApiStub` — every method *rejects* with a clear `not stubbed` error until a test overrides it, so missing coverage fails loud instead of returning `undefined`.
- `makeDownloadManagerStub` / `makeShikimoriClientStub` — the minimal surfaces the orchestrators consume.

Each integration test wires only what it needs.

## Flows covered

### Auto-downloader — `test/integration/auto-download-tick.test.ts` (14 tests)

- **Gating:** `autoDownloadEnabled=false`, no subscriptions, not-logged-in, `episodes_aired=0` — each short-circuits without touching the API.
- **Enqueue flow:** single episode end-to-end (translation pick → height probe via `getEmbed` → `downloadManager.enqueue` → `auto-dl:enqueued` broadcast); already-downloaded skip that still advances `lastEnqueuedEpisodeInt`; `MAX_ENQUEUES_PER_TICK = 10` cap with `cap-reached`; `no-translation` outcome; API-error outcome; `lastEnqueuedEpisodeInt` persistence to store; reentrancy lock (a concurrent second tick is a no-op).
- **`setSubscription`:** disable removes the entry; refuse-to-subscribe when cache is empty and refresh returns null; `episodes_aired` stamping so a fresh subscription never backfills the whole show.

### Shikimori offline drain — `test/integration/shikimori-offline-sync.test.ts` (4 tests)

End-to-end through `ShikimoriSyncService.syncShikimoriQueue` (vs the per-branch unit tests in PR 2):

- Three independent malIds drained in one run → queue cleared, cache reconciled, final `offline-queue-changed` reports `{ length: 0 }`.
- Multiple queued edits to the same malId consolidated into a **single** server write (latest-wins).
- Network failure mid-drain stops the run and preserves the remaining items for the next attempt.
- Sync timer adjusts + status reports `idle` with `lastSyncError: null` once the queue empties.

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (only pre-existing `index.ts` warnings)
- [x] `npm run format:check` — green
- [x] `npm run check:subscription-contract` — green
- [x] `npm run test` — 442 / 442 pass (+18 from PR 2)
- [x] `npm run build` — green

## Out of scope (later Phase 7 PRs)

- e2e Playwright flows beyond the boot smoke — PR 4.
- CI coverage gate + `docs/testing.md` — PR 5.
- Download enqueue→merge state machine integration (the real `DownloadManager` ffmpeg path) — deferred; needs a heavier ffmpeg stub, tracked for a follow-up.

Refs #140 (Phase 7 PR 3 of 5). Stacked on #143.
