### PR TITLE
perf(detail): bulk-fetch episode translations to cut cold load (#155)

### DIFF
--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -33,7 +33,8 @@ Renderer composables that own broadcast subscriptions (e.g. `useShikimori`, `use
 | `get-anime` | invoke | Fetch anime details by ID |
 | `get-anime-cache` | invoke | Read cached AnimeDetail for fast first paint (returns null if missing or older than 24h) |
 | `set-anime-cache` | invoke | Write AnimeDetail to cache (no-op if anime is neither starred nor downloaded) |
-| `get-episode` | invoke | Fetch episode translations |
+| `get-episode` | invoke | Fetch episode translations (single episode) |
+| `get-episodes-batch` | invoke | Bulk-fetch translations for a page of episodes in one request (collapses the per-episode cold-load waterfall, #155); caches each result, falls back to cached episodes on failure |
 | `probe-embed-quality` | invoke | Probe embed API for actual stream height |
 | `report-quality-mismatch` | invoke | Report a detected quality mismatch (stored in memory) |
 | `get-quality-mismatch-count` | invoke | Get number of collected mismatches |

--- a/docs/smotret-api.md
+++ b/docs/smotret-api.md
@@ -4,8 +4,11 @@
 |----------|-------|
 | `GET /api/series/?query=&fields=` | Search anime |
 | `GET /api/series/{id}` | Anime details |
-| `GET /api/episodes/{id}` | Episode + translations |
+| `GET /api/episodes/{id}` | Episode + translations (single episode) |
+| `GET /api/translations/?episodeId[]=…&fields=…` | Bulk translations for many episodes in one request |
 | `GET /api/translations/embed/{id}?access_token=` | Stream URLs + subtitle info |
 | `GET /translations/ass/{id}?download=1` | Subtitle file download |
 
 The embed API returns `stream[]` with direct CDN URLs (used for downloads) and `download[]` with site redirect URLs (not used, causes 403).
+
+`SmotretApi.getEpisodesBatch(ids)` uses the bulk `/translations?episodeId[]=…` endpoint (chunked at 30 ids/request, `limit=5000`) to load an entire episode-list page in one round-trip instead of one `/episodes/{id}` call per episode — this is the cold-load fast path for the anime detail view (#155). Each translation carries a nested `episode` object, so the flat list is grouped back into `EpisodeDetail[]`. Episodes with no translations are absent from the response.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/main/ipc/anime.ipc.ts
+++ b/src/main/ipc/anime.ipc.ts
@@ -78,4 +78,28 @@ export function register({ smotretApi, animeCacheService, rememberAnimeMeta }: A
       throw err
     }
   })
+
+  ipcMain.handle(
+    CHANNELS.GET_EPISODES_BATCH,
+    async (_event, episodeIds: number[], animeId?: number) => {
+      try {
+        const result = await smotretApi.getEpisodesBatch(episodeIds)
+        if (animeId) {
+          for (const ep of result.data) animeCacheService.updateEpisode(animeId, ep.id, ep)
+        }
+        return { ...result, source: 'api' }
+      } catch (err) {
+        if (animeId) {
+          const cached = animeCacheService.getEntry(animeId)
+          if (cached) {
+            const data = episodeIds
+              .map((id) => cached.episodes[id])
+              .filter((d): d is NonNullable<typeof d> => d !== undefined)
+            if (data.length > 0) return { data, source: 'cache' }
+          }
+        }
+        throw err
+      }
+    }
+  )
 }

--- a/src/main/smotret-api.ts
+++ b/src/main/smotret-api.ts
@@ -93,6 +93,59 @@ export class SmotretApi {
     return this.request(`/episodes/${id}`) as Promise<{ data: EpisodeDetail }>
   }
 
+  /**
+   * Bulk-fetch translations for many episodes in a single request via the
+   * `/translations?episodeId[]=…` endpoint, collapsing the per-episode
+   * `/episodes/{id}` waterfall into one round-trip per chunk (issue #155).
+   * Returns one `EpisodeDetail` per episode that has at least one translation,
+   * in the order the ids were requested.
+   */
+  async getEpisodesBatch(episodeIds: number[]): Promise<{ data: EpisodeDetail[] }> {
+    const CHUNK = 30
+    const fields =
+      'id,episodeId,type,typeKind,typeLang,authorsSummary,isActive,width,height,duration,episode'
+    const byEpisode = new Map<number, EpisodeDetail>()
+
+    for (let i = 0; i < episodeIds.length; i += CHUNK) {
+      const chunk = episodeIds.slice(i, i + CHUNK)
+      const params = chunk.map((id) => `episodeId[]=${id}`).join('&')
+      const json = (await this.request(`/translations?${params}&limit=5000&fields=${fields}`)) as {
+        data: (Translation & { episodeId: number; episode?: EpisodeSummary })[]
+      }
+
+      for (const tr of json.data) {
+        let detail = byEpisode.get(tr.episodeId)
+        if (!detail) {
+          const ep = tr.episode
+          detail = {
+            id: tr.episodeId,
+            episodeFull: ep?.episodeFull ?? '',
+            episodeInt: ep?.episodeInt ?? '',
+            episodeType: ep?.episodeType ?? '',
+            translations: []
+          }
+          byEpisode.set(tr.episodeId, detail)
+        }
+        detail.translations.push({
+          id: tr.id,
+          type: tr.type,
+          typeKind: tr.typeKind,
+          typeLang: tr.typeLang,
+          authorsSummary: tr.authorsSummary,
+          isActive: tr.isActive,
+          width: tr.width,
+          height: tr.height,
+          duration: tr.duration
+        })
+      }
+    }
+
+    const data = episodeIds
+      .map((id) => byEpisode.get(id))
+      .filter((d): d is EpisodeDetail => d !== undefined)
+    return { data }
+  }
+
   async getEmbed(translationId: number): Promise<EmbedData> {
     const json = (await this.request(`/translations/embed/${translationId}`)) as { data: EmbedData }
     return json.data

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,8 @@ const api = {
     ipcRenderer.invoke(CHANNELS.SET_ANIME_CACHE, id, data) as Promise<boolean>,
   getEpisode: (id: number, animeId?: number) =>
     ipcRenderer.invoke(CHANNELS.GET_EPISODE, id, animeId),
+  getEpisodesBatch: (episodeIds: number[], animeId?: number) =>
+    ipcRenderer.invoke(CHANNELS.GET_EPISODES_BATCH, episodeIds, animeId),
   probeEmbedQuality: (translationId: number, animeId?: number) =>
     ipcRenderer.invoke(CHANNELS.PROBE_EMBED_QUALITY, translationId, animeId) as Promise<
       number | null

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -28,6 +28,10 @@ interface Api {
   getAnimeCache: (id: number) => Promise<{ data: AnimeDetail; cachedAt: number } | null>
   setAnimeCache: (id: number, data: AnimeDetail) => Promise<boolean>
   getEpisode: (id: number, animeId?: number) => Promise<ApiResponse<EpisodeDetail>>
+  getEpisodesBatch: (
+    episodeIds: number[],
+    animeId?: number
+  ) => Promise<ApiResponse<EpisodeDetail[]>>
   probeEmbedQuality: (translationId: number, animeId?: number) => Promise<number | null>
   getCachedPoster: (animeId: number) => Promise<string | null>
   probeFullScanNeeded: (animeId: number, episodeCount: number) => Promise<boolean>

--- a/src/renderer/src/composables/use-episode-list.ts
+++ b/src/renderer/src/composables/use-episode-list.ts
@@ -277,17 +277,29 @@ export function useEpisodeList(deps: {
     if (!deps.anime.value || pagedEpisodes.value.length === 0) return
     loadingEpisodes.value = true
 
-    const batch = 5
     const toLoad = pagedEpisodes.value.filter((ep) => !episodes.value.has(ep.id))
 
-    for (let i = 0; i < toLoad.length; i += batch) {
-      const chunk = toLoad.slice(i, i + batch)
-      const fetched = await Promise.all(
-        chunk.map((ep) => window.api.getEpisode(ep.id, deps.getAnimeId()).then((r) => r.data))
+    if (toLoad.length > 0) {
+      const res = await window.api.getEpisodesBatch(
+        toLoad.map((ep) => ep.id),
+        deps.getAnimeId()
       )
+      const byId = new Map(res.data.map((d) => [d.id, d]))
       const updated = new Map(episodes.value)
-      for (const ep of fetched) {
-        updated.set(ep.id, ep)
+      for (const ep of toLoad) {
+        // Episodes with no translations are absent from the bulk response —
+        // synthesize an empty detail so the map stays complete and they aren't
+        // re-fetched on every page revisit.
+        updated.set(
+          ep.id,
+          byId.get(ep.id) ?? {
+            id: ep.id,
+            episodeFull: ep.episodeFull,
+            episodeInt: ep.episodeInt,
+            episodeType: ep.episodeType,
+            translations: []
+          }
+        )
       }
       episodes.value = updated
     }

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -151,6 +151,7 @@ export const CHANNELS = {
   GET_ANIME: 'get-anime',
   GET_ANIME_CACHE: 'get-anime-cache',
   GET_EPISODE: 'get-episode',
+  GET_EPISODES_BATCH: 'get-episodes-batch',
   GET_QUALITY_MISMATCH_COUNT: 'get-quality-mismatch-count',
   GET_SETTING: 'get-setting',
   LIBRARY_GET: 'library-get',

--- a/test/api-clients/smotret-api.test.ts
+++ b/test/api-clients/smotret-api.test.ts
@@ -96,6 +96,53 @@ describe('SmotretApi — fixture replay', () => {
     })
   })
 
+  describe('getEpisodesBatch', () => {
+    it('groups the flat translations list into one EpisodeDetail per episode', async () => {
+      mockFetchOnce(fixture('translations-batch.json'))
+      const result = await makeApi().getEpisodesBatch([100, 101])
+      expect(result.data.length).toBe(2)
+      const ep100 = result.data.find((e) => e.id === 100)!
+      expect(ep100.episodeInt).toBe('1')
+      expect(ep100.episodeFull).toBe('1 серия')
+      expect(ep100.episodeType).toBe('tv')
+      expect(ep100.translations.map((t) => t.id).sort()).toEqual([1001, 1002])
+      expect(ep100.translations[0]).toMatchObject({
+        id: 1001,
+        type: 'subtitles',
+        typeKind: 'sub',
+        height: 1080,
+        authorsSummary: 'AniDub'
+      })
+      const ep101 = result.data.find((e) => e.id === 101)!
+      expect(ep101.translations.length).toBe(1)
+      expect(ep101.translations[0].id).toBe(2001)
+    })
+
+    it('returns episodes in the requested order and skips ids with no translations', async () => {
+      mockFetchOnce(fixture('translations-batch.json'))
+      // 999 has no translations in the fixture → absent from the result
+      const result = await makeApi().getEpisodesBatch([101, 999, 100])
+      expect(result.data.map((e) => e.id)).toEqual([101, 100])
+    })
+
+    it('requests episodeId[] for each id and a fields list', async () => {
+      mockFetchOnce(fixture('translations-batch.json'))
+      await makeApi().getEpisodesBatch([100, 101])
+      const url = lastFetchUrl()
+      expect(url).toContain('/translations?')
+      expect(url).toContain('episodeId[]=100')
+      expect(url).toContain('episodeId[]=101')
+      expect(url).toContain('fields=')
+    })
+
+    it('chunks requests at 30 episode ids', async () => {
+      mockFetchOnce(fixture('translations-batch.json'))
+      const ids = Array.from({ length: 31 }, (_, i) => i + 1)
+      await makeApi().getEpisodesBatch(ids)
+      expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2)
+    })
+  })
+
   describe('getEmbed', () => {
     it('unwraps the data envelope and returns EmbedData directly', async () => {
       mockFetchOnce(fixture('embed.json'))

--- a/test/fixtures/smotret/translations-batch.json
+++ b/test/fixtures/smotret/translations-batch.json
@@ -1,0 +1,61 @@
+{
+  "data": [
+    {
+      "id": 1001,
+      "episodeId": 100,
+      "type": "subtitles",
+      "typeKind": "sub",
+      "typeLang": "ru",
+      "authorsSummary": "AniDub",
+      "isActive": 1,
+      "width": 1920,
+      "height": 1080,
+      "duration": "24:00",
+      "episode": {
+        "id": 100,
+        "episodeFull": "1 серия",
+        "episodeInt": "1",
+        "episodeType": "tv",
+        "isActive": 1
+      }
+    },
+    {
+      "id": 1002,
+      "episodeId": 100,
+      "type": "voice",
+      "typeKind": "voice",
+      "typeLang": "ru",
+      "authorsSummary": "AniLibria",
+      "isActive": 1,
+      "width": 1920,
+      "height": 1080,
+      "duration": "24:00",
+      "episode": {
+        "id": 100,
+        "episodeFull": "1 серия",
+        "episodeInt": "1",
+        "episodeType": "tv",
+        "isActive": 1
+      }
+    },
+    {
+      "id": 2001,
+      "episodeId": 101,
+      "type": "subtitles",
+      "typeKind": "sub",
+      "typeLang": "en",
+      "authorsSummary": "HorribleSubs",
+      "isActive": 1,
+      "width": 1280,
+      "height": 720,
+      "duration": "24:00",
+      "episode": {
+        "id": 101,
+        "episodeFull": "2 серия",
+        "episodeInt": "2",
+        "episodeType": "tv",
+        "isActive": 1
+      }
+    }
+  ]
+}

--- a/test/renderer/composables/use-episode-list.test.ts
+++ b/test/renderer/composables/use-episode-list.test.ts
@@ -6,6 +6,7 @@ import { useEpisodeList } from '../../../src/renderer/src/composables/use-episod
 
 type Api = {
   getEpisode: (id: number, animeId: number) => Promise<{ data: EpisodeDetail }>
+  getEpisodesBatch: (episodeIds: number[], animeId: number) => Promise<{ data: EpisodeDetail[] }>
   watchProgressSave: (...args: unknown[]) => Promise<void>
   probeEmbedQuality: (id: number, animeId: number) => Promise<number | null>
   getSetting: (key: string) => Promise<unknown>
@@ -143,6 +144,65 @@ describe('useEpisodeList — filtering & paging', () => {
     expect(list.pagedEpisodes.value.length).toBe(30)
     list.currentPage.value = 1
     expect(list.pagedEpisodes.value.length).toBe(20)
+  })
+})
+
+describe('useEpisodeList — loadPageEpisodes', () => {
+  it('fetches a whole page in a single bulk getEpisodesBatch call (not per-episode)', async () => {
+    const eps: EpisodeSummary[] = []
+    for (let i = 1; i <= 30; i++) eps.push(mkEpisode(i, String(i)))
+    const getEpisodesBatch = vi.fn(async (ids: number[]) => ({
+      data: ids.map((id) => ({
+        id,
+        episodeFull: `Episode ${id}`,
+        episodeInt: String(id),
+        episodeType: 'tv',
+        translations: [mkTr(1000 + id, 'subRu', 'A')]
+      })) as unknown as EpisodeDetail[]
+    }))
+    const getEpisode = vi.fn()
+    setApi({
+      getEpisodesBatch,
+      getEpisode,
+      probeEmbedQuality: vi.fn().mockResolvedValue(null),
+      getSetting: vi.fn().mockResolvedValue(false)
+    })
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const list = useEpisodeList(makeDeps({ anime }))
+
+    await list.loadPageEpisodes()
+
+    expect(getEpisode).not.toHaveBeenCalled()
+    expect(getEpisodesBatch).toHaveBeenCalledTimes(1)
+    expect(getEpisodesBatch.mock.calls[0][0]).toEqual(eps.map((e) => e.id))
+    expect(list.episodes.value.size).toBe(30)
+  })
+
+  it('synthesizes an empty-translation entry for episodes absent from the response', async () => {
+    const eps = [mkEpisode(1, '1'), mkEpisode(2, '2')]
+    setApi({
+      // Only episode 1 comes back with translations; episode 2 is absent.
+      getEpisodesBatch: vi.fn(async () => ({
+        data: [
+          {
+            id: 1,
+            episodeFull: 'Episode 1',
+            episodeInt: '1',
+            episodeType: 'tv',
+            translations: [mkTr(101, 'subRu', 'A')]
+          }
+        ] as unknown as EpisodeDetail[]
+      })),
+      probeEmbedQuality: vi.fn().mockResolvedValue(null),
+      getSetting: vi.fn().mockResolvedValue(false)
+    })
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const list = useEpisodeList(makeDeps({ anime }))
+
+    await list.loadPageEpisodes()
+
+    expect(list.episodes.value.size).toBe(2)
+    expect(list.episodes.value.get(2)?.translations).toEqual([])
   })
 })
 
@@ -316,11 +376,11 @@ describe('useEpisodeList — applyFocusEpisode', () => {
 
   it('marks focus applied even if DOM lookup fails', async () => {
     setApi({
-      getEpisode: vi
-        .fn()
-        .mockImplementation((id: number) =>
-          Promise.resolve({ data: { id, translations: [] } as unknown as EpisodeDetail })
-        ),
+      getEpisodesBatch: vi.fn().mockImplementation((ids: number[]) =>
+        Promise.resolve({
+          data: ids.map((id) => ({ id, translations: [] }) as unknown as EpisodeDetail)
+        })
+      ),
       getSetting: vi.fn().mockResolvedValue(false)
     })
     const eps: EpisodeSummary[] = []


### PR DESCRIPTION
## Summary

The **uncached** first load of an anime detail page took ~2s. The "Loading…" spinner is gated by `getAnime()` **and** `loadPageEpisodes()`, and that path was a network waterfall against the smotret-anime API (each round-trip ~0.5–0.7s):

1. `GET /series/{id}` — 1 round-trip (returns episode summaries, **no** translations).
2. `loadPageEpisodes()` — one `GET /episodes/{id}` **per episode**, in sequential batches of 5. A 30-episode page = up to **6 serial round-trips (~3.3s)**.

This PR replaces the per-episode fan-out with a single bulk request, collapsing stage 2 from `ceil(N/5)` serial round-trips into **one** — flat regardless of episode count.

Fixes #155.

## Changes

- **`SmotretApi.getEpisodesBatch(ids)`** (`src/main/smotret-api.ts`) — hits `GET /api/translations?episodeId[]=…&fields=…&limit=5000` (chunked at 30 ids/request), then groups the flat translation list back into `EpisodeDetail[]` using each translation's nested `episode` object, preserving requested order. Episodes with no translations are absent from the response (handled below).
- **New IPC channel `get-episodes-batch`** wired through all four seams: `src/shared/ipc/channels.ts`, `src/main/ipc/anime.ipc.ts` (caches each result via `animeCacheService.updateEpisode`, falls back to cached episodes on failure → `source: 'cache'`), `src/preload/index.ts`, `src/preload/types.d.ts`.
- **`loadPageEpisodes()`** (`src/renderer/src/composables/use-episode-list.ts`) — one `getEpisodesBatch` call for the whole page instead of the batched `getEpisode` loop. Episodes absent from the bulk response get a synthesized empty-translation entry so the `episodes` Map stays complete and they aren't re-fetched on page revisit.
- **Docs** — `docs/smotret-api.md` (bulk endpoint + `getEpisodesBatch`), `docs/ipc.md` (new channel).

## Behavior

- **Before:** cold-load episode stage = `ceil(pageSize/5)` serial round-trips (~1.7s for 12 eps, ~3.3s for a 30-ep page; longer for paged 100+-ep shows).
- **After:** one bulk request (~1.1s) for the page, independent of episode count. Total cold load is now the series call + one bulk call (~1.5s floor — the two are inherently serial since episode IDs come from the series response).
- Cached/offline path, translation-type counts, author dropdown, per-episode translation selection, and quality probing are all unchanged. The single-episode `get-episode` channel is retained (player + cache fallback still use it).

## Test plan

- **`test/api-clients/smotret-api.test.ts`** — fixture replay for `getEpisodesBatch`: grouping the flat list into one `EpisodeDetail` per episode, field + nested-episode mapping, requested-order preservation, skipping ids with no translations, `episodeId[]=` URL shape, and chunking at 30 ids.
- **`test/renderer/composables/use-episode-list.test.ts`** — regression test asserting `loadPageEpisodes` issues **one** `getEpisodesBatch` call for a 30-ep page and never calls the old per-episode `getEpisode` (fails on the old behavior); plus the empty-translation synthesis case. Updated the existing `applyFocusEpisode` test to the new bulk call.
- New fixture `test/fixtures/smotret/translations-batch.json`.
- Full local quality gate green: **typecheck · lint · format:check · test (477) · build**.
- **Manual:** verified an uncached detail page loads correctly (counts, dropdowns, rows) and faster in the running app; the bulk endpoint was validated against the live API (30 episodes → 950 translations in one ~1.1s request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
