### PR TITLE
docs: rewrite README — modern, media-rich, accurate to current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,153 @@
+<div align="center">
+
+<img src="resources/icon.png" alt="Anime DL logo" width="120" />
+
 # Anime DL
 
-[![Ready for Implementation](https://img.shields.io/badge/Issues-Ready%20for%20Implementation-2cbe4e?style=flat-square&logo=github)](https://github.com/mikkerlo/anime-downloader/issues?q=is%3Aopen+is%3Aissue+label%3A%22Ready+for+implementation%22)
+**A modern desktop app to download, organize, and watch anime from [smotret-anime.ru](https://smotret-anime.ru) (anime365).**
 
-Desktop app for downloading anime episodes from [smotret-anime.ru](https://smotret-anime.ru) (anime365).
+<p>
+  <a href="https://github.com/mikkerlo/anime-downloader/releases/latest"><img src="https://img.shields.io/github/v/release/mikkerlo/anime-downloader?style=flat-square" alt="Latest release" /></a>
+  <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey?style=flat-square" alt="Platforms" />
+  <a href="https://github.com/mikkerlo/anime-downloader/actions/workflows/check.yml"><img src="https://img.shields.io/github/actions/workflow/status/mikkerlo/anime-downloader/check.yml?branch=main&style=flat-square&label=CI" alt="CI status" /></a>
+  <img src="https://img.shields.io/badge/license-ISC-blue?style=flat-square" alt="License: ISC" />
+  <br />
+  <img src="https://img.shields.io/badge/Electron-47848F?style=flat-square&logo=electron&logoColor=white" alt="Electron" />
+  <img src="https://img.shields.io/badge/Vue%203-42b883?style=flat-square&logo=vuedotjs&logoColor=white" alt="Vue 3" />
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript" />
+</p>
 
-Built with Electron, Vue 3, and TypeScript.
+</div>
+
+Anime DL is more than a downloader — it has a built-in player with MKV streaming, Anime4K upscaling, and native ASS subtitles, two-way Shikimori sync that works offline, watch-together via Syncplay, and local OP/ED skip detection.
+
+## Contents
+
+- [Features](#features)
+- [Download](#download)
+- [Quick Start](#quick-start)
+- [Development](#development)
+- [Project Structure](#project-structure)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+- [License](#license)
 
 ## Features
 
-- Search and browse anime catalog
-- Per-episode translation selector with multiple types (subtitles, voice, raw)
-- Download video + subtitles with resume support
-- Automatic merging into MKV via ffmpeg (downloaded automatically on first launch)
-- Re-encoding support (H.265 CPU/GPU)
-- Library with starred and downloaded anime tracking
-- Cross-platform (Windows, macOS, Linux)
+### 📥 Downloading
 
-## Requirements
+- **Search & browse** the full anime365 catalog.
+- **Per-episode translation picker** — subtitles, voice-over, or raw, with multiple authors supported and several translations kept side by side.
+- **Resumable downloads** of video + subtitles, backed by a persistent queue that survives restarts.
+- **Automatic MKV merge** via ffmpeg — downloaded automatically on first launch, no manual setup.
+- **Bandwidth & concurrency limits** to keep downloads from saturating your connection.
 
-- Node.js 18+
-- npm
+### ▶️ Built-in player
+
+- **Instant MKV streaming** through MediaSource Extensions — no waiting for a full remux — with frame-accurate seeking.
+- **HEVC (H.265)** playback, with an automatic **H.264 transcode fallback** on platforms without a hardware HEVC decoder.
+- **Anime4K upscaling** via WebGPU compute shaders (Mode A / B / C) for real-time enhancement.
+- **Native ASS/SSA subtitles** rendered with [JASSUB](https://github.com/ThaUnknown/jassub) (libass) — full styling, positioning, fonts, and sign translations preserved.
+- **Quality & translation switching** mid-playback, seek-time preview, and previous/next episode with auto-advance.
+- **Auto-resume** — picks up where you left off and reports progress back to Shikimori.
+
+### 🔍 Discovery & Shikimori
+
+- **Two-way Shikimori sync** of watch status and episode progress.
+- **Works offline** — edits are queued locally and synced (with conflict resolution) once you reconnect.
+- **Auto-download** new episodes for anime you're currently watching.
+- **Friends' activity** — friends' status and score on each anime, plus a global recent-activity feed.
+- **Series chronology** and a **release calendar**.
+
+### 👥 Watch Together
+
+- **Syncplay support** — keep playback in lockstep with friends. Compatible with the [Syncplay](https://syncplay.pl) protocol and the reference mpv/VLC desktop clients.
+
+### ⏭️ Skip detection
+
+- **Local OP/ED detection** by fingerprinting your own downloaded episodes (Chromaprint) — accurate to your encodes, no reliance on a different reference release.
+
+### 🗄️ Library & storage
+
+- **Library** of starred and downloaded anime with offline detail caching.
+- **Hot/cold storage** with automatic move of watched episodes.
+- **Auto-update** via `electron-updater`.
+
+## Download
+
+Grab the latest build for your platform from the [**Releases**](https://github.com/mikkerlo/anime-downloader/releases/latest) page:
+
+| Platform    | Download                       |
+| ----------- | ------------------------------ |
+| **Windows** | `.exe` (x64)                   |
+| **macOS**   | `.dmg` / `.zip` (Apple Silicon) |
+| **Linux**   | `.AppImage` or `.deb` (x86_64) |
+
+Builds are produced automatically by CI for every release.
+
+## Quick Start
+
+1. Install and launch the app.
+2. Open **Settings › General** and paste your **smotret-anime.ru API token** (required to download and stream episodes).
+3. On first run, ffmpeg/ffprobe are downloaded automatically to the app-data directory — nothing to install.
+4. Search for an anime, choose episodes and a translation, then download or play directly.
 
 ## Development
 
+Requires **Node.js 20+** and npm.
+
 ```bash
 npm install
-npm run dev
+npm run dev          # run with hot reload
 ```
 
-## Build
+Useful scripts:
 
 ```bash
-npm run build              # compile to out/
-npm run pack:win           # Windows portable exe
-npm run pack:linux         # Linux AppImage
-npm run pack:mac           # macOS zip
+npm run build        # compile to out/
+npm run typecheck    # type-check (node + web)
+npm run lint         # ESLint
+npm run format:check # Prettier
+npm run test         # Vitest (unit + integration)
+npm run test:e2e     # Playwright (Electron) e2e
 ```
 
-## Configuration
+Package a desktop build:
 
-On first launch, set your smotret-anime.ru API token in **Settings > General**. The token is required for downloading episodes.
+```bash
+npm run pack:win     # Windows
+npm run pack:linux   # Linux
+npm run pack:mac     # macOS
+```
 
-FFmpeg is downloaded automatically to the app data directory on first run.
+Before pushing, the full quality gate should be green: `typecheck` · `lint` · `format:check` · `test` · `build`. See [`CLAUDE.md`](CLAUDE.md) for project conventions and the contribution workflow, and [`docs/testing.md`](docs/testing.md) for the test layers and coverage gates.
 
 ## Project Structure
 
 ```
 src/
-  main/           Electron main process (downloads, merging, API proxy)
-  preload/        IPC bridge (contextBridge)
-  renderer/       Vue 3 frontend (search, library, downloads, settings)
+  main/        Electron main process — App controller, IPC routers, services, streaming
+  preload/     contextBridge IPC bridge (window.api)
+  renderer/    Vue 3 + Pinia frontend — views, stores, composables, components
+  shared/      Single-source IPC channel contract + ambient types
+docs/          Per-subsystem architecture docs
 ```
 
-See [DESIGN.md](DESIGN.md) for detailed architecture documentation.
+[`DESIGN.md`](DESIGN.md) is the architecture index — it links to a per-subsystem page under [`docs/`](docs/) for each part of the app.
+
+## Contributing
+
+Issues and pull requests are welcome. The [issues labelled **Ready for Implementation**](https://github.com/mikkerlo/anime-downloader/issues?q=is%3Aopen+is%3Aissue+label%3A%22Ready+for+implementation%22) are a good place to start. Project conventions, the commit/release flow, and the IPC pattern are documented in [`CLAUDE.md`](CLAUDE.md).
+
+## Acknowledgements
+
+- [smotret-anime.ru / anime365](https://smotret-anime.ru) — catalog and streaming source
+- [Shikimori](https://shikimori.one) — watchlist sync
+- [Anime4K](https://github.com/bloc97/Anime4K) — real-time upscaling shaders
+- [JASSUB](https://github.com/ThaUnknown/jassub) / libass — subtitle rendering
+- [FFmpeg](https://ffmpeg.org) — remuxing, transcoding, and merging
+- [Syncplay](https://syncplay.pl) — watch-together protocol
 
 ## License
 
-ISC
+Licensed under the **ISC** license.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "anime-dl-app",
-  "version": "3.25.1",
+  "version": "4.0.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",


### PR DESCRIPTION
## Summary

Rewrites the stale 59-line `README.md` into a modern, scannable, accurate document. Implements #147.

The old README undersold the app badly — it didn't mention the built-in player, Anime4K upscaling, Shikimori sync, Syncplay, or skip detection, had no visual identity, no end-user download path, and a stale "Node 18+" claim. This rewrite fixes all of that and represents the app as it stands after the #84 structure-refactor epic.

## Changes

- **Hero** — app logo + tagline + badge row (latest release · platforms · CI · license · Electron/Vue/TS) and a table of contents.
- **Features** — accurate, grouped, sourced from `docs/`:
  - *Built-in player*: instant MKV streaming via MSE, frame-accurate seek, HEVC + H.264 transcode fallback, Anime4K WebGPU upscaling, JASSUB/ASS subtitles, quality/translation switching, auto-resume.
  - *Discovery & Shikimori*: two-way sync, offline edit queue, auto-download, friends' activity, chronology, calendar.
  - *Watch Together* (Syncplay), *local OP/ED skip detection* (Chromaprint), *hot/cold storage*, *auto-update*.
- **Download** — new section linking the real per-platform release artifacts (Windows `.exe`, macOS `.dmg`/`.zip`, Linux `.AppImage`/`.deb`).
- **Quick Start** — API token + automatic ffmpeg download.
- **Development** — corrected Node requirement (**20+**, matching CI), full script list + quality gate, pointers to `CLAUDE.md` and `docs/testing.md`.
- **Project Structure** — points at the `DESIGN.md` index + `docs/` (post Phase 6).
- **Acknowledgements** + **License** (ISC).
- `package.json`: add `engines.node: ">=20"` (backs the README claim, matches CI).

## Version

Bumped to **4.0.0** to mark completion of the #84 structure-refactor epic (all 7 phases shipped). CI will cut a `v4.0.0` release on merge.

## Notes

Screenshots were intentionally omitted: the two committed images (`resources/screenshots/*`) are a color-bar test pattern and a "Failed to prepare MKV" error dialog — unsuitable for the README. A follow-up issue tracks capturing real screenshots.

## Test plan

Docs + metadata only; no source or behavior change. Full quality gate green locally:

- `typecheck` ✅ · `lint` ✅ (0 errors) · `format:check` ✅ · `test` ✅ 442/442 · `build` ✅
- Verify on the PR preview: badges load, the logo renders, all relative links (`DESIGN.md`, `docs/`, TOC anchors) resolve, and the Download link points at real release assets.
