### PR TITLE
fix(syncplay): drop misleading 'Auto-reconnect disabled' error in disconnect status (#119)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.0.6",
+  "version": "4.0.7",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/main/syncplay.ts
+++ b/src/main/syncplay.ts
@@ -695,19 +695,26 @@ export class SyncplayClient extends EventEmitter {
       return
     }
     if (!cfg.autoReconnect || this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-      const reason =
-        this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS
-          ? 'Max reconnect attempts reached'
-          : 'Auto-reconnect disabled'
+      const maxedOut = this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS
+      // status.error surfaces in the UI (test-connection button, player
+      // popover). 'Auto-reconnect disabled' is *why we're not retrying*, not
+      // *why we disconnected* — showing it as the error confuses users (#119).
+      // Use a neutral 'Connection closed' for the user-initiated-off case;
+      // the room-event log still carries the retry-state for diagnostics.
+      const errorReason = maxedOut ? 'Max reconnect attempts reached' : 'Connection closed'
+      const eventReason = maxedOut ? 'Max reconnect attempts reached' : 'auto-reconnect disabled'
       this.setStatus({
         state: 'disconnected',
         host: cfg.host,
         port: cfg.port,
         room: cfg.room,
         username: cfg.username,
-        error: reason
+        error: errorReason
       })
-      this.emit('room-event', { level: 'warn', text: `Disconnected from Syncplay room: ${reason}` })
+      this.emit('room-event', {
+        level: 'warn',
+        text: `Disconnected from Syncplay room: ${eventReason}`
+      })
       return
     }
     this.reconnectAttempts += 1

--- a/test/services/syncplay-disconnect-reason.test.ts
+++ b/test/services/syncplay-disconnect-reason.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+
+class FakeSocket extends EventEmitter {
+  setKeepAlive = vi.fn()
+  destroy = vi.fn()
+  write = vi.fn()
+}
+
+let lastSocket: FakeSocket | null = null
+
+vi.mock('net', () => ({
+  createConnection: vi.fn(() => {
+    lastSocket = new FakeSocket()
+    return lastSocket
+  })
+}))
+
+vi.mock('tls', () => ({
+  connect: vi.fn(() => new FakeSocket())
+}))
+
+import { SyncplayClient } from '../../src/main/syncplay'
+
+describe('SyncplayClient onSocketClose disconnect reason (#119)', () => {
+  let client: SyncplayClient
+  let statuses: Array<{ state: string; error?: string }>
+
+  beforeEach(() => {
+    lastSocket = null
+    client = new SyncplayClient()
+    statuses = []
+    client.on('connection-status', (s) => statuses.push(s as { state: string; error?: string }))
+  })
+
+  it('emits "Connection closed" (not "Auto-reconnect disabled") when autoReconnect is off and the socket drops', () => {
+    client.connect({
+      host: 'example.test',
+      port: 8999,
+      room: 'r',
+      username: 'u',
+      autoReconnect: false
+    })
+    expect(lastSocket).not.toBeNull()
+    // Simulate the socket dropping without ever connecting.
+    lastSocket!.emit('close')
+
+    const last = statuses[statuses.length - 1]
+    expect(last.state).toBe('disconnected')
+    expect(last.error).toBe('Connection closed')
+    expect(last.error).not.toBe('Auto-reconnect disabled')
+  })
+
+  it('still reports "Max reconnect attempts reached" when retries are exhausted', () => {
+    client.connect({
+      host: 'example.test',
+      port: 8999,
+      room: 'r',
+      username: 'u',
+      autoReconnect: true
+    })
+    // Force the client past the max-attempts threshold so onSocketClose hits
+    // the "give up" branch on the next close.
+    ;(client as unknown as { reconnectAttempts: number }).reconnectAttempts = 5
+    lastSocket!.emit('close')
+
+    const last = statuses[statuses.length - 1]
+    expect(last.state).toBe('disconnected')
+    expect(last.error).toBe('Max reconnect attempts reached')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the papercut from #119 where pressing **Settings › Watch Together › Test connection** could surface the misleading error *"Auto-reconnect disabled"* even when the user's saved Auto-reconnect setting was ON.

## Root cause

When the Syncplay socket closes while `autoReconnect` is off — either because the user disabled it in Settings, or because `testSyncplayConnection` forces it off so the one-shot probe can disconnect cleanly — `src/main/syncplay.ts:697` writes `'Auto-reconnect disabled'` into `status.error`. That phrase is *why we're not retrying*, not *why we disconnected*; treating it as the error string confuses any UI that just renders `status.error` verbatim (test button **and** the in-player Syncplay popover).

## Changes

- `src/main/syncplay.ts` — split the give-up branch into two reasons. `status.error` is now the neutral `'Connection closed'` when auto-reconnect is intentionally off, and stays `'Max reconnect attempts reached'` when retries are exhausted (that one is genuinely informative). The `room-event` log line keeps the diagnostic `auto-reconnect disabled` mention so debug traces still tell the full story.
- `test/services/syncplay-disconnect-reason.test.ts` — new regression test. Mocks `net`/`tls`, drives the socket `close` event, asserts both branches. Verified to fail on the pre-fix code.

## Behavior

- Test connection w/ Auto-reconnect ON → never shows *"Auto-reconnect disabled"*. Network failures show their underlying reason (or `Connection closed` if the socket dropped silently). Successful tests still show *"Connected successfully"*.
- Test connection w/ Auto-reconnect OFF → same; saved `syncplay.autoReconnect` value remains untouched (the test still forces `autoReconnect: false` over the wire, but that no longer leaks the misleading string back into the UI).
- In-player Syncplay popover also benefits — a manual disconnect (with auto-reconnect off) no longer shows the same misleading error chip.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings)
- [x] `npm run format:check`
- [x] `npm run test` — 479 tests pass, including the new 2 cases
- [x] `npm run build`
- [x] Regression test verified to fail on main (`Expected: 'Connection closed' / Received: 'Auto-reconnect disabled'`) and pass with the fix.

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)