### PR TITLE
feat(ui): Refined Dark design-token foundation + restyle Sidebar/AnimeCard (#161)

### DIFF
--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -50,8 +50,9 @@ src/renderer/src/
       DebugTab.vue
   composables/                 Reactive logic (15 modules — see below)
   stores/                      Pinia stores (5 stores — see below)
-  assets/                      Shared CSS imported scoped into each component
-    player-menus.css
+  assets/                      Shared CSS
+    theme.css                  Global design tokens + base + shared primitives (imported once in main.ts)
+    player-menus.css           Imported scoped into each component
     settings-tabs.css
 ```
 
@@ -101,6 +102,15 @@ Global reactive logic that doesn't belong on a Pinia store goes into `src/render
 ### Settings
 
 - **`useSettingsAutosave`** (`use-settings-autosave.ts`) — module-level singleton holding `savedVisible` + `showSaved` + `autoSave(key, value)`. Every tab calls `autoSave(...)` in its watchers; `SettingsShell` renders the toast. (Phase 5 slice 5a)
+
+## Design system (Refined Dark)
+
+`assets/theme.css` is the global styling foundation, imported once in `main.ts` (before `App.vue`). It defines the **Refined Dark** design language — the locked output of the [redesign epic #160](https://github.com/mikkerlo/anime-downloader/issues/160) (foundation: #161):
+
+- **Tokens on `:root`** — surfaces (`--bg`, `--surface`, `--surface-2/3`), borders, text (`--text`, `--text-2/3`, `--text-faint`), accent (`--accent: #ef4d67` + `color-mix`-derived `--accent-hover/-soft/-line/-ink`), a status palette (`--st-blue/green/orange/purple/red`, `--star`), radii, regular-density spacing (`--gap`, `--pad-x/y`, `--row-pad`, `--poster-grid`), and font vars. Re-theming is a one-file edit; the multi-direction / density / Tweaks machinery from the design prototype was intentionally dropped.
+- **Fonts are bundled, not CDN** — `main.ts` imports the needed weights of **Manrope** (`--font-ui`/`--font-display`) and **JetBrains Mono** (`--font-data`, used for speeds/sizes/ETAs/episode numbers) from `@fontsource/*`. The per-weight CSS ships every subset incl. **Cyrillic** (Russian titles). No network dependency, so the app's offline modes render correctly. A guard test (`test/renderer/theme-tokens.test.ts`) fails the build on any remote `url()` / `@import` / Google Fonts reference in renderer source.
+- **Base + scrollbar** — the reset, `body`, `.app`, and themed scrollbar live here (moved out of `App.vue`).
+- **Shared primitives** — global classes the redesigned chrome uses: the `.sidebar` family (logo mark, `.nav-group`/`.nav-item` + count pill, `.user-chip`), the `.acard` poster-grid card (with its `.poster-wrap`/`.star-btn`/`.score-badge`/`.watch-bar` nested **under `.acard`** so they don't leak onto the bare `.poster`/`.score-badge` classes other not-yet-restyled components still own), `.pbar`, `.pill-tabs`, `.select-wrap`, `.empty-state`, `.poster-grid`. Generic colliding primitives (`.btn`, `.chip`, bare `.poster`, `.topbar`) are deliberately **not** globalized yet — they're added by the per-screen redesign issues that adopt them, to avoid changing screens that haven't been restyled.
 
 ## Path aliases
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "anime-dl-app",
-  "version": "4.0.5",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anime-dl-app",
-      "version": "4.0.5",
+      "version": "4.1.0",
       "license": "ISC",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/manrope": "^5.2.8",
         "anime4k-webgpu": "^1.0.0",
         "electron-store": "^8.2.0",
         "electron-updater": "^6.8.3",
@@ -26,6 +28,7 @@
         "@types/fluent-ffmpeg": "^2.1.28",
         "@vitejs/plugin-vue": "^6.0.5",
         "@vitest/coverage-v8": "^3.2.4",
+        "@vue/test-utils": "^2.4.10",
         "electron": "^41.1.0",
         "electron-builder": "^26.8.1",
         "electron-vite": "^5.0.0",
@@ -33,6 +36,7 @@
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-vue": "^9.33.0",
         "globals": "^15.15.0",
+        "happy-dom": "^20.9.0",
         "playwright": "^1.59.1",
         "prettier": "^3.8.3",
         "typescript": "^6.0.2",
@@ -91,6 +95,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -746,6 +751,68 @@
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+      "integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "cross-dirname": "^0.1.0",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.1.1",
+        "minimist": "^1.2.8",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.js"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/windows-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -1411,6 +1478,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/manrope": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.2.8.tgz",
+      "integrity": "sha512-gJHJmcuUk7qWcNCfcAri/DJQtXtBYqi9yKratr4jXhSo0I3xUtNNKI+igQIcw5c+m95g0vounk8ZnX/kb8o0TA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1779,6 +1864,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -2322,6 +2414,23 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
@@ -2377,6 +2486,7 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2811,6 +2921,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
       "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.32",
         "@vue/shared": "3.5.32"
@@ -2942,6 +3053,27 @@
       "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+      "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
@@ -2988,6 +3120,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3021,6 +3154,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3519,6 +3653,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4094,6 +4229,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4134,6 +4280,14 @@
       "dependencies": {
         "buffer": "^5.1.0"
       }
+    },
+    "node_modules/cross-dirname": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+      "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4401,6 +4555,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -4543,6 +4698,81 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ejs": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -4565,6 +4795,7 @@
       "integrity": "sha512-0OKLiymqfV0WK68RBXqAm3Myad2TpI5wwxLCBEUcH5Nugo3YfSk7p1Js/AL9266qTz5xZioUnxt9hG8FFwax0g==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^24.9.0",
@@ -4829,7 +5060,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -4850,7 +5080,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5064,6 +5293,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5971,6 +6201,25 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6237,6 +6486,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -6456,6 +6712,116 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7009,7 +7375,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -7503,6 +7868,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7632,6 +7998,34 @@
         "node": ">=4"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7702,6 +8096,13 @@
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -7865,7 +8266,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -8408,7 +8808,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -8703,6 +9102,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8853,6 +9253,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9450,6 +9851,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -9529,6 +9931,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/compiler-sfc": "3.5.32",
@@ -9544,6 +9947,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.2.tgz",
+      "integrity": "sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "9.4.3",
@@ -9658,6 +10068,16 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -9743,6 +10163,28 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {
@@ -72,6 +72,7 @@
     "@types/fluent-ffmpeg": "^2.1.28",
     "@vitejs/plugin-vue": "^6.0.5",
     "@vitest/coverage-v8": "^3.2.4",
+    "@vue/test-utils": "^2.4.10",
     "electron": "^41.1.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
@@ -79,6 +80,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-vue": "^9.33.0",
     "globals": "^15.15.0",
+    "happy-dom": "^20.9.0",
     "playwright": "^1.59.1",
     "prettier": "^3.8.3",
     "typescript": "^6.0.2",
@@ -91,6 +93,8 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/manrope": "^5.2.8",
     "anime4k-webgpu": "^1.0.0",
     "electron-store": "^8.2.0",
     "electron-updater": "^6.8.3",

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -27,7 +27,6 @@ const shikimoriStore = useShikimoriStore();
 const { currentView, activeAnimeId, activeFocusEpisodeInt } = storeToRefs(libraryStore);
 const { playerState, animePrefs } = storeToRefs(playerStore);
 const { shortcuts, ffmpegDownloading, ffmpegProgress } = storeToRefs(settingsStore);
-const { loggedIn: shikimoriLoggedIn } = storeToRefs(shikimoriStore);
 
 const searchViewRef = ref<InstanceType<typeof SearchView> | null>(null);
 
@@ -146,7 +145,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div class="app">
-    <Sidebar :shikimori-logged-in="shikimoriLoggedIn" />
+    <Sidebar />
     <AnimeDetailView
       v-if="activeAnimeId"
       :key="activeAnimeId"
@@ -222,48 +221,15 @@ onBeforeUnmount(() => {
 </template>
 
 <style>
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  background-color: #1a1a2e;
-  color: #e0e0e0;
-  overflow: hidden;
-}
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-::-webkit-scrollbar-track {
-  background: #1a1a2e;
-}
-::-webkit-scrollbar-thumb {
-  background: #2a2a4a;
-  border-radius: 4px;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: #3a3a5a;
-}
-::-webkit-scrollbar-corner {
-  background: #1a1a2e;
-}
-
-.app {
-  display: flex;
-  height: 100vh;
-}
-
+/* Base reset, body, scrollbar, and `.app` now live in assets/theme.css
+   (the shared token foundation, #161). What stays here is App.vue-local
+   chrome — the ffmpeg first-launch overlay and the cleanup toast. */
 .placeholder {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #4a4a6a;
+  color: var(--text-faint);
   font-size: 1.2rem;
 }
 
@@ -278,9 +244,9 @@ body {
 }
 
 .ffmpeg-modal {
-  background: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
   padding: 2rem 2.5rem;
   text-align: center;
   min-width: 320px;
@@ -289,8 +255,8 @@ body {
 .ffmpeg-spinner {
   width: 40px;
   height: 40px;
-  border: 3px solid #0f3460;
-  border-top-color: #e94560;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
   border-radius: 50%;
   margin: 0 auto 1rem;
   animation: spin 0.8s linear infinite;
@@ -311,14 +277,14 @@ body {
 .ffmpeg-progress-bar {
   width: 100%;
   height: 6px;
-  background: #0f3460;
+  background: var(--surface-3);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .ffmpeg-progress-fill {
   height: 100%;
-  background: #e94560;
+  background: var(--accent);
   border-radius: 3px;
   transition: width 0.3s ease;
 }
@@ -326,13 +292,13 @@ body {
 .ffmpeg-percent {
   margin-top: 0.5rem;
   font-size: 0.9rem;
-  color: #a0a0c0;
+  color: var(--text-2);
 }
 
 .ffmpeg-hint {
   margin-top: 0.5rem;
   font-size: 0.75rem;
-  color: #6a6a8a;
+  color: var(--text-3);
 }
 
 .cleanup-toast {
@@ -340,9 +306,9 @@ body {
   right: 20px;
   bottom: 20px;
   width: 360px;
-  background: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-card);
   padding: 14px 16px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
   z-index: 8000;
@@ -354,13 +320,13 @@ body {
 .cleanup-toast-title {
   font-size: 0.92rem;
   font-weight: 600;
-  color: #e0e0e0;
+  color: var(--text);
   margin-bottom: 4px;
 }
 
 .cleanup-toast-size {
   font-size: 0.8rem;
-  color: #a0a0b8;
+  color: var(--text-2);
 }
 
 .cleanup-toast-actions {
@@ -372,33 +338,33 @@ body {
 .cleanup-toast-btn {
   padding: 5px 10px;
   font-size: 0.78rem;
-  border-radius: 5px;
-  border: 1px solid #0f3460;
+  border-radius: var(--radius-btn);
+  border: 1px solid var(--border);
   background: transparent;
-  color: #c0c0d0;
+  color: var(--text-2);
   cursor: pointer;
 }
 
 .cleanup-toast-btn:hover {
-  background: rgba(15, 52, 96, 0.4);
+  background: var(--surface-2);
 }
 
 .cleanup-toast-btn.primary {
-  background: #e94560;
-  border-color: #e94560;
-  color: #ffffff;
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-ink);
 }
 
 .cleanup-toast-btn.primary:hover {
-  background: #f25670;
+  background: var(--accent-hover);
 }
 
 .cleanup-toast-btn.subtle {
-  color: #7a7a98;
+  color: var(--text-3);
   border-color: transparent;
 }
 
 .cleanup-toast-btn.subtle:hover {
-  color: #c0c0d0;
+  color: var(--text-2);
 }
 </style>

--- a/src/renderer/src/assets/theme.css
+++ b/src/renderer/src/assets/theme.css
@@ -1,0 +1,530 @@
+/* ============================================================
+   Anime DL — Refined Dark theme foundation (#161)
+   Single locked design direction: Refined Dark · regular density
+   · accent #ef4d67. The multi-direction / density / Tweaks
+   machinery from the design prototype is intentionally dropped
+   (epic #160). Tokens still flow through CSS variables so a future
+   re-theme stays a one-file edit.
+
+   Fonts (Manrope + JetBrains Mono) are imported in main.ts from the
+   bundled @fontsource packages — no CDN, so they render offline.
+   ============================================================ */
+
+:root {
+  /* surfaces */
+  --bg: #101019;
+  --bg-deep: #0a0a12;
+  --surface: #181a28;
+  --surface-2: #1f2235;
+  --surface-3: #272b44;
+
+  /* borders */
+  --border: #262a44;
+  --border-soft: #1f2336;
+  --border-strong: #343a5c;
+
+  /* text */
+  --text: #edeef5;
+  --text-2: #a9abc4;
+  --text-3: #71748f;
+  --text-faint: #4d5070;
+
+  /* accent (locked) + derived tints */
+  --accent: #ef4d67;
+  --accent-hover: color-mix(in srgb, var(--accent) 84%, white);
+  --accent-soft: color-mix(in srgb, var(--accent) 14%, transparent);
+  --accent-line: color-mix(in srgb, var(--accent) 32%, transparent);
+  --accent-ink: #ffffff;
+
+  /* status palette */
+  --st-blue: #4aa3e0;
+  --st-green: #5cc08a;
+  --st-orange: #e8a33d;
+  --st-purple: #a878e8;
+  --st-red: #ef5573;
+  --star: #f5c451;
+
+  /* radii */
+  --radius-card: 14px;
+  --radius-btn: 9px;
+  --radius-chip: 999px;
+  --radius-input: 9px;
+
+  /* fonts */
+  --font-ui: 'Manrope', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Manrope', system-ui, -apple-system, sans-serif;
+  --font-data: 'JetBrains Mono', ui-monospace, 'SFMono-Regular', monospace;
+
+  /* spacing (regular density) */
+  --gap: 16px;
+  --pad-x: 28px;
+  --pad-y: 18px;
+  --row-pad: 13px;
+  --poster-grid: 168px;
+
+  /* effects */
+  --shadow-card: 0 1px 0 rgba(255, 255, 255, 0.02) inset, 0 10px 30px rgba(0, 0, 0, 0.28);
+  --hero-overlay: linear-gradient(
+    180deg,
+    rgba(16, 16, 25, 0) 0%,
+    rgba(16, 16, 25, 0.72) 62%,
+    var(--bg) 100%
+  );
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ============================================================ Base ============================================================ */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}
+
+body {
+  font-family: var(--font-ui);
+  background: var(--bg);
+  color: var(--text);
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.app {
+  display: flex;
+  height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+}
+
+.mono {
+  font-family: var(--font-data);
+  font-variant-numeric: tabular-nums;
+}
+
+/* scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 6px;
+  border: 3px solid var(--bg);
+}
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-faint);
+}
+::-webkit-scrollbar-corner {
+  background: var(--bg);
+}
+
+/* ============================================================ Sidebar ============================================================ */
+.sidebar {
+  width: 232px;
+  min-width: 232px;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 22px 22px 18px;
+}
+.logo-mark {
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  background: var(--accent);
+  display: grid;
+  place-items: center;
+  color: var(--accent-ink);
+  flex-shrink: 0;
+  box-shadow: 0 4px 14px var(--accent-soft);
+}
+.logo-mark svg {
+  width: 18px;
+  height: 18px;
+}
+.logo-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.05;
+}
+.logo-text .name {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+.logo-text .sub {
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-3);
+  margin-top: 2px;
+}
+
+.nav-group {
+  padding: 6px 12px;
+}
+.nav-group + .nav-group {
+  border-top: 1px solid var(--border-soft);
+  margin-top: 4px;
+  padding-top: 12px;
+}
+.nav-label {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  padding: 4px 12px 8px;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-btn);
+  color: var(--text-3);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s var(--ease);
+  position: relative;
+}
+.nav-item:hover {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.nav-item.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.nav-item .ico {
+  width: 19px;
+  height: 19px;
+  flex-shrink: 0;
+}
+.nav-item .count {
+  margin-left: auto;
+  font-family: var(--font-data);
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: var(--surface-3);
+  color: var(--text-2);
+  padding: 1px 7px;
+  border-radius: 999px;
+}
+.nav-item.active .count {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+
+.sidebar-foot {
+  margin-top: auto;
+  padding: 14px;
+  border-top: 1px solid var(--border-soft);
+}
+.user-chip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-btn);
+  transition: background 0.15s;
+}
+.user-chip:hover {
+  background: var(--surface-2);
+}
+.user-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: linear-gradient(135deg, var(--accent), var(--st-purple));
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.8rem;
+  object-fit: cover;
+}
+.user-meta {
+  line-height: 1.2;
+  min-width: 0;
+}
+.user-meta .u-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.user-meta .u-sync {
+  font-size: 0.68rem;
+  color: var(--st-green);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.user-meta .u-sync.offline {
+  color: var(--st-orange);
+}
+.u-sync .dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* ============================================================ Poster grid + anime card ============================================================
+   Card internals (poster / star / score / watch-bar) are nested under
+   `.acard` so they never leak onto the bare `.poster` / `.score-badge`
+   classes other (not-yet-restyled) components still own. */
+.poster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--poster-grid), 1fr));
+  gap: var(--gap);
+}
+
+.acard {
+  position: relative;
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  transition: all 0.18s var(--ease);
+  text-align: left;
+  cursor: pointer;
+}
+.acard:hover {
+  transform: translateY(-4px);
+  border-color: var(--accent);
+  box-shadow: var(--shadow-card);
+}
+.acard .poster-wrap {
+  position: relative;
+  line-height: 0;
+  aspect-ratio: 2 / 3;
+  background: var(--bg-deep);
+  overflow: hidden;
+}
+.acard .poster {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.acard .acard-info {
+  padding: 10px 12px 12px;
+}
+.acard .acard-title {
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.28;
+  color: var(--text);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.acard .acard-meta {
+  margin-top: 5px;
+  font-size: 0.73rem;
+  color: var(--text-3);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.acard .star-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 3;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.5);
+  border: none;
+  color: rgba(255, 255, 255, 0.78);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  backdrop-filter: blur(3px);
+  transition: all 0.15s;
+  opacity: 0;
+}
+.acard:hover .star-btn {
+  opacity: 1;
+}
+.acard .star-btn:hover {
+  transform: scale(1.12);
+  color: var(--star);
+}
+.acard .star-btn.active {
+  opacity: 1;
+  color: var(--star);
+}
+.acard .star-btn svg {
+  width: 17px;
+  height: 17px;
+}
+.acard .score-badge {
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  z-index: 3;
+  font-family: var(--font-data);
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  background: rgba(0, 0, 0, 0.6);
+  color: var(--star);
+  backdrop-filter: blur(3px);
+}
+.acard .score-badge svg {
+  width: 11px;
+  height: 11px;
+}
+.acard .watch-bar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  background: rgba(0, 0, 0, 0.4);
+}
+.acard .watch-bar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+/* ============================================================ Shared primitives (zero-collision) ============================================================ */
+/* progress bar */
+.pbar {
+  flex: 1;
+  height: 5px;
+  background: var(--bg-deep);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.pbar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 0.4s var(--ease);
+}
+.pbar.thin {
+  height: 3px;
+}
+
+/* pill tabs */
+.pill-tabs {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-btn);
+}
+.pill-tab {
+  padding: 6px 14px;
+  border-radius: calc(var(--radius-btn) - 2px);
+  background: none;
+  border: none;
+  color: var(--text-3);
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.pill-tab:hover {
+  color: var(--text);
+}
+.pill-tab.active {
+  background: var(--surface-3);
+  color: var(--text);
+}
+
+/* select with caret */
+.select-wrap {
+  position: relative;
+}
+.select-wrap select {
+  appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.84rem;
+  font-weight: 600;
+  padding: 9px 34px 9px 13px;
+  border-radius: var(--radius-input);
+}
+.select-wrap select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.select-wrap .caret {
+  position: absolute;
+  right: 11px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 14px;
+  height: 14px;
+  color: var(--text-3);
+  pointer-events: none;
+}
+
+/* empty state */
+.empty-state {
+  text-align: center;
+  padding: 90px 20px;
+}
+.empty-state .es-icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 18px;
+  border-radius: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  color: var(--text-3);
+}
+.empty-state .es-icon svg {
+  width: 26px;
+  height: 26px;
+}
+.empty-state p {
+  color: var(--text-3);
+  font-size: 0.95rem;
+  margin-bottom: 18px;
+}

--- a/src/renderer/src/components/shared/AnimeCard.vue
+++ b/src/renderer/src/components/shared/AnimeCard.vue
@@ -12,7 +12,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="card">
+  <div class="acard">
     <div class="poster-wrap">
       <img :src="anime.posterUrlSmall" :alt="anime.title" class="poster" loading="lazy" />
       <button class="star-btn" :class="{ active: starred }" @click.stop="emit('toggleStar', anime)">
@@ -32,9 +32,9 @@ const emit = defineEmits<{
         </svg>
       </button>
     </div>
-    <div class="info">
-      <div class="title" :title="anime.title">{{ getAnimeName(anime) }}</div>
-      <div class="meta">
+    <div class="acard-info">
+      <div class="acard-title" :title="anime.title">{{ getAnimeName(anime) }}</div>
+      <div class="acard-meta">
         <span v-if="anime.typeTitle">{{ anime.typeTitle }}</span>
         <span v-if="anime.year"> · {{ anime.year }}</span>
         <span v-if="anime.numberOfEpisodes"> · {{ anime.numberOfEpisodes }} ep</span>
@@ -42,82 +42,3 @@ const emit = defineEmits<{
     </div>
   </div>
 </template>
-
-<style scoped>
-.card {
-  background-color: #16213e;
-  border-radius: 10px;
-  overflow: hidden;
-  transition:
-    transform 0.15s,
-    box-shadow 0.15s;
-  cursor: pointer;
-}
-
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-}
-
-.poster-wrap {
-  position: relative;
-  aspect-ratio: 2 / 3;
-  overflow: hidden;
-  background-color: #0f3460;
-}
-
-.poster {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.star-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: rgba(0, 0, 0, 0.6);
-  border: none;
-  border-radius: 50%;
-  width: 34px;
-  height: 34px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  color: rgba(255, 255, 255, 0.7);
-  transition:
-    color 0.15s,
-    transform 0.15s;
-}
-
-.star-btn:hover {
-  color: #fbbf24;
-  transform: scale(1.1);
-}
-
-.star-btn.active {
-  color: #fbbf24;
-}
-
-.info {
-  padding: 10px 12px 12px;
-}
-
-.title {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #e0e0e0;
-  line-height: 1.3;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.meta {
-  margin-top: 4px;
-  font-size: 0.75rem;
-  color: #6a6a8a;
-}
-</style>

--- a/src/renderer/src/components/shared/Sidebar.vue
+++ b/src/renderer/src/components/shared/Sidebar.vue
@@ -2,17 +2,23 @@
 import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useLibraryStore, type LibraryView } from '../../stores/library';
-
-const props = defineProps<{
-  shikimoriLoggedIn?: boolean;
-}>();
+import { useShikimoriStore } from '../../stores/shikimori';
+import { useDownloadsStore } from '../../stores/downloads';
 
 const libraryStore = useLibraryStore();
+const shikimoriStore = useShikimoriStore();
+const downloadsStore = useDownloadsStore();
 const { currentView } = storeToRefs(libraryStore);
+const { user, loggedIn, offlineQueueLength, syncStatus } = storeToRefs(shikimoriStore);
+const { groups } = storeToRefs(downloadsStore);
 
 type MenuItem = { id: LibraryView; label: string; icon: string };
 
-const baseItems: MenuItem[] = [
+// Download icon — reused for the logo mark and the Downloads nav item.
+const downloadIcon =
+  'M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3';
+
+const primaryItems: MenuItem[] = [
   {
     id: 'home',
     label: 'Home',
@@ -23,11 +29,7 @@ const baseItems: MenuItem[] = [
     label: 'Search',
     icon: 'M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z'
   },
-  {
-    id: 'downloads',
-    label: 'Downloads',
-    icon: 'M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3'
-  },
+  { id: 'downloads', label: 'Downloads', icon: downloadIcon },
   {
     id: 'library',
     label: 'Library',
@@ -35,21 +37,23 @@ const baseItems: MenuItem[] = [
   }
 ];
 
-const shikimoriItem: MenuItem = {
-  id: 'shikimori',
-  label: 'Shikimori',
-  icon: 'M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z'
-};
-const friendsItem: MenuItem = {
-  id: 'friends',
-  label: 'Friends',
-  icon: 'M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z'
-};
-const calendarItem: MenuItem = {
-  id: 'calendar',
-  label: 'Calendar',
-  icon: 'M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5'
-};
+const shikimoriItems: MenuItem[] = [
+  {
+    id: 'shikimori',
+    label: 'Shikimori',
+    icon: 'M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 010 3.75H5.625a1.875 1.875 0 010-3.75z'
+  },
+  {
+    id: 'friends',
+    label: 'Friends',
+    icon: 'M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z'
+  },
+  {
+    id: 'calendar',
+    label: 'Calendar',
+    icon: 'M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 012.25-2.25h13.5A2.25 2.25 0 0121 7.5v11.25m-18 0A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75m-18 0v-7.5A2.25 2.25 0 015.25 9h13.5A2.25 2.25 0 0121 11.25v7.5'
+  }
+];
 
 const settingsItem: MenuItem = {
   id: 'settings',
@@ -57,95 +61,105 @@ const settingsItem: MenuItem = {
   icon: 'M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a6.759 6.759 0 010 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 010-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.28z M15 12a3 3 0 11-6 0 3 3 0 016 0z'
 };
 
-const menuItems = computed(() => {
-  const items = [...baseItems];
-  if (props.shikimoriLoggedIn) {
-    items.push(shikimoriItem);
-    items.push(friendsItem);
-    items.push(calendarItem);
+// Active downloads + subtitles still in flight — surfaced as the count pill.
+const downloadCount = computed(
+  () =>
+    groups.value.filter((g) =>
+      [g.video, g.subtitle].some(
+        (item) => item != null && (item.status === 'downloading' || item.status === 'queued')
+      )
+    ).length
+);
+
+const userInitial = computed(() => user.value?.nickname?.charAt(0).toUpperCase() ?? '?');
+
+// Reflect the real Shikimori sync state rather than always reading "Synced":
+// the app has an offline queue, so pending changes / an in-flight sync should
+// show instead of a misleading green dot.
+const fullySynced = computed(
+  () => syncStatus.value.state !== 'syncing' && offlineQueueLength.value === 0
+);
+const syncLabel = computed(() => {
+  if (syncStatus.value.state === 'syncing') return 'Syncing…';
+  if (offlineQueueLength.value > 0) {
+    return `${offlineQueueLength.value} pending`;
   }
-  items.push(settingsItem);
-  return items;
+  return 'Synced';
 });
 </script>
 
 <template>
   <aside class="sidebar">
     <div class="logo">
-      <h1>Anime DL</h1>
+      <div class="logo-mark">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2">
+          <path stroke-linecap="round" stroke-linejoin="round" :d="downloadIcon" />
+        </svg>
+      </div>
+      <div class="logo-text">
+        <span class="name">Anime DL</span>
+        <span class="sub">smotret-anime</span>
+      </div>
     </div>
-    <nav class="menu">
+
+    <nav class="nav-group">
       <button
-        v-for="item in menuItems"
+        v-for="item in primaryItems"
         :key="item.id"
-        class="menu-item"
+        class="nav-item"
         :class="{ active: currentView === item.id }"
         @click="libraryStore.navigate(item.id)"
       >
-        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
           <path stroke-linecap="round" stroke-linejoin="round" :d="item.icon" />
         </svg>
-        <span class="label">{{ item.label }}</span>
+        <span>{{ item.label }}</span>
+        <span v-if="item.id === 'downloads' && downloadCount > 0" class="count">{{
+          downloadCount
+        }}</span>
       </button>
     </nav>
+
+    <nav v-if="loggedIn" class="nav-group">
+      <div class="nav-label">Shikimori</div>
+      <button
+        v-for="item in shikimoriItems"
+        :key="item.id"
+        class="nav-item"
+        :class="{ active: currentView === item.id }"
+        @click="libraryStore.navigate(item.id)"
+      >
+        <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+          <path stroke-linecap="round" stroke-linejoin="round" :d="item.icon" />
+        </svg>
+        <span>{{ item.label }}</span>
+      </button>
+    </nav>
+
+    <nav class="nav-group">
+      <button
+        class="nav-item"
+        :class="{ active: currentView === settingsItem.id }"
+        @click="libraryStore.navigate(settingsItem.id)"
+      >
+        <svg class="ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+          <path stroke-linecap="round" stroke-linejoin="round" :d="settingsItem.icon" />
+        </svg>
+        <span>{{ settingsItem.label }}</span>
+      </button>
+    </nav>
+
+    <div v-if="loggedIn && user" class="sidebar-foot">
+      <div class="user-chip">
+        <img v-if="user.avatar" :src="user.avatar" :alt="user.nickname" class="user-avatar" />
+        <div v-else class="user-avatar">{{ userInitial }}</div>
+        <div class="user-meta">
+          <div class="u-name">{{ user.nickname }}</div>
+          <div class="u-sync" :class="{ offline: !fullySynced }">
+            <span class="dot"></span>{{ syncLabel }}
+          </div>
+        </div>
+      </div>
+    </div>
   </aside>
 </template>
-
-<style scoped>
-.sidebar {
-  width: 200px;
-  min-width: 200px;
-  background-color: #16213e;
-  display: flex;
-  flex-direction: column;
-  border-right: 1px solid #0f3460;
-}
-
-.logo {
-  padding: 20px;
-  border-bottom: 1px solid #0f3460;
-}
-
-.logo h1 {
-  font-size: 1.3rem;
-  color: #e94560;
-  font-weight: 700;
-}
-
-.menu {
-  display: flex;
-  flex-direction: column;
-  padding: 8px 0;
-}
-
-.menu-item {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 11px 20px;
-  background: none;
-  border: none;
-  color: #6a6a8a;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: all 0.15s;
-  text-align: left;
-}
-
-.menu-item:hover {
-  background-color: #1a1a2e;
-  color: #c0c0d8;
-}
-
-.menu-item.active {
-  color: #e94560;
-  background-color: #1a1a2e;
-  border-right: 2px solid #e94560;
-}
-
-.icon {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-}
-</style>

--- a/src/renderer/src/main.ts
+++ b/src/renderer/src/main.ts
@@ -1,5 +1,18 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+
+// Bundled fonts (self-hosted via @fontsource — no CDN, render offline).
+// Manrope drives UI + display; JetBrains Mono drives data (speeds/sizes/ETAs).
+// The per-weight CSS ships every subset, including Cyrillic for Russian titles.
+import '@fontsource/manrope/400.css'
+import '@fontsource/manrope/500.css'
+import '@fontsource/manrope/600.css'
+import '@fontsource/manrope/700.css'
+import '@fontsource/jetbrains-mono/400.css'
+import '@fontsource/jetbrains-mono/500.css'
+import '@fontsource/jetbrains-mono/700.css'
+
+import './assets/theme.css'
 import App from './App.vue'
 
 createApp(App).use(createPinia()).mount('#app')

--- a/test/renderer/components/anime-card.test.ts
+++ b/test/renderer/components/anime-card.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AnimeCard from '../../../src/renderer/src/components/shared/AnimeCard.vue'
+
+const anime: AnimeSearchResult = {
+  id: 1,
+  title: 'Steins;Gate',
+  titles: { ru: 'Врата Штейна', romaji: 'Steins;Gate' },
+  posterUrlSmall: 'poster.jpg',
+  numberOfEpisodes: 24,
+  type: 'tv',
+  typeTitle: 'TV',
+  year: 2011,
+  season: 'spring'
+}
+
+describe('AnimeCard', () => {
+  it('anchors the star button inside the poster wrapper, not the card root', () => {
+    // Regression for the design prototype's overlap bug: poster overlays must
+    // live inside `.poster-wrap` so they can never collide with the title/meta
+    // rendered below the poster.
+    const wrapper = mount(AnimeCard, { props: { anime, starred: false } })
+    const overlay = wrapper.find('.poster-wrap .star-btn')
+    expect(overlay.exists()).toBe(true)
+    // And it is NOT a direct child of the card root (i.e. not a sibling of info).
+    expect(wrapper.find('.acard > .star-btn').exists()).toBe(false)
+    // Title + meta live outside the poster wrapper.
+    expect(wrapper.find('.acard-info .acard-title').exists()).toBe(true)
+  })
+
+  it('reflects the starred state and emits toggleStar on click', async () => {
+    const wrapper = mount(AnimeCard, { props: { anime, starred: true } })
+    expect(wrapper.find('.star-btn').classes()).toContain('active')
+
+    await wrapper.find('.star-btn').trigger('click')
+    expect(wrapper.emitted('toggleStar')).toBeTruthy()
+    expect(wrapper.emitted('toggleStar')![0]).toEqual([anime])
+  })
+})

--- a/test/renderer/components/sidebar.test.ts
+++ b/test/renderer/components/sidebar.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import Sidebar from '../../../src/renderer/src/components/shared/Sidebar.vue'
+import { useLibraryStore } from '../../../src/renderer/src/stores/library'
+import { useShikimoriStore } from '../../../src/renderer/src/stores/shikimori'
+
+beforeEach(() => {
+  // The downloads + shikimori stores subscribe to `window.api.on*` at setup.
+  // A permissive stub returns a no-op unsubscribe handle for any access.
+  ;(window as unknown as { api: unknown }).api = new Proxy({}, { get: () => () => () => {} })
+  setActivePinia(createPinia())
+})
+
+describe('Sidebar', () => {
+  it('marks the nav item for the current view as active and tracks changes', async () => {
+    const library = useLibraryStore()
+    library.navigate('home')
+
+    const wrapper = mount(Sidebar)
+
+    const activeLabel = () => wrapper.find('.nav-item.active span').text()
+    expect(wrapper.findAll('.nav-item.active')).toHaveLength(1)
+    expect(activeLabel()).toBe('Home')
+
+    library.navigate('library')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.findAll('.nav-item.active')).toHaveLength(1)
+    expect(activeLabel()).toBe('Library')
+  })
+
+  it('hides the Shikimori nav group and user chip until logged in', async () => {
+    const shiki = useShikimoriStore()
+    const wrapper = mount(Sidebar)
+    expect(wrapper.find('.nav-label').exists()).toBe(false)
+    expect(wrapper.find('.user-chip').exists()).toBe(false)
+
+    // Login is derived from the store (the `shikimoriLoggedIn` prop was removed).
+    shiki.user = { id: 1, nickname: 'mikkerlo', avatar: '' }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.nav-label').text()).toBe('Shikimori')
+    expect(wrapper.find('.user-chip').exists()).toBe(true)
+  })
+
+  it('reflects the real Shikimori sync state in the footer chip', async () => {
+    const shiki = useShikimoriStore()
+    shiki.user = { id: 1, nickname: 'mikkerlo', avatar: '' }
+    const wrapper = mount(Sidebar)
+
+    // Empty offline queue → green "Synced".
+    expect(wrapper.find('.u-sync').text()).toBe('Synced')
+    expect(wrapper.find('.u-sync').classes()).not.toContain('offline')
+
+    // Pending offline changes must NOT read "Synced" (the reviewed nit).
+    shiki.offlineQueueLength = 2
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.u-sync').classes()).toContain('offline')
+    expect(wrapper.find('.u-sync').text()).toContain('2 pending')
+  })
+})

--- a/test/renderer/theme-tokens.test.ts
+++ b/test/renderer/theme-tokens.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { resolve } from 'path'
+
+// Foundation guard tests (#161). These run in the default node env — no DOM
+// needed; they read source files directly.
+
+const RENDERER_DIR = resolve(__dirname, '../../src/renderer')
+const THEME_CSS = resolve(RENDERER_DIR, 'src/assets/theme.css')
+
+describe('Refined Dark theme tokens', () => {
+  const css = readFileSync(THEME_CSS, 'utf8')
+
+  it('locks the accent to #ef4d67', () => {
+    // Fails if the palette is reverted to the old coral (#e94560) or any other.
+    expect(css).toMatch(/--accent:\s*#ef4d67\b/i)
+  })
+
+  it('defines the core surface, text, and border tokens on :root', () => {
+    expect(css).toMatch(/:root\s*\{/)
+    for (const token of ['--bg', '--surface', '--surface-2', '--text', '--text-2', '--border']) {
+      expect(css, `missing ${token}`).toMatch(new RegExp(`${token}:\\s*#`, 'i'))
+    }
+  })
+
+  it('declares the bundled font families (Manrope + JetBrains Mono)', () => {
+    expect(css).toMatch(/--font-ui:[^;]*Manrope/i)
+    expect(css).toMatch(/--font-data:[^;]*JetBrains Mono/i)
+  })
+})
+
+describe('offline-font guard', () => {
+  // A stray CDN reference (Google Fonts, a remote url()) is invisible until
+  // someone runs offline. Scan our own renderer CSS / .vue / .html source for
+  // remote references and fail loudly. (Bundled @fontsource lives in
+  // node_modules and uses relative url(./files/…), so it is not scanned.)
+  function collectSource(dir: string, acc: string[] = []): string[] {
+    for (const entry of readdirSync(dir)) {
+      if (entry === 'node_modules' || entry === 'out' || entry === 'dist') continue
+      const full = resolve(dir, entry)
+      if (statSync(full).isDirectory()) collectSource(full, acc)
+      else if (/\.(css|vue|html)$/.test(entry)) acc.push(full)
+    }
+    return acc
+  }
+
+  const files = collectSource(RENDERER_DIR)
+
+  it('finds renderer source files to scan', () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('contains no remote url() or @import in renderer source', () => {
+    const offenders: string[] = []
+    const remoteUrl = /url\(\s*['"]?https?:\/\//i
+    const remoteImport = /@import\s+(url\()?\s*['"]?https?:\/\//i
+    const googleFonts = /fonts\.(googleapis|gstatic)\.com/i
+    for (const file of files) {
+      const content = readFileSync(file, 'utf8')
+      if (remoteUrl.test(content) || remoteImport.test(content) || googleFonts.test(content)) {
+        offenders.push(file)
+      }
+    }
+    expect(offenders, `remote font/asset reference(s) found in: ${offenders.join(', ')}`).toEqual(
+      []
+    )
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,10 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
 
 export default defineConfig({
+  // Vue plugin lets the renderer component tests (happy-dom) mount .vue SFCs.
+  plugins: [vue()],
   resolve: {
     alias: {
       '@shared': resolve('src/shared'),


### PR DESCRIPTION
## What & why

Foundation for the **Refined Dark** redesign epic (#160) — the keystone every per-screen restyle builds on. Today the renderer has no design tokens (hardcoded hex scattered across scoped styles); this PR introduces the shared token system, bundled fonts, and the shared primitives, then restyles the always-on chrome (Sidebar + AnimeCard).

Renderer-only — no main-process, IPC, or settings-schema changes.

Fixes #161.

## Changes

- **`assets/theme.css`** (new) — locked Refined Dark tokens on `:root` (surfaces, borders, text, `--accent: #ef4d67` + `color-mix` derivations, status palette, radii, regular-density spacing, font vars), base reset + themed scrollbar (moved out of `App.vue`), and **zero-collision** shared primitives: the `.sidebar` family, the `.acard` poster-grid card (poster/star/score/watch-bar nested **under `.acard`**), `.pbar`, `.pill-tabs`, `.select-wrap`, `.empty-state`, `.poster-grid`.
- **Bundled fonts** — `@fontsource/manrope` + `@fontsource/jetbrains-mono` imported in `main.ts`; self-hosted woff/woff2 (no CDN), every subset incl. **Cyrillic** for Russian titles. JetBrains Mono (`--font-data`) currently shows on the sidebar Downloads count pill; it spreads to sizes/speeds/ETAs/episode numbers in the per-screen restyle issues.
- **`Sidebar.vue`** — grouped nav (primary / Shikimori / Settings), coral logo mark, active = accent-soft, Downloads **count pill** (active in-flight groups), and a footer **user chip** (Shikimori nickname/avatar + sync dot) when logged in. Nav ids, store wiring, and logged-in gating unchanged.
- **`AnimeCard.vue`** — `.acard` primitives; props/emits unchanged; star button anchored inside `.poster-wrap`.
- **`App.vue`** — base/scrollbar removed (now in theme.css); ffmpeg overlay + cleanup toast re-tokenized.
- **`docs/renderer.md`** — documents the token system, bundled fonts, and shared primitive layer.

## Scope note

Generic primitives that **already collide** with existing components' scoped styles (`.btn` ×26, bare `.poster` ×7, `.topbar` ×9, `.chip` ×3) are deliberately **not** globalized here — a bare global rule would leak un-overridden properties into not-yet-restyled views. They land with the per-screen issues that adopt them. Sidebar/AnimeCard don't use them, so this PR doesn't need them.

## Tests

- `theme-tokens.test.ts` — **token guard** (`--accent: #ef4d67` + core vars present, fails on palette revert) and **offline-font guard** (scans renderer source for any remote `url()` / `@import` / Google Fonts ref).
- `components/anime-card.test.ts` — star overlay is anchored inside `.poster-wrap` (regression for the prototype overlap bug; our `AnimeSearchResult` has no score field, so no score badge is rendered — the class ships for later use); starred state + `toggleStar` emit.
- `components/sidebar.test.ts` — `.nav-item.active` tracks `currentView`; Shikimori group + user chip gated on login.
- Wired `@vitejs/plugin-vue` into `vitest.config.ts` + added `@vue/test-utils` & `happy-dom` (the repo had no DOM test runner) for the per-file `happy-dom` component tests.

## Verification

`typecheck` ✓ · `test` (488 passing, incl. new) ✓ · `test:coverage` per-seam gate ✓ · `build` ✓ (fonts emitted as local woff/woff2) · `lint` (0 errors) ✓ · `format:check` ✓ · launched `npm run dev` — app boots clean, theme + restyled sidebar/cards render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
