### PR TITLE
feat(ui): restyle Search & Library views to Refined Dark (#163)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anime-dl-app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anime-dl-app",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "ISC",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/renderer/src/components/views/LibraryView.vue
+++ b/src/renderer/src/components/views/LibraryView.vue
@@ -1,16 +1,59 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
 import AnimeCard from '../shared/AnimeCard.vue';
 import { getAnimeName } from '../../utils';
 import { useLibraryStore } from '../../stores/library';
+import { useShikimoriStore } from '../../stores/shikimori';
 
 const libraryStore = useLibraryStore();
+const shikimoriStore = useShikimoriStore();
+const { rates } = storeToRefs(shikimoriStore);
 
 const library = ref<AnimeSearchResult[]>([]);
 const starredIds = ref(new Set<number>());
 const downloadedIds = ref(new Set<number>());
 
-onMounted(loadLibrary);
+// Join Shikimori rates onto library entries by smotret-anime id, so the
+// status tabs can filter the saved library by watch status.
+const statusBySmotretId = computed(() => {
+  const map = new Map<number, ShikiUserRateStatus>();
+  for (const e of rates.value) {
+    if (e.smotretAnime) map.set(e.smotretAnime.id, e.rate.status);
+  }
+  return map;
+});
+// Only show the status tabs when at least one *library* entry has a resolved
+// Shikimori status — not merely when the user has any tracked rates (which
+// would surface tabs whose non-"All" options are all empty).
+const hasStatuses = computed(() => library.value.some((a) => statusBySmotretId.value.has(a.id)));
+
+const statusTabs: { id: string; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'watching', label: 'Watching' },
+  { id: 'planned', label: 'Planned' },
+  { id: 'completed', label: 'Completed' }
+];
+const statusFilter = ref('all');
+
+function matchesFilter(anime: AnimeSearchResult): boolean {
+  if (statusFilter.value === 'all') return true;
+  const status = statusBySmotretId.value.get(anime.id);
+  if (statusFilter.value === 'watching') return status === 'watching' || status === 'rewatching';
+  return status === statusFilter.value;
+}
+
+const filteredLibrary = computed(() => library.value.filter(matchesFilter));
+
+onMounted(async () => {
+  await loadLibrary();
+  // Hydrate Shikimori rates (cache-first) so the status tabs have data.
+  if (shikimoriStore.loggedIn && rates.value.length === 0) {
+    shikimoriStore
+      .refreshRates()
+      .catch((err) => console.error('Failed to hydrate Shikimori rates for Library:', err));
+  }
+});
 
 async function loadLibrary(): Promise<void> {
   library.value = await window.api.libraryGet();
@@ -42,10 +85,25 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
   <main class="library-view">
     <header class="topbar">
       <h2>Library</h2>
+      <span v-if="library.length > 0" class="sub">· {{ library.length }} shows</span>
     </header>
     <div class="body">
-      <div v-if="library.length > 0" class="results-grid">
-        <div v-for="anime in library" :key="anime.id" class="card-wrap">
+      <div v-if="hasStatuses && library.length > 0" class="filter-row">
+        <div class="pill-tabs">
+          <button
+            v-for="tab in statusTabs"
+            :key="tab.id"
+            class="pill-tab"
+            :class="{ active: statusFilter === tab.id }"
+            @click="statusFilter = tab.id"
+          >
+            {{ tab.label }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="filteredLibrary.length > 0" class="poster-grid">
+        <div v-for="anime in filteredLibrary" :key="anime.id" class="card-wrap">
           <AnimeCard
             :anime="anime"
             :starred="starredIds.has(anime.id)"
@@ -55,8 +113,8 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
           <button
             v-if="downloadedIds.has(anime.id)"
             class="delete-folder-btn"
-            @click.stop="deleteAnime(anime)"
             title="Delete downloaded files"
+            @click.stop="deleteAnime(anime)"
           >
             <svg
               viewBox="0 0 24 24"
@@ -76,6 +134,7 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
           </button>
         </div>
       </div>
+      <div v-else-if="library.length > 0" class="status-text">No anime with this status.</div>
       <div v-else class="status-text">
         No saved anime yet. Use the star button on search results to add anime here.
       </div>
@@ -89,29 +148,45 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: 0;
 }
 
 .topbar {
-  padding: 16px 24px;
-  border-bottom: 1px solid #0f3460;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 var(--pad-x);
+  height: 64px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: blur(8px);
 }
 
 .topbar h2 {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #e0e0e0;
+  font-family: var(--font-display);
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+}
+
+.topbar .sub {
+  color: var(--text-3);
+  font-size: 0.85rem;
 }
 
 .body {
   flex: 1;
   overflow-y: auto;
-  padding: 20px 24px;
+  padding: var(--pad-y) var(--pad-x) 48px;
 }
 
-.results-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 20px;
+.filter-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 22px;
 }
 
 .card-wrap {
@@ -125,27 +200,27 @@ async function deleteAnime(anime: AnimeSearchResult): Promise<void> {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  margin-top: 4px;
-  padding: 5px 8px;
-  background-color: rgba(233, 69, 96, 0.1);
-  border: 1px solid rgba(233, 69, 96, 0.3);
-  border-radius: 6px;
-  color: #e94560;
-  font-size: 0.7rem;
+  margin-top: 6px;
+  padding: 6px 10px;
+  background: color-mix(in srgb, var(--st-red) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--st-red) 32%, transparent);
+  border-radius: var(--radius-btn);
+  color: var(--st-red);
+  font-size: 0.72rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .delete-folder-btn:hover {
-  background-color: rgba(233, 69, 96, 0.2);
-  border-color: #e94560;
+  background: color-mix(in srgb, var(--st-red) 22%, transparent);
+  border-color: var(--st-red);
 }
 
 .status-text {
   text-align: center;
-  color: #4a4a6a;
-  font-size: 1.1rem;
-  padding-top: 100px;
+  color: var(--text-faint);
+  font-size: 1.05rem;
+  padding-top: 80px;
 }
 </style>

--- a/src/renderer/src/components/views/SearchView.vue
+++ b/src/renderer/src/components/views/SearchView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, reactive } from 'vue';
+import { ref, reactive, computed } from 'vue';
 import AnimeCard from '../shared/AnimeCard.vue';
 import { useLibraryStore } from '../../stores/library';
 
@@ -19,12 +19,26 @@ const loading = ref(false);
 const searched = ref(false);
 const starredIds = reactive(new Set<number>());
 
+// Client-side type filter over the current result set (distinct typeTitles).
+const typeFilter = ref('all');
+const availableTypes = computed(() => {
+  const set = new Set<string>();
+  for (const a of results.value) if (a.typeTitle) set.add(a.typeTitle);
+  return Array.from(set);
+});
+const filteredResults = computed(() =>
+  typeFilter.value === 'all'
+    ? results.value
+    : results.value.filter((a) => a.typeTitle === typeFilter.value)
+);
+
 async function search(): Promise<void> {
   const q = query.value.trim();
   if (!q) return;
 
   loading.value = true;
   searched.value = true;
+  typeFilter.value = 'all';
   try {
     const response = await window.api.searchAnime(q);
     results.value = response.data;
@@ -56,39 +70,58 @@ async function toggleStar(anime: AnimeSearchResult): Promise<void> {
 <template>
   <main class="search-view">
     <header class="topbar">
-      <form class="search-form" @submit.prevent="search">
+      <h2>Search</h2>
+      <span v-if="searched && !loading" class="sub">· {{ results.length }} titles</span>
+    </header>
+    <div class="body">
+      <form class="search-wrap" @submit.prevent="search">
+        <svg
+          class="search-icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+          />
+        </svg>
         <input
           ref="searchInput"
           v-model="query"
           type="text"
           class="search-input"
-          placeholder="Search anime..."
+          placeholder="Search anime by title…"
         />
-        <button type="submit" class="search-btn" :disabled="loading">
-          <svg
-            v-if="!loading"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            width="18"
-            height="18"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
-            />
-          </svg>
-          <span v-else class="spinner" />
-        </button>
       </form>
-    </header>
-    <div class="body">
-      <div v-if="loading" class="status-text">Searching...</div>
-      <div v-else-if="results.length > 0" class="results-grid">
+
+      <div v-if="availableTypes.length > 1" class="filter-row">
+        <div class="pill-tabs">
+          <button
+            class="pill-tab"
+            :class="{ active: typeFilter === 'all' }"
+            @click="typeFilter = 'all'"
+          >
+            All
+          </button>
+          <button
+            v-for="t in availableTypes"
+            :key="t"
+            class="pill-tab"
+            :class="{ active: typeFilter === t }"
+            @click="typeFilter = t"
+          >
+            {{ t }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="loading" class="status-text">Searching…</div>
+      <div v-else-if="filteredResults.length > 0" class="poster-grid">
         <AnimeCard
-          v-for="anime in results"
+          v-for="anime in filteredResults"
           :key="anime.id"
           :anime="anime"
           :starred="starredIds.has(anime.id)"
@@ -96,8 +129,19 @@ async function toggleStar(anime: AnimeSearchResult): Promise<void> {
           @click="libraryStore.openAnime(anime.id)"
         />
       </div>
-      <div v-else-if="searched" class="status-text">No results found</div>
-      <div v-else class="status-text">Search for anime to get started</div>
+      <div v-else-if="searched" class="empty-state">
+        <div class="es-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7">
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
+          </svg>
+        </div>
+        <p>No titles match your search.</p>
+      </div>
+      <div v-else class="status-text">Search for anime to get started.</div>
     </div>
   </main>
 </template>
@@ -108,88 +152,94 @@ async function toggleStar(anime: AnimeSearchResult): Promise<void> {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-width: 0;
 }
 
 .topbar {
-  padding: 16px 24px;
-  border-bottom: 1px solid #0f3460;
-}
-
-.search-form {
-  display: flex;
-  gap: 8px;
-  max-width: 500px;
-}
-
-.search-input {
-  flex: 1;
-  padding: 10px 16px;
-  background-color: #16213e;
-  border: 1px solid #0f3460;
-  border-radius: 8px;
-  color: #e0e0e0;
-  font-size: 0.9rem;
-  outline: none;
-  transition: border-color 0.15s;
-}
-
-.search-input:focus {
-  border-color: #e94560;
-}
-
-.search-btn {
-  padding: 10px 14px;
-  background-color: #e94560;
-  border: none;
-  border-radius: 8px;
-  color: white;
-  cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: background-color 0.15s;
+  gap: 12px;
+  padding: 0 var(--pad-x);
+  height: 64px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter: blur(8px);
 }
 
-.search-btn:hover {
-  background-color: #d63851;
+.topbar h2 {
+  font-family: var(--font-display);
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: -0.015em;
 }
 
-.search-btn:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.spinner {
-  width: 18px;
-  height: 18px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: white;
-  border-radius: 50%;
-  animation: spin 0.6s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+.topbar .sub {
+  color: var(--text-3);
+  font-size: 0.85rem;
 }
 
 .body {
   flex: 1;
   overflow-y: auto;
-  padding: 20px 24px;
+  padding: var(--pad-y) var(--pad-x) 48px;
 }
 
-.results-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 20px;
+.search-wrap {
+  position: relative;
+  max-width: 560px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 19px;
+  height: 19px;
+  color: var(--text-3);
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  padding: 12px 16px 12px 44px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-input);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-family: inherit;
+  outline: none;
+  transition: all 0.15s;
+}
+
+.search-input::placeholder {
+  color: var(--text-faint);
+}
+
+.search-input:focus {
+  border-color: var(--accent);
+  background: var(--surface-2);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.filter-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.poster-grid {
+  margin-top: 22px;
 }
 
 .status-text {
   text-align: center;
-  color: #4a4a6a;
-  font-size: 1.1rem;
-  padding-top: 100px;
+  color: var(--text-faint);
+  font-size: 1.05rem;
+  padding-top: 80px;
 }
 </style>

--- a/test/renderer/components/search-library.test.ts
+++ b/test/renderer/components/search-library.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import SearchView from '../../../src/renderer/src/components/views/SearchView.vue'
+import LibraryView from '../../../src/renderer/src/components/views/LibraryView.vue'
+import { useShikimoriStore } from '../../../src/renderer/src/stores/shikimori'
+
+function anime(id: number, typeTitle: string): AnimeSearchResult {
+  return {
+    id,
+    title: `Anime ${id}`,
+    titles: {},
+    posterUrlSmall: 'p.jpg',
+    numberOfEpisodes: 12,
+    type: typeTitle.toLowerCase(),
+    typeTitle,
+    year: 2020,
+    season: 'spring'
+  }
+}
+
+function stubApi(overrides: Record<string, unknown>): void {
+  ;(window as unknown as { api: unknown }).api = new Proxy(overrides, {
+    get: (target, prop, recv) => (prop in target ? Reflect.get(target, prop, recv) : () => () => {})
+  })
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('SearchView', () => {
+  it('renders a card per result and a type filter that narrows them', async () => {
+    stubApi({
+      searchAnime: vi
+        .fn()
+        .mockResolvedValue({ data: [anime(1, 'TV'), anime(2, 'TV'), anime(3, 'Movie')] }),
+      libraryHas: vi.fn().mockResolvedValue(false),
+      libraryToggle: vi.fn().mockResolvedValue(true)
+    })
+    const wrapper = mount(SearchView)
+    await wrapper.find('input.search-input').setValue('x')
+    await wrapper.find('form.search-wrap').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(3)
+    // Two distinct typeTitles → "All" + TV + Movie.
+    const tabs = wrapper.findAll('.pill-tab')
+    expect(tabs.map((t) => t.text())).toEqual(['All', 'TV', 'Movie'])
+
+    await tabs[2].trigger('click') // Movie
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(1)
+  })
+
+  it('shows the empty state when a search returns nothing', async () => {
+    stubApi({ searchAnime: vi.fn().mockResolvedValue({ data: [] }), libraryHas: vi.fn() })
+    const wrapper = mount(SearchView)
+    await wrapper.find('input.search-input').setValue('zzz')
+    await wrapper.find('form.search-wrap').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.find('.poster-grid').exists()).toBe(false)
+    expect(wrapper.find('.empty-state p').text()).toContain('No titles match')
+  })
+})
+
+describe('LibraryView', () => {
+  function rate(smotretId: number, status: string): Record<string, unknown> {
+    return {
+      rate: {
+        id: smotretId,
+        score: 0,
+        status,
+        episodes: 0,
+        rewatches: 0,
+        updated_at: '',
+        target_id: smotretId
+      },
+      shikiAnime: { id: smotretId, name: `Anime ${smotretId}` },
+      smotretAnime: anime(smotretId, 'TV')
+    }
+  }
+
+  it('renders the saved library and filters by Shikimori status', async () => {
+    stubApi({
+      libraryGet: vi.fn().mockResolvedValue([anime(1, 'TV'), anime(2, 'TV'), anime(3, 'TV')]),
+      libraryGetStatus: vi.fn().mockResolvedValue({ 1: { starred: true, downloaded: true } })
+    })
+    const shiki = useShikimoriStore()
+    shiki.rates = [rate(1, 'watching'), rate(2, 'completed')] as unknown as typeof shiki.rates
+
+    const wrapper = mount(LibraryView)
+    await flushPromises()
+
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(3)
+    // Status tabs appear because rates resolved against library ids.
+    const tabs = wrapper.findAll('.pill-tab')
+    expect(tabs.map((t) => t.text())).toEqual(['All', 'Watching', 'Planned', 'Completed'])
+
+    await tabs[1].trigger('click') // Watching → only id 1
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(1)
+
+    await tabs[3].trigger('click') // Completed → only id 2
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(1)
+  })
+
+  it('hides the status tabs when no library entry has a Shikimori status', async () => {
+    stubApi({
+      libraryGet: vi.fn().mockResolvedValue([anime(9, 'TV')]),
+      libraryGetStatus: vi.fn().mockResolvedValue({})
+    })
+    // Rates exist but for a show NOT in the library — tabs must stay hidden
+    // (regression: gating on rate count alone showed empty non-"All" tabs).
+    const shiki = useShikimoriStore()
+    shiki.rates = [rate(1234, 'watching')] as unknown as typeof shiki.rates
+
+    const wrapper = mount(LibraryView)
+    await flushPromises()
+
+    expect(wrapper.find('.pill-tabs').exists()).toBe(false)
+    expect(wrapper.findAll('.poster-grid .acard')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## What & why

Restyle the **Search** and **Library** poster-grid views to the Refined Dark language (redesign epic #160). Search/library data + IPC unchanged.

Fixes #163.

> **Stacked on #161 (PR #171).** Base is `redesign-foundation-theme` so the diff shows only Search/Library changes; GitHub auto-retargets to `main` once #171 merges.

## Changes
**SearchView**
- TopBar "Search · N titles"; `.search-wrap` with an inner `.search-icon` + `.search-input` accent focus ring (`0 0 0 3px var(--accent-soft)`), Enter-to-search (dropped the separate magnifier button per the mock).
- **Type filter** — a real `.pill-tabs` row of the distinct `typeTitle`s in the current results ("All" + e.g. TV / Movie / ONA), filtering client-side.
- Results → global `.poster-grid` of `.acard`s; no results → `.empty-state`.

**LibraryView**
- TopBar "Library · N shows"; **status `.pill-tabs`** (All / Watching / Planned / Completed) — joins the Shikimori rates onto library entries by smotret-anime id and filters by watch status (Watching also matches Rewatching). Tabs hide when no library entry has a Shikimori status (e.g. logged out). Rates are hydrated cache-first on mount.
- `.poster-grid` of card-wraps; re-tokenized "Remove files" delete button on downloaded entries.

## Scope notes
- Implemented the two filters with **real data** (result `typeTitle`; library↔Shikimori status join) rather than the prototype's placeholder Genre/Year outline chips, which are omitted (no data behind them).

## Tests
`test/renderer/components/search-library.test.ts` (happy-dom): Search renders a card per result, the type filter narrows them, empty-state on no results; Library renders the grid, status tabs filter by Watching/Completed, and tabs hide when no entry has a status.

## Verification
typecheck ✓ · test (493 passing, incl. 4 new) ✓ · lint 0 errors ✓ · format ✓ · build ✓ · `npm run dev` boots clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
