### PR TITLE
ci(check): gate /build comment trigger on author association

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,13 @@ jobs:
     # Detect whether a PR touches anything other than docs. Output is consumed by
     # the build job to skip the artifact build (and the artifacts comment) when
     # only documentation changed. /build comments bypass this check entirely.
+    #
+    # The issue_comment trigger runs in the default-branch context with the repo
+    # token, so gate /build on author association — only trusted maintainers may
+    # build untrusted PR head code here (prevents cache poisoning / CWE-349).
     if: >
       github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,7 +48,7 @@ jobs:
     needs: changes
     if: >
       (github.event_name == 'pull_request' && needs.changes.outputs.code == 'true') ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     strategy:
       matrix:
         include:
@@ -115,10 +119,11 @@ jobs:
   comment-artifacts:
     needs: build
     runs-on: ubuntu-latest
-    # Run for non-draft PRs or when triggered by a /build comment
+    # Run for non-draft PRs or when triggered by a /build comment from a trusted
+    # maintainer (see the author-association gate on the build job).
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build'))
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '/build') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary

Resolves the three open CodeQL code-scanning alerts (#11, #12, #13 — `actions/cache-poisoning/poisonable-step`, CWE-349) in `.github/workflows/check.yml`.

All three flag the `build` job's `issue_comment` (`/build` comment) path. `issue_comment` events run in the **default-branch context** with the repo's `GITHUB_TOKEN`. The job checks out `refs/pull/N/head` (the PR head, which can be a fork) and runs it — `npm ci` (arbitrary postinstall), `electron-vite build`, etc. Because there was **no author gate**, any GitHub user could comment `/build` on a malicious PR and execute untrusted code in that privileged context, which is the precondition for cache poisoning and lateral movement into privileged workflows.

A prior fix (`dda350e`) disabled the npm cache on this path via a ternary, but CodeQL can't statically prove the ternary resolves to empty, so it still flags every step after the untrusted checkout — and the underlying "untrusted code in default-branch context" risk remained.

## Changes

- Add an author-association gate — `contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)` — to the `/build` `issue_comment` condition on the `changes`, `build`, and `comment-artifacts` jobs.
- Only trusted maintainers can now trigger a build of untrusted PR head code, implementing the rule's recommendation to never run untrusted code in the default-branch context.

## Behavior

- `pull_request` builds: unchanged (run in PR-branch context; fork PRs already can't write the base cache).
- `/build` comments from OWNER/MEMBER/COLLABORATOR: unchanged.
- `/build` comments from anyone else (CONTRIBUTOR, NONE, etc.): now ignored — the build job no longer runs untrusted code on their behalf.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Expression syntax is the standard `contains(fromJSON([...]), author_association)` allow-list pattern.
- [ ] CodeQL re-scans this PR / on merge to `main` and auto-resolves alerts #11-13.
- [ ] Manual: a `/build` comment from a maintainer still produces artifacts; a `/build` from a non-collaborator is a no-op.

> Note: this is a GitHub Actions workflow change with no app-code surface, so it isn't covered by the Vitest/Playwright suites; CodeQL itself is the verifying check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)