### PR TITLE
test(phase 7): e2e navigation + settings persistence + keyboard (#140)

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,91 @@
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page
+} from '@playwright/test'
+import { resolve } from 'path'
+
+/**
+ * Navigation e2e (Phase 7 PR 4, #140).
+ *
+ * Drives the real built app through sidebar navigation with no network
+ * dependency — every view here renders from local state. Network/media-bound
+ * flows (search, player, Shikimori sync) are deliberately excluded; see the
+ * PR description for why they're deferred.
+ */
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeAll(async () => {
+  const args = [resolve(__dirname, '../out/main/index.js')]
+  if (process.env.CI) args.unshift('--no-sandbox')
+  app = await electron.launch({ args })
+  page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await expect.poll(() => page.title()).toContain('Anime DL')
+})
+
+test.afterAll(async () => {
+  await app?.close()
+})
+
+test('sidebar navigates between local views', async () => {
+  // The app boots on Home.
+  await expect(page.locator('.home-view')).toBeVisible()
+
+  // Downloads — `v-if`, so the view mounts on navigation.
+  await page.getByRole('button', { name: 'Downloads' }).click()
+  await expect(page.locator('.downloads-view, [class*="downloads"]').first()).toBeVisible()
+
+  // Settings — has a stable "Settings" heading.
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+  // Library.
+  await page.getByRole('button', { name: 'Library' }).click()
+  await expect(page.getByRole('button', { name: 'Library' })).toHaveClass(/active/)
+
+  // Back to Home.
+  await page.getByRole('button', { name: 'Home' }).click()
+  await expect(page.locator('.home-view')).toBeVisible()
+})
+
+test('settings tabs switch and the token round-trips through electron-store', async () => {
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible()
+
+  // Switch to the Connectors tab where the smotret token input lives.
+  await page.getByRole('button', { name: 'Connectors' }).click()
+  const tokenInput = page.locator('#token-input')
+  await expect(tokenInput).toBeVisible()
+
+  // Type a token; the tab autosaves after an 800ms debounce.
+  const sample = 'e2e-sample-token-123'
+  await tokenInput.fill(sample)
+  // Wait past the debounce + IPC round-trip.
+  await page.waitForTimeout(1200)
+
+  // Navigate away and back — the value should reload from the persisted store.
+  await page.getByRole('button', { name: 'Home' }).click()
+  await expect(page.locator('.home-view')).toBeVisible()
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('button', { name: 'Connectors' }).click()
+
+  await expect(page.locator('#token-input')).toHaveValue(sample)
+})
+
+test('Ctrl+F navigates to search and focuses the input', async () => {
+  // Make sure we're not already on search.
+  await page.getByRole('button', { name: 'Home' }).click()
+  await expect(page.locator('.home-view')).toBeVisible()
+
+  await page.keyboard.press('Control+f')
+
+  // Search view becomes active; its input gains focus.
+  await expect(page.getByRole('button', { name: 'Search' })).toHaveClass(/active/)
+  const searchInput = page.locator('input[type="text"], input[type="search"]').first()
+  await expect(searchInput).toBeFocused()
+})


### PR DESCRIPTION
## Summary

Fourth PR of Phase 7 (#140), slice 7f. Adds **deterministic, network-free** Playwright/Electron flows beyond the boot smoke. 3 new e2e tests (4 total with the existing smoke).

**Stacked on #144.** Retargeted to `main` once the chain below it merges.

## What's covered — `e2e/navigation.spec.ts`

Drives the real built app (`out/`) through a single shared Electron instance:

1. **Sidebar navigation** — home → downloads → settings → library → home, asserting the correct view renders / the nav button goes `active`.
2. **Settings token round-trip** — type a token in the Connectors tab, navigate away and back, assert it reloaded from the **real electron-store**. Exercises the autosave debounce + `getSetting`/`setSetting` IPC through the real main process end-to-end.
3. **Ctrl+F → Search** — keyboard shortcut navigates to Search and focuses its input, exercising the global `useKeyboardShortcuts` path in the real renderer.

## Why the issue's other flows are deferred

The issue's 7f sketch listed search→enqueue, MKV open+seek, and Shikimori offline-edit→sync. I'm **not** shipping those here:

- **search→enqueue** needs live `smotret-anime.ru` (or a fake API server) + a valid token.
- **MKV open+seek** needs a real media file + ffmpeg in the e2e environment.
- **Shikimori offline→sync** needs a logged-in Shikimori session + network.

Each needs infrastructure (a stub HTTP server, committed fixture media) that's a larger piece of work than this PR, and shipping them network-bound would make CI flaky — exactly what the epic's risk section warns against. Rather than ship flaky e2e, I covered the flows that are genuinely deterministic and left the rest as a tracked follow-up. The service-level logic behind those flows *is* covered by the PR 2 unit tests + PR 3 integration tests (auto-download enqueue, Shikimori drain).

## Test plan

- [x] `npm run build` then `npm run test:e2e` — 4/4 pass (3 new + smoke), run locally via WSLg display
- [x] `npm run test` — 442/442 unit tests still pass
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green (only pre-existing `index.ts` warnings)
- [x] `npm run format:check` — green

CI already runs `xvfb-run -a npm run test:e2e` in the `quality` job, so these execute on every PR with no workflow change.

## Out of scope (PR 5)

- CI coverage gate (`npm run test:coverage` step + threshold) — PR 5.
- `docs/testing.md` documenting the full test stack — PR 5.
- Network-bound e2e flows — tracked follow-up (see rationale above).

Refs #140 (Phase 7 PR 4 of 5). Stacked on #144.
