### PR TITLE
feat(sidebar): update banner above the user profile

### DIFF
--- a/docs/renderer.md
+++ b/docs/renderer.md
@@ -22,6 +22,7 @@ src/renderer/src/
       AnimeCard.vue
       CleanupModal.vue
       Sidebar.vue
+      SidebarUpdateBanner.vue   Update prompt pinned above the profile chip (reads settings store updateStatus)
     detail/                    AnimeDetailView sub-components + injection keys
       AnimeDetailShell.vue (= views/AnimeDetailView.vue acts as shell)
       ChronologyPanel.vue

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.1.12",
+  "version": "4.1.13",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/renderer/src/assets/theme.css
+++ b/src/renderer/src/assets/theme.css
@@ -241,8 +241,10 @@ body {
   color: var(--accent-ink);
 }
 
-.sidebar-foot {
+.sidebar-bottom {
   margin-top: auto;
+}
+.sidebar-foot {
   padding: 14px;
   border-top: 1px solid var(--border-soft);
 }

--- a/src/renderer/src/components/shared/Sidebar.vue
+++ b/src/renderer/src/components/shared/Sidebar.vue
@@ -4,6 +4,7 @@ import { storeToRefs } from 'pinia';
 import { useLibraryStore, type LibraryView } from '../../stores/library';
 import { useShikimoriStore } from '../../stores/shikimori';
 import { useDownloadsStore } from '../../stores/downloads';
+import SidebarUpdateBanner from './SidebarUpdateBanner.vue';
 
 const libraryStore = useLibraryStore();
 const shikimoriStore = useShikimoriStore();
@@ -149,14 +150,17 @@ const syncLabel = computed(() => {
       </button>
     </nav>
 
-    <div v-if="loggedIn && user" class="sidebar-foot">
-      <div class="user-chip">
-        <img v-if="user.avatar" :src="user.avatar" :alt="user.nickname" class="user-avatar" />
-        <div v-else class="user-avatar">{{ userInitial }}</div>
-        <div class="user-meta">
-          <div class="u-name">{{ user.nickname }}</div>
-          <div class="u-sync" :class="{ offline: !fullySynced }">
-            <span class="dot"></span>{{ syncLabel }}
+    <div class="sidebar-bottom">
+      <SidebarUpdateBanner />
+      <div v-if="loggedIn && user" class="sidebar-foot">
+        <div class="user-chip">
+          <img v-if="user.avatar" :src="user.avatar" :alt="user.nickname" class="user-avatar" />
+          <div v-else class="user-avatar">{{ userInitial }}</div>
+          <div class="user-meta">
+            <div class="u-name">{{ user.nickname }}</div>
+            <div class="u-sync" :class="{ offline: !fullySynced }">
+              <span class="dot"></span>{{ syncLabel }}
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/src/components/shared/SidebarUpdateBanner.vue
+++ b/src/renderer/src/components/shared/SidebarUpdateBanner.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useSettingsStore } from '../../stores/settings';
+
+// Surfaces an available app update right above the sidebar profile chip so users
+// don't have to dig into Settings → General. The whole update pipeline already
+// exists (electron-updater in the main process, broadcast via `update:status`);
+// this just reads the reactive status the settings store already holds and
+// drives the existing `window.api.update*` methods.
+const settingsStore = useSettingsStore();
+const { updateStatus } = storeToRefs(settingsStore);
+
+const dismissed = ref(false);
+
+// A fresh `available`/`ready` transition re-surfaces the banner even if the user
+// dismissed an earlier one (e.g. the download they kicked off has finished).
+watch(
+  () => updateStatus.value.status,
+  (status) => {
+    if (status === 'available' || status === 'ready') dismissed.value = false;
+  }
+);
+
+// Stay silent for idle/checking/up-to-date/error — notably the dev-mode
+// "not available" error must never show a banner.
+const visible = computed(
+  () =>
+    !dismissed.value && ['available', 'downloading', 'ready'].includes(updateStatus.value.status)
+);
+
+const title = computed(() => {
+  switch (updateStatus.value.status) {
+    case 'downloading':
+      return 'Downloading update';
+    case 'ready':
+      return 'Update ready';
+    default:
+      return 'Update available';
+  }
+});
+
+function download(): void {
+  void window.api.updateDownload();
+}
+
+function install(): void {
+  window.api.updateInstall();
+}
+</script>
+
+<template>
+  <div v-if="visible" class="update-banner" :class="updateStatus.status">
+    <div class="ub-head">
+      <svg class="ub-ico" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M12 3v12m0 0l-4-4m4 4l4-4M4.5 19.5h15"
+        />
+      </svg>
+      <div class="ub-meta">
+        <span class="ub-title">{{ title }}</span>
+        <span v-if="updateStatus.version" class="ub-version">v{{ updateStatus.version }}</span>
+      </div>
+      <button
+        v-if="updateStatus.status !== 'downloading'"
+        class="ub-dismiss"
+        aria-label="Dismiss"
+        @click="dismissed = true"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18" />
+        </svg>
+      </button>
+    </div>
+
+    <button v-if="updateStatus.status === 'available'" class="ub-action" @click="download">
+      Download
+    </button>
+    <button v-else-if="updateStatus.status === 'ready'" class="ub-action" @click="install">
+      Restart to update
+    </button>
+    <div v-else class="ub-progress">
+      <div class="ub-bar"><span :style="{ width: (updateStatus.percent || 0) + '%' }" /></div>
+      <span class="ub-pct">{{ updateStatus.percent || 0 }}%</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.update-banner {
+  margin: 0 14px 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--accent-soft);
+  border-radius: var(--radius-btn);
+  background: var(--accent-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ub-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.ub-ico {
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.ub-meta {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+  min-width: 0;
+  flex: 1;
+}
+
+.ub-title {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.ub-version {
+  font-family: var(--font-data);
+  font-size: 0.68rem;
+  color: var(--text-3);
+}
+
+.ub-dismiss {
+  background: none;
+  border: none;
+  padding: 2px;
+  color: var(--text-3);
+  cursor: pointer;
+  display: flex;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.ub-dismiss:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+
+.ub-dismiss svg {
+  width: 14px;
+  height: 14px;
+}
+
+.ub-action {
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-btn);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: filter 0.15s var(--ease);
+}
+
+.ub-action:hover {
+  filter: brightness(1.08);
+}
+
+.ub-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ub-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--surface-3);
+  overflow: hidden;
+}
+
+.ub-bar span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.2s var(--ease);
+}
+
+.ub-pct {
+  font-family: var(--font-data);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-2);
+  min-width: 32px;
+  text-align: right;
+}
+</style>

--- a/test/renderer/components/sidebar-update-banner.test.ts
+++ b/test/renderer/components/sidebar-update-banner.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import SidebarUpdateBanner from '../../../src/renderer/src/components/shared/SidebarUpdateBanner.vue'
+import { useSettingsStore, type UiUpdateStatus } from '../../../src/renderer/src/stores/settings'
+
+const updateDownload = vi.fn()
+const updateInstall = vi.fn()
+
+beforeEach(() => {
+  updateDownload.mockClear()
+  updateInstall.mockClear()
+  // The settings store eagerly subscribes to these at init, so they must exist.
+  ;(window as unknown as { api: unknown }).api = {
+    onFfmpegDownloadProgress: () => () => {},
+    onFpcalcDownloadProgress: () => () => {},
+    onUpdateStatus: () => () => {},
+    updateDownload,
+    updateInstall
+  }
+  setActivePinia(createPinia())
+})
+
+function mountBanner(status: UiUpdateStatus) {
+  const store = useSettingsStore()
+  store.updateStatus = status
+  return { wrapper: mount(SidebarUpdateBanner), store }
+}
+
+describe('SidebarUpdateBanner', () => {
+  it('shows the Download action and version when an update is available', async () => {
+    const { wrapper } = mountBanner({ status: 'available', version: '4.1.12' })
+    expect(wrapper.find('.update-banner').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Update available')
+    expect(wrapper.text()).toContain('v4.1.12')
+
+    await wrapper.get('.ub-action').trigger('click')
+    expect(updateDownload).toHaveBeenCalledTimes(1)
+    expect(updateInstall).not.toHaveBeenCalled()
+  })
+
+  it('shows progress (no action button) while downloading', () => {
+    const { wrapper } = mountBanner({ status: 'downloading', percent: 42 })
+    expect(wrapper.find('.update-banner').exists()).toBe(true)
+    expect(wrapper.find('.ub-progress').exists()).toBe(true)
+    expect(wrapper.text()).toContain('42%')
+    expect(wrapper.find('.ub-action').exists()).toBe(false)
+    // No dismiss mid-download.
+    expect(wrapper.find('.ub-dismiss').exists()).toBe(false)
+  })
+
+  it('shows a Restart action when the update is ready to install', async () => {
+    const { wrapper } = mountBanner({ status: 'ready' })
+    expect(wrapper.text()).toContain('Update ready')
+    await wrapper.get('.ub-action').trigger('click')
+    expect(updateInstall).toHaveBeenCalledTimes(1)
+    expect(updateDownload).not.toHaveBeenCalled()
+  })
+
+  // Regression guard: the banner must stay silent for non-actionable states —
+  // in particular `error`, which fires in dev mode ("not available").
+  it.each(['idle', 'checking', 'up-to-date', 'error'] as const)(
+    'renders nothing for status "%s"',
+    (status) => {
+      const { wrapper } = mountBanner({ status })
+      expect(wrapper.find('.update-banner').exists()).toBe(false)
+    }
+  )
+
+  it('hides when dismissed, then re-surfaces on a fresh "ready" transition', async () => {
+    const { wrapper, store } = mountBanner({ status: 'available', version: '4.1.12' })
+    await wrapper.get('.ub-dismiss').trigger('click')
+    expect(wrapper.find('.update-banner').exists()).toBe(false)
+
+    store.updateStatus = { status: 'downloading', percent: 80 }
+    await wrapper.vm.$nextTick()
+    // Still dismissed while downloading.
+    expect(wrapper.find('.update-banner').exists()).toBe(false)
+
+    store.updateStatus = { status: 'ready' }
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.update-banner').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Update ready')
+  })
+})

--- a/test/renderer/components/sidebar.test.ts
+++ b/test/renderer/components/sidebar.test.ts
@@ -5,6 +5,7 @@ import { createPinia, setActivePinia } from 'pinia'
 import Sidebar from '../../../src/renderer/src/components/shared/Sidebar.vue'
 import { useLibraryStore } from '../../../src/renderer/src/stores/library'
 import { useShikimoriStore } from '../../../src/renderer/src/stores/shikimori'
+import { useSettingsStore } from '../../../src/renderer/src/stores/settings'
 
 beforeEach(() => {
   // The downloads + shikimori stores subscribe to `window.api.on*` at setup.
@@ -57,5 +58,16 @@ describe('Sidebar', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('.u-sync').classes()).toContain('offline')
     expect(wrapper.find('.u-sync').text()).toContain('2 pending')
+  })
+
+  it('shows the update banner even when logged out (it is not gated on login)', () => {
+    // Updates are app-level, not tied to Shikimori — a logged-out user with no
+    // `.user-chip` footer must still see the banner pinned at the bottom.
+    const settings = useSettingsStore()
+    settings.updateStatus = { status: 'available', version: '4.1.12' }
+
+    const wrapper = mount(Sidebar)
+    expect(wrapper.find('.user-chip').exists()).toBe(false)
+    expect(wrapper.find('.update-banner').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

Closes #188. Surfaces an available app update in a small banner pinned to the bottom of the sidebar, directly above the user-profile chip, with a one-click action to download + install — so users stop silently running stale builds.

While investigating, I confirmed the **update backend already works end-to-end** (verified the published Windows installer's sha512 matches `latest.yml`); the gap was purely that updates were only ever shown in **Settings → General**. Findings and the remaining backend gaps (macOS unsigned builds, CI blockmap upload, Windows portable/nsis collision) are tracked separately in #189.

## What it does

New `SidebarUpdateBanner.vue` reads the reactive `updateStatus` the `settings` store already maintains (subscribed to the `update:status` broadcast) and drives the existing `window.api.update*` IPC — **no new IPC, preload, or main-process code**:

| status | banner |
|---|---|
| `available` | "Update available · v{version}" + **Download** |
| `downloading` | progress bar + percent |
| `ready` | **Restart to update** |
| `idle` / `checking` / `up-to-date` / `error` | renders nothing |

The `error` case is deliberately silent so the dev-mode "update not available" error never flashes a banner.

## Positioning (incl. logged-out)

The banner sits in a new always-rendered `.sidebar-bottom` wrapper that now carries `margin-top: auto`, **outside** the `v-if="loggedIn && user"` footer. So the banner appears and stays pinned to the bottom whether or not the user is logged in to Shikimori (updates are app-level). When logged in it sits just above the profile chip; when logged out it's the bottom-most element. `margin-top: auto` simply moved from `.sidebar-foot` to the wrapper, so footer pinning is unchanged.

Dismissible for the session; re-surfaces on a fresh `available`/`ready` transition (e.g. when a download the user kicked off finishes).

## Changes
- **New** `src/renderer/src/components/shared/SidebarUpdateBanner.vue`
- **Modify** `src/renderer/src/components/shared/Sidebar.vue` (render banner in `.sidebar-bottom` wrapper)
- **Modify** `src/renderer/src/assets/theme.css` (`.sidebar-bottom { margin-top: auto }`; move it off `.sidebar-foot`)
- **Docs** `docs/renderer.md` (component inventory)

## Test plan
- **New** `test/renderer/components/sidebar-update-banner.test.ts` (8 cases): Download calls `updateDownload`; downloading shows percent and hides the action/dismiss; ready calls `updateInstall`; `idle/checking/up-to-date/error` render nothing (regression guard); dismiss hides then a fresh `ready` re-surfaces.
- **Extended** `test/renderer/components/sidebar.test.ts`: banner shows when **logged out** (no `.user-chip`) — locks in the not-gated-on-login contract.
- Full gate green locally: typecheck, lint (0 errors), format:check, test (567 passing), test:coverage (no threshold regressions), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
