### PR TITLE
test(contract): weekly live API contract check (#141)

### DIFF
--- a/.github/workflows/contract-check.yml
+++ b/.github/workflows/contract-check.yml
@@ -1,0 +1,81 @@
+name: Live API contract check
+
+# Weekly probe against the real shikimori.one + smotret-anime.ru APIs. The
+# fixture-replay tests under test/api-clients/ catch parser drift given the
+# response shape we recorded; this job catches the response shape changing
+# upstream — silent regressions that would otherwise reach a user before us.
+# (#141; complements the fixture suite under test/api-clients/)
+
+on:
+  # Mondays at 06:00 UTC — gentle cadence per the issue review (APIs move
+  # slowly; nightly trains us to ignore the alert).
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - id: run
+        run: npm run test:contract
+        continue-on-error: true
+
+      - name: Open or update sticky contract-drift issue on failure
+        if: steps.run.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Find an existing open contract-drift issue (sticky).
+          EXISTING=$(gh issue list --label contract-drift --state open --json number \
+            --jq '.[0].number' || echo "")
+
+          BODY=$(cat <<EOF
+          The weekly live API contract check (\`.github/workflows/contract-check.yml\`)
+          failed on $(date -u +%Y-%m-%dT%H:%M:%SZ).
+
+          Run: $RUN_URL
+
+          Likely cause: a response shape change at \`shikimori.one\` or
+          \`smotret-anime.ru\` made one of our parsers' required fields
+          missing or wrong-typed. Update the affected fixture(s) under
+          \`test/fixtures/\` and the corresponding TypeScript interface(s) in
+          \`src/main/shikimori.ts\` or \`src/main/smotret-api.ts\`, then verify
+          \`npm run test:contract\` is green locally before closing this issue.
+          EOF
+          )
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing contract-drift issue #$EXISTING"
+            echo "$BODY" | gh issue comment "$EXISTING" --body-file -
+          else
+            echo "Creating new contract-drift issue"
+            echo "$BODY" | gh issue create \
+              --title "Live API contract check failed" \
+              --label contract-drift \
+              --body-file -
+          fi
+
+      # Surface the failure on the workflow page itself too. The notify step
+      # above creates an issue; this re-fails the job so the green-checkmark
+      # heuristic in the Actions UI doesn't lie about the contract state.
+      - name: Re-fail on contract-test failure
+        if: steps.run.outcome == 'failure'
+        run: |
+          echo "Contract tests failed — see issue created above." >&2
+          exit 1

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,10 +3,11 @@
 Two runners, split by what they touch (refactor epic #84, Phase 7):
 
 ```bash
-npm run test            # Vitest: unit + integration (no Electron)
+npm run test            # Vitest: unit + integration (no Electron, no network)
 npm run test:watch      # Vitest in watch mode
 npm run test:coverage   # Vitest + v8 coverage; enforces per-seam thresholds
 npm run test:e2e        # Playwright: drives the built app in out/ (run `npm run build` first)
+npm run test:contract   # Vitest: live API contract check (hits shikimori.one + smotret-anime.ru)
 ```
 
 ## Layers
@@ -36,6 +37,21 @@ npm run test:e2e        # Playwright: drives the built app in out/ (run `npm run
   player seek, live Shikimori sync) are deliberately excluded to keep CI
   deterministic; their underlying logic is covered at the unit + integration
   layers.
+
+- **Live API contract** (`test/contract/`, separate `vitest.contract.config.ts`)
+  — weekly probe against the real `shikimori.one` + `smotret-anime.ru` APIs,
+  asserting our parsers' required fields are still present and the right
+  primitive type. Excluded from `npm run test` so PRs stay offline; runs only
+  via `npm run test:contract` or the `Live API contract check` GitHub workflow
+  (`.github/workflows/contract-check.yml`, Mondays 06:00 UTC + manual dispatch).
+  Anonymous endpoints only — no OAuth tokens in CI. Assertions are
+  intentionally **loose** (parse succeeds, required fields non-null) so
+  upstream adding new optional fields doesn't trip us. On failure the workflow
+  opens or comments on a sticky issue tagged `contract-drift`; investigate by
+  re-recording the affected fixture under `test/fixtures/` and updating the
+  matching TypeScript interface in `src/main/shikimori.ts` or
+  `src/main/smotret-api.ts`, then verify `npm run test:contract` passes
+  locally before closing the issue. (#141)
 
 ## IPC contract guard
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {
@@ -24,6 +24,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:contract": "vitest run --config vitest.contract.config.ts",
     "check:subscription-contract": "bash scripts/check-subscription-contract.sh",
     "screenshot": "node scripts/screenshot.js"
   },

--- a/test/contract/shikimori.contract.test.ts
+++ b/test/contract/shikimori.contract.test.ts
@@ -1,0 +1,126 @@
+// Live contract test against shikimori.one (#141).
+//
+// These tests are EXCLUDED from the default `npm run test` suite (see
+// `test/contract/**` in vitest.config.ts) — they hit the real API over the
+// network and would flake any PR run. Triggered weekly by
+// `.github/workflows/contract-check.yml`, or locally via `npm run test:contract`.
+//
+// Per the review on #141: only anonymous endpoints, only LOOSE assertions
+// (parser doesn't throw, required fields present + correct primitive type).
+// Upstream is free to add new optional fields without tripping us.
+
+import { describe, it, expect } from 'vitest'
+
+const BASE = 'https://shikimori.one'
+const UA = 'anime-dl-app/contract-check'
+
+// Steins;Gate — picked as a stable, long-released MAL id that won't disappear.
+const STABLE_MAL_ID = 9253
+
+async function getJson(path: string): Promise<unknown> {
+  const res = await fetch(`${BASE}${path}`, { headers: { 'User-Agent': UA } })
+  if (!res.ok) throw new Error(`shikimori ${path}: HTTP ${res.status} ${res.statusText}`)
+  return res.json()
+}
+
+function requireString(obj: Record<string, unknown>, key: string): void {
+  expect(obj[key], `expected ${key} to be a non-empty string`).toEqual(expect.any(String))
+  expect((obj[key] as string).length, `expected ${key} to be non-empty`).toBeGreaterThan(0)
+}
+
+function requireNumber(obj: Record<string, unknown>, key: string): void {
+  expect(obj[key], `expected ${key} to be a number`).toEqual(expect.any(Number))
+}
+
+describe('Shikimori live contract', () => {
+  // Run sequentially to be polite to upstream; total elapsed is ~1–2s.
+  it(`GET /api/animes/${STABLE_MAL_ID} returns ShikiAnimeDetails-shaped payload`, async () => {
+    const anime = (await getJson(`/api/animes/${STABLE_MAL_ID}`)) as Record<string, unknown>
+
+    // Required scalars from src/main/shikimori.ts → ShikiAnimeDetails.
+    requireNumber(anime, 'id')
+    requireString(anime, 'name')
+    requireString(anime, 'russian')
+    requireString(anime, 'kind')
+    requireString(anime, 'rating')
+    requireNumber(anime, 'duration')
+    requireString(anime, 'score')
+    requireString(anime, 'status')
+    requireNumber(anime, 'episodes')
+    requireNumber(anime, 'episodes_aired')
+
+    expect(anime.genres, 'genres must be an array').toBeInstanceOf(Array)
+    expect((anime.genres as unknown[]).length).toBeGreaterThan(0)
+    const g = (anime.genres as Record<string, unknown>[])[0]
+    requireNumber(g, 'id')
+    requireString(g, 'name')
+    requireString(g, 'russian')
+    requireString(g, 'kind')
+
+    expect(anime.studios, 'studios must be an array').toBeInstanceOf(Array)
+    if ((anime.studios as unknown[]).length > 0) {
+      const s = (anime.studios as Record<string, unknown>[])[0]
+      requireNumber(s, 'id')
+      requireString(s, 'name')
+      requireString(s, 'filtered_name')
+      expect(typeof s.real).toBe('boolean')
+    }
+  })
+
+  it(`GET /api/animes/${STABLE_MAL_ID}/franchise returns ShikiFranchise-shaped payload`, async () => {
+    const f = (await getJson(`/api/animes/${STABLE_MAL_ID}/franchise`)) as Record<string, unknown>
+
+    requireNumber(f, 'current_id')
+    expect(f.nodes, 'nodes must be an array').toBeInstanceOf(Array)
+    expect(f.links, 'links must be an array').toBeInstanceOf(Array)
+    expect((f.nodes as unknown[]).length).toBeGreaterThan(0)
+
+    const n = (f.nodes as Record<string, unknown>[])[0]
+    requireNumber(n, 'id')
+    requireString(n, 'name')
+    requireString(n, 'image_url')
+    requireString(n, 'url')
+    requireNumber(n, 'weight')
+
+    if ((f.links as unknown[]).length > 0) {
+      const l = (f.links as Record<string, unknown>[])[0]
+      requireNumber(l, 'id')
+      requireNumber(l, 'source_id')
+      requireNumber(l, 'target_id')
+      requireNumber(l, 'weight')
+      requireString(l, 'relation')
+    }
+  })
+
+  it('GET /api/calendar returns ShikiCalendarEntry[] -shaped payload', async () => {
+    const entries = (await getJson('/api/calendar')) as Record<string, unknown>[]
+    expect(entries, 'response must be an array').toBeInstanceOf(Array)
+    // Calendar can technically be empty if nothing is airing — only validate
+    // the shape if there's something to validate against.
+    if (entries.length === 0) return
+
+    const entry = entries[0]
+    expect(entry.next_episode === null || typeof entry.next_episode === 'number').toBe(true)
+    expect(entry.next_episode_at === null || typeof entry.next_episode_at === 'string').toBe(true)
+    expect(entry.duration === null || typeof entry.duration === 'number').toBe(true)
+
+    const anime = entry.anime as Record<string, unknown>
+    expect(anime, 'entry.anime must be an object').toBeTypeOf('object')
+    requireNumber(anime, 'id')
+    requireString(anime, 'name')
+    requireString(anime, 'russian')
+    requireString(anime, 'url')
+    requireString(anime, 'kind')
+    requireString(anime, 'score')
+    requireString(anime, 'status')
+    requireNumber(anime, 'episodes')
+    requireNumber(anime, 'episodes_aired')
+
+    const img = anime.image as Record<string, unknown>
+    expect(img, 'entry.anime.image must be an object').toBeTypeOf('object')
+    requireString(img, 'original')
+    requireString(img, 'preview')
+    requireString(img, 'x96')
+    requireString(img, 'x48')
+  })
+})

--- a/test/contract/smotret-api.contract.test.ts
+++ b/test/contract/smotret-api.contract.test.ts
@@ -1,0 +1,109 @@
+// Live contract test against smotret-anime.ru (#141).
+//
+// Excluded from the default `npm run test` suite — runs weekly via
+// `.github/workflows/contract-check.yml` or locally via `npm run test:contract`.
+//
+// Anonymous (empty-token) requests only — sufficient for searchAnime, getAnime,
+// getEpisode, and the new getEpisodesBatch path. getEmbed requires a token and
+// is intentionally out of scope. Assertions are LOOSE per the review on #141:
+// parser doesn't throw, required fields present.
+
+import { describe, it, expect } from 'vitest'
+import { SmotretApi } from '../../src/main/smotret-api'
+
+const api = new SmotretApi(() => '')
+
+function requireString(obj: Record<string, unknown>, key: string): void {
+  expect(obj[key], `expected ${key} to be a string`).toEqual(expect.any(String))
+}
+
+function requireNumber(obj: Record<string, unknown>, key: string): void {
+  expect(obj[key], `expected ${key} to be a number`).toEqual(expect.any(Number))
+}
+
+describe('smotret-anime live contract', () => {
+  // The chain: search → anime → episodes-batch / episode. Each step uses the
+  // ID from the previous, so we don't pin smotret-anime-specific IDs (those
+  // are less stable than MAL ids).
+  it('search → anime → episodes-batch + episode covers the cold-load path', async () => {
+    // 1) searchAnime — non-empty result with the basic AnimeSearchResult shape.
+    const searchResult = await api.searchAnime('Steins;Gate')
+    expect(searchResult.data, 'searchAnime.data must be an array').toBeInstanceOf(Array)
+    expect(searchResult.data.length, 'search "Steins;Gate" must have results').toBeGreaterThan(0)
+
+    // Prefer a result that has episodes (some entries are 0-episode placeholders).
+    const seed = searchResult.data.find((r) => r.numberOfEpisodes > 0) ?? searchResult.data[0]
+    const s = seed as unknown as Record<string, unknown>
+    requireNumber(s, 'id')
+    requireString(s, 'title')
+    requireNumber(s, 'numberOfEpisodes')
+    requireString(s, 'type')
+    requireString(s, 'typeTitle')
+    expect(seed.titles, 'titles must be an object').toBeTypeOf('object')
+
+    // 2) getAnime — full AnimeDetail with episodes array + genres + descriptions.
+    const animeRes = await api.getAnime(seed.id)
+    const anime = animeRes.data as unknown as Record<string, unknown>
+    requireNumber(anime, 'id')
+    requireString(anime, 'title')
+    requireString(anime, 'posterUrl')
+    expect(anime.episodes, 'anime.episodes must be an array').toBeInstanceOf(Array)
+    expect(anime.genres, 'anime.genres must be an array').toBeInstanceOf(Array)
+    expect(anime.descriptions, 'anime.descriptions must be an array').toBeInstanceOf(Array)
+
+    const episodes = anime.episodes as Record<string, unknown>[]
+    // Some shows have 0 episodes (announcements). Skip the episode-level shape
+    // checks in that case — they aren't a contract breakage.
+    if (episodes.length === 0) return
+
+    const firstEp = episodes[0]
+    requireNumber(firstEp, 'id')
+    requireString(firstEp, 'episodeFull')
+    requireString(firstEp, 'episodeInt')
+    requireString(firstEp, 'episodeType')
+    requireNumber(firstEp, 'isActive')
+
+    // 3) getEpisodesBatch — the new bulk path (#155). Pull the first three
+    //    active episodes and confirm the response shape we depend on.
+    const activeIds = episodes
+      .filter((e) => e.isActive === 1)
+      .slice(0, 3)
+      .map((e) => e.id as number)
+    if (activeIds.length === 0) return
+
+    const batchRes = await api.getEpisodesBatch(activeIds)
+    expect(batchRes.data, 'getEpisodesBatch.data must be an array').toBeInstanceOf(Array)
+    expect(
+      batchRes.data.length,
+      'getEpisodesBatch must return at least one episode'
+    ).toBeGreaterThan(0)
+
+    const batchEp = batchRes.data[0] as unknown as Record<string, unknown>
+    requireNumber(batchEp, 'id')
+    requireString(batchEp, 'episodeFull')
+    requireString(batchEp, 'episodeInt')
+    requireString(batchEp, 'episodeType')
+    expect(batchEp.translations, 'translations must be an array').toBeInstanceOf(Array)
+    if ((batchEp.translations as unknown[]).length > 0) {
+      const t = (batchEp.translations as Record<string, unknown>[])[0]
+      requireNumber(t, 'id')
+      requireString(t, 'type')
+      requireString(t, 'typeKind')
+      requireString(t, 'typeLang')
+      requireString(t, 'authorsSummary')
+      requireNumber(t, 'isActive')
+      requireNumber(t, 'width')
+      requireNumber(t, 'height')
+    }
+
+    // 4) getEpisode (single) — the legacy path still used by the player +
+    //    cache-fallback. Confirm one round-trip.
+    const single = await api.getEpisode(activeIds[0])
+    const singleEp = single.data as unknown as Record<string, unknown>
+    requireNumber(singleEp, 'id')
+    requireString(singleEp, 'episodeFull')
+    requireString(singleEp, 'episodeInt')
+    requireString(singleEp, 'episodeType')
+    expect(singleEp.translations, 'single-ep translations must be an array').toBeInstanceOf(Array)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,11 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts', 'src/**/*.test.ts'],
-    exclude: ['node_modules/**', 'out/**', 'dist/**', 'e2e/**'],
+    // `test/contract/**` is the live-API contract check (#141): real network
+    // calls to shikimori.one + smotret-anime.ru, run weekly by
+    // `.github/workflows/contract-check.yml` via `npm run test:contract`, not
+    // here. Keeping it out of the default suite means PR runs stay offline.
+    exclude: ['node_modules/**', 'out/**', 'dist/**', 'e2e/**', 'test/contract/**'],
     setupFiles: ['./test/setup/electron-mock.ts'],
     coverage: {
       provider: 'v8',

--- a/vitest.contract.config.ts
+++ b/vitest.contract.config.ts
@@ -1,0 +1,29 @@
+// Vitest config for the weekly live-API contract suite (#141).
+//
+// `vitest.config.ts` excludes `test/contract/**` so PRs don't hit the network;
+// this config flips that — only the contract tests run, against real upstreams.
+// Wired into `npm run test:contract` + the contract-check workflow.
+
+import { resolve } from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@shared': resolve('src/shared'),
+      '@main': resolve('src/main'),
+      '@renderer': resolve('src/renderer/src')
+    }
+  },
+  test: {
+    environment: 'node',
+    include: ['test/contract/**/*.test.ts'],
+    exclude: ['node_modules/**', 'out/**', 'dist/**', 'e2e/**'],
+    setupFiles: ['./test/setup/electron-mock.ts'],
+    // Live network — give each request more headroom than the default 5s, and
+    // run tests serially to be polite to upstream.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+    fileParallelism: false
+  }
+})


### PR DESCRIPTION
## Summary

Implements the live-API contract check approved in the #141 review. Fixture-replay tests under `test/api-clients/` keep our parsers pinned to a recorded response shape; this PR adds a weekly probe against the *live* `shikimori.one` + `smotret-anime.ru` APIs and pages us when a required field disappears or changes type — silent regressions that would otherwise reach a user before us.

Fixes #141.

## What's in here

| Piece | Path |
|---|---|
| Shikimori contract suite (calendar, animes/:id, animes/:id/franchise) | `test/contract/shikimori.contract.test.ts` |
| Smotret-anime contract suite (search → anime → episodes-batch + episode) | `test/contract/smotret-api.contract.test.ts` |
| Contract-only vitest config (longer timeouts, serial, includes `test/contract/**`) | `vitest.contract.config.ts` |
| Default suite excludes `test/contract/**` (PRs stay offline) | `vitest.config.ts` |
| `npm run test:contract` script | `package.json` |
| Weekly workflow + sticky `contract-drift` issue | `.github/workflows/contract-check.yml` |
| Docs entry | `docs/testing.md` |

The `contract-drift` label was created on the repo (orange, autodescribed) — the workflow uses it to find/update the sticky issue.

## How the review settled the open questions

| # | Question | Choice (per @mikkerlo's review) | Reflected in |
|---|---|---|---|
| 1 | Auth | Anonymous endpoints only | Tests never pass a real token; smotret client constructed with `() => ''`. |
| 2 | Cadence | Weekly | `cron: '0 6 * * 1'` (Mon 06:00 UTC). |
| 3 | Failure UX | Auto-created issue, label `contract-drift` | Workflow finds-or-creates a sticky open issue, appends a comment per failure with the run URL. |
| 4 | Scope | Shikimori + smotret only, no AniSkip | Two suites; AniSkip remains provisional per `project_aniskip_provisional`. |
| 5 | Assertion tightness | **Loose** | Tests assert parse-succeeds + required fields non-null with the right primitive type. Upstream adding new optional fields won't trip us. |

## Design deviation worth flagging

The issue's sketch suggested adding a `VITEST_LIVE_CONTRACT=1` branch *inside* the existing `test/api-clients/{shikimori,smotret-api}.test.ts` files. I went with a separate `test/contract/` folder + a dedicated `vitest.contract.config.ts` instead:

- The fixture-replay tests stay PR-blocking and focused on **canned values** from recorded payloads.
- The live contract tests use **loose-shape assertions** — they're a fundamentally different test, and mixing both modes in one file with an env-flag would have made the fixture suite harder to read.
- Same end-state (PRs stay offline; live check runs only on the scheduled workflow).

## Behavior

- **PR runs:** `npm run test` still passes 477/477, contract folder excluded — no network touched. Coverage thresholds + IPC contract guard unchanged.
- **Weekly job:** runs `npm run test:contract`; on parse failure or missing-required-field, opens a sticky `contract-drift` issue (or comments on the existing one) with the run URL, then re-fails the workflow step so the Actions UI doesn't show a misleading green checkmark.
- **Manual dispatch** is wired (`workflow_dispatch:`) so you can trigger a fresh run any time from the Actions tab.

## Test plan

- `npm run test:contract` — verified against the live APIs locally, **4/4 passed in ~4s**. Will also run via `workflow_dispatch` once this lands on `main`.
- Full quality gate green locally: **typecheck · lint · format:check · check:subscription-contract · test (477) · build**.
- I'll trigger the workflow manually on `main` post-merge and report back; if it goes red I'll address before next Monday's scheduled run.

## What's deliberately out of scope (logged in #141)

- "2–3 consecutive failures before paging" debounce — weekly cadence + loose assertions already kill most false-positive sources; revisit if it gets noisy.
- Separating transient 5xx from parse failures.
- Authenticated-endpoint coverage (`whoami`, `user_rates`, `friends`, `history`) — would require provisioning a bot account; not worth the leak risk for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
