### PR TITLE
fix(shikimori): migrate API origin to shikimori.io + fix rate-cache target_id

### DIFF
--- a/docs/shikimori.md
+++ b/docs/shikimori.md
@@ -1,6 +1,8 @@
 # Shikimori Integration
 
-Syncs anime watch status and episode progress with [Shikimori](https://shikimori.one). Uses MAL IDs as the shared key between smotret-anime and Shikimori (`myAnimeListId` field on anime series).
+Syncs anime watch status and episode progress with [Shikimori](https://shikimori.io). Uses MAL IDs as the shared key between smotret-anime and Shikimori (`myAnimeListId` field on anime series).
+
+> **Domain:** Shikimori has migrated origins over time (`shikimori.org` → `shikimori.one` → `shikimori.io`). The origin lives in **one** place — `SHIKIMORI_ORIGIN` in `src/shared/shikimori.ts` — and everything (the API base in `shikimori.ts`, image hotlink filters, renderer deep-links) derives from it. Don't hardcode a domain literal anywhere else. The reason centralization matters: a stale domain 301-redirects to the new host, and Node/Electron `fetch` (undici) **strips the `Authorization` header on a cross-origin redirect** — so public reads silently keep working while every authenticated write 404s, which is hard to diagnose.
 
 ## OAuth Flow (OOB)
 
@@ -60,7 +62,7 @@ The **Activity** tab of `FriendsActivityView.vue` shows a chronological feed of 
 
 ### Image hotlink protection (`src/main/lib/shikimori-images.ts`)
 
-Shikimori hotlink-protects the images it serves from `shikimori.one`: a request whose `Referer` is a foreign origin (the renderer's dev-server `http://localhost:…` or the packaged `file://` origin) gets a placeholder instead of the real image. Friend avatars in both `FriendsActivityView.vue` and the detail-page `FriendsPanel.vue` are loaded by the renderer straight from `shikimori.one`, so without intervention they render blank (posters in the same rows look fine because they prefer smotret-anime's CDN). `installShikimoriReferer(session.defaultSession)` — called in `bootstrap()` — registers a `webRequest.onBeforeSendHeaders` interceptor that rewrites the `Referer` to `https://shikimori.one/` for `shikimori.one` URLs. This only touches renderer-initiated `<img>` loads; the REST calls in `shikimori.ts` go through Node `fetch` (a different network stack) and keep their auth headers.
+Shikimori hotlink-protects the images it serves from its origin: a request whose `Referer` is a foreign origin (the renderer's dev-server `http://localhost:…` or the packaged `file://` origin) gets a placeholder instead of the real image. Friend avatars in both `FriendsActivityView.vue` and the detail-page `FriendsPanel.vue` are loaded by the renderer straight from Shikimori, so without intervention they render blank (posters in the same rows look fine because they prefer smotret-anime's CDN). `installShikimoriReferer(session.defaultSession)` — called in `bootstrap()` — registers a `webRequest.onBeforeSendHeaders` interceptor that rewrites the `Referer` to `${SHIKIMORI_ORIGIN}/` for Shikimori URLs (filters derived from `SHIKIMORI_ORIGIN` in `src/shared/shikimori.ts`). This only touches renderer-initiated `<img>` loads; the REST calls in `shikimori.ts` go through Node `fetch` (a different network stack) and keep their auth headers.
 
 ## Airing Calendar
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.1.14",
+  "version": "4.1.15",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -757,7 +757,7 @@ function createWindow(): void {
 
 async function bootstrap(): Promise<void> {
   // Satisfy Shikimori's image hotlink protection so friend avatars (loaded by
-  // the renderer straight from shikimori.one) render instead of coming back blank.
+  // the renderer straight from shikimori.io) render instead of coming back blank.
   installShikimoriReferer(session.defaultSession)
 
   // Handle anime-video:// protocol for local video playback with Range request support.

--- a/src/main/ipc/shikimori.ipc.ts
+++ b/src/main/ipc/shikimori.ipc.ts
@@ -1,12 +1,14 @@
 import { ipcMain } from 'electron'
 import { CHANNELS, EVENT_CHANNELS } from '@shared/ipc/channels'
+import { SHIKIMORI_ORIGIN } from '@shared/shikimori'
 import * as shikimori from '../shikimori'
 import { isNetworkError } from '../lib/errors'
 import { type QueuedShikimoriUpdate } from '../lib/shikimori-queue'
+import { buildRateCacheEntries } from '../lib/shikimori-rate-cache'
 import { CALENDAR_CACHE_TTL_MS, type CalendarEntry } from '../services/shikimori-sync'
 import type { AppDeps } from './index'
 
-const SHIKI_BASE = 'https://shikimori.one'
+const SHIKI_BASE = SHIKIMORI_ORIGIN
 
 export function register({
   store,
@@ -27,19 +29,7 @@ export function register({
     )
     const malIds = rates.map((r) => r.anime.id)
     const malMap = await lookupByMalIds(malIds)
-    const entries = rates.map((rate) => ({
-      rate: {
-        id: rate.id,
-        score: rate.score,
-        status: rate.status,
-        episodes: rate.episodes,
-        rewatches: rate.rewatches ?? 0,
-        updated_at: rate.updated_at,
-        target_id: rate.target_id
-      },
-      shikiAnime: rate.anime,
-      smotretAnime: malMap[rate.anime.id] ?? null
-    }))
+    const entries = buildRateCacheEntries(rates, malMap)
     if (!status) {
       store.set('shikimoriUserRates', entries)
     }

--- a/src/main/lib/continue-watching.ts
+++ b/src/main/lib/continue-watching.ts
@@ -1,7 +1,8 @@
 import type { AnimeSearchResult, AnimeDetail, EpisodeSummary } from '../smotret-api'
 import type { AnimeCacheEntry } from '../services/anime-cache'
+import { SHIKIMORI_ORIGIN } from '../../shared/shikimori'
 
-const SHIKI_BASE = 'https://shikimori.one'
+const SHIKI_BASE = SHIKIMORI_ORIGIN
 const RESUME_POSITION_GATE_SECONDS = 5
 const RESUME_COMPLETION_GATE = 0.95
 const MAX_ENTRIES = 24

--- a/src/main/lib/shikimori-images.ts
+++ b/src/main/lib/shikimori-images.ts
@@ -1,4 +1,4 @@
-// Shikimori serves avatars and posters from shikimori.one behind hotlink
+// Shikimori serves avatars and posters from its origin behind hotlink
 // protection: a request whose `Referer` is a foreign origin (our renderer's
 // dev-server `http://localhost:…` or packaged `file://` origin) gets a
 // placeholder instead of the real image, so friend avatars render blank.
@@ -8,11 +8,13 @@
 // `src/main/shikimori.ts` run through Node `fetch` (a different network stack)
 // and never hit this session interceptor, so their auth headers are untouched.
 
-const SHIKIMORI_REFERER = 'https://shikimori.one/'
+import { SHIKIMORI_ORIGIN, SHIKIMORI_IMAGE_URL_FILTERS } from '../../shared/shikimori'
 
-// Scoped to shikimori.one and its image subdomains (e.g. desu.shikimori.one)
-// so no other host is ever touched.
-export const SHIKIMORI_IMAGE_URL_FILTER = ['https://shikimori.one/*', 'https://*.shikimori.one/*']
+const SHIKIMORI_REFERER = `${SHIKIMORI_ORIGIN}/`
+
+// Scoped to the Shikimori origin and its image subdomains (e.g.
+// desu.shikimori.io) so no other host is ever touched.
+export const SHIKIMORI_IMAGE_URL_FILTER = SHIKIMORI_IMAGE_URL_FILTERS
 
 export function withShikimoriReferer(
   requestHeaders: Record<string, string>

--- a/src/main/lib/shikimori-rate-cache.ts
+++ b/src/main/lib/shikimori-rate-cache.ts
@@ -1,0 +1,48 @@
+// Pure builder for the cached `shikimoriUserRates` entries — split out from the
+// IPC fetch orchestration so the field-mapping (the part that has actually had
+// bugs) can be unit-tested without network or electron-store.
+//
+// The source rows come from `/api/users/:id/anime_rates` (`getUserAnimeRates`),
+// whose entries nest the anime id under `anime.id` and carry NO top-level
+// `target_id`. The renderer store keys rate lookups by `rate.target_id`
+// (`rateByMalId`), so the mapping must derive `target_id` from `anime.id` when
+// the row lacks one — otherwise every cached entry gets a null target and the
+// store can never mirror a status from cache.
+
+import type { AnimeSearchResult } from '../smotret-api'
+import type { ShikiAnimeRateEntry } from '../shikimori'
+
+export interface CachedRateEntry {
+  rate: {
+    id: number
+    score: number
+    status: ShikiAnimeRateEntry['status']
+    episodes: number
+    rewatches: number
+    updated_at: string
+    target_id: number
+  }
+  shikiAnime: ShikiAnimeRateEntry['anime']
+  smotretAnime: AnimeSearchResult | null
+}
+
+export function buildRateCacheEntries(
+  rates: ShikiAnimeRateEntry[],
+  malMap: Record<number, AnimeSearchResult>
+): CachedRateEntry[] {
+  return rates.map((rate) => ({
+    rate: {
+      id: rate.id,
+      score: rate.score,
+      status: rate.status,
+      episodes: rate.episodes,
+      rewatches: rate.rewatches ?? 0,
+      updated_at: rate.updated_at,
+      // anime_rates rows have no top-level target_id; fall back to the nested
+      // anime id so `rateByMalId` can match.
+      target_id: rate.target_id ?? rate.anime.id
+    },
+    shikiAnime: rate.anime,
+    smotretAnime: malMap[rate.anime.id] ?? null
+  }))
+}

--- a/src/main/shikimori.ts
+++ b/src/main/shikimori.ts
@@ -1,8 +1,9 @@
 import type { StorageService } from './store/types'
+import { SHIKIMORI_ORIGIN } from '../shared/shikimori'
 
 const CLIENT_ID = 'wlhQeTkDVSMFmXqvtDJqPG_ZhWEUnG8iI4YG9nadvLU'
 const CLIENT_SECRET = 'r_lIMZbmFWZmVgP9pC9-9XaS0e96lwduMOegZ3YREfM'
-const BASE_URL = 'https://shikimori.one'
+const BASE_URL = SHIKIMORI_ORIGIN
 const REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
 const USER_AGENT = 'anime-dl'
 

--- a/src/renderer/src/components/detail/ShikimoriPanel.vue
+++ b/src/renderer/src/components/detail/ShikimoriPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { inject } from 'vue';
 import { storeToRefs } from 'pinia';
+import { SHIKIMORI_ORIGIN } from '@shared/shikimori';
 import { useShikimoriStore } from '../../stores/shikimori';
 import { ShikimoriKey } from './keys';
 
@@ -44,7 +45,7 @@ const SHIKI_STATUSES: { value: ShikiUserRateStatus; label: string }[] = [
       <h4>
         <span class="sk-logo">Sh</span>Shikimori
         <a
-          :href="`https://shikimori.one/animes/${props.anime.myAnimeListId}`"
+          :href="`${SHIKIMORI_ORIGIN}/animes/${props.anime.myAnimeListId}`"
           target="_blank"
           class="sk-open"
           title="Open on Shikimori"

--- a/src/renderer/src/components/views/FriendsActivityView.vue
+++ b/src/renderer/src/components/views/FriendsActivityView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
+import { SHIKIMORI_ORIGIN } from '@shared/shikimori';
 import { useLibraryStore } from '../../stores/library';
 import { useShikimoriStore } from '../../stores/shikimori';
 
@@ -111,7 +112,7 @@ function openWatching(card: ShikiFriendCard): void {
   if (w.animeId != null) {
     libraryStore.openAnime(w.animeId, String(w.episode || ''));
   } else {
-    void window.api.shellOpenExternal(`https://shikimori.one/animes/${w.malId}`);
+    void window.api.shellOpenExternal(`${SHIKIMORI_ORIGIN}/animes/${w.malId}`);
   }
 }
 
@@ -242,13 +243,13 @@ onMounted(() => loadFriends());
               <div class="fc-actions">
                 <button
                   class="hdr-btn ghost sm"
-                  @click="openExternal(`https://shikimori.one/@${f.nickname}/list/anime`)"
+                  @click="openExternal(`${SHIKIMORI_ORIGIN}/@${f.nickname}/list/anime`)"
                 >
                   Compare
                 </button>
                 <button
                   class="hdr-btn ghost sm"
-                  @click="openExternal(`https://shikimori.one/@${f.nickname}`)"
+                  @click="openExternal(`${SHIKIMORI_ORIGIN}/@${f.nickname}`)"
                 >
                   Message
                 </button>

--- a/src/renderer/src/components/views/ShikimoriView.vue
+++ b/src/renderer/src/components/views/ShikimoriView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
+import { SHIKIMORI_ORIGIN } from '@shared/shikimori';
 import AnimeCard from '../shared/AnimeCard.vue';
 import { useLibraryStore } from '../../stores/library';
 import { useShikimoriStore } from '../../stores/shikimori';
@@ -131,7 +132,7 @@ function selectList(status: string): void {
 
 function openProfile(): void {
   if (profileNickname.value) {
-    void window.api.shellOpenExternal(`https://shikimori.one/@${profileNickname.value}`);
+    void window.api.shellOpenExternal(`${SHIKIMORI_ORIGIN}/@${profileNickname.value}`);
   }
 }
 
@@ -155,7 +156,7 @@ function shikiPosterUrl(entry: ShikiAnimeRateEntry): string {
   // smotret entries via `enrichMissingPosters`, so this is normally non-empty.
   if (entry.smotretAnime?.posterUrlSmall) return entry.smotretAnime.posterUrlSmall;
   const img = entry.shikiAnime.image.original;
-  return img.startsWith('http') ? img : `https://shikimori.one${img}`;
+  return img.startsWith('http') ? img : `${SHIKIMORI_ORIGIN}${img}`;
 }
 
 function shikiTitle(entry: ShikiAnimeRateEntry): string {

--- a/src/renderer/src/stores/shikimori.ts
+++ b/src/renderer/src/stores/shikimori.ts
@@ -44,7 +44,11 @@ export const useShikimoriStore = defineStore('shikimori', () => {
 
   function rateByMalId(malId: number): ShikiAnimeRateEntry | null {
     if (!malId) return null
-    return rates.value.find((r) => r.rate.target_id === malId) ?? null
+    // Fall back to the nested anime id: rate caches written before the
+    // target_id fix (and any future endpoint that omits a top-level target_id)
+    // store `rate.target_id` as null, so match on `shikiAnime.id` too. Keeps
+    // already-cached entries resolvable without waiting for a re-fetch.
+    return rates.value.find((r) => (r.rate.target_id ?? r.shikiAnime?.id) === malId) ?? null
   }
 
   function animeDetailsByMalId(malId: number): ShikiAnimeDetails | null {

--- a/src/shared/shikimori.ts
+++ b/src/shared/shikimori.ts
@@ -1,0 +1,22 @@
+// Single source of truth for the Shikimori web/API origin.
+//
+// Shikimori has migrated domains over its lifetime (shikimori.org →
+// shikimori.one → shikimori.io). When the domain moves, every hardcoded
+// `https://shikimori.<tld>` literal silently breaks — and worst of all the
+// breakage is asymmetric: public GET reads transparently follow the 301 to
+// the new host and still return data, but authenticated writes fail because
+// undici (Node/Electron `fetch`) strips the `Authorization` header on a
+// cross-origin redirect. The result is the app appearing to work (details,
+// friends, recommendations load) while every rate update 404s and live rate
+// lookups fall back to defaults. Centralizing the origin here makes the next
+// migration a one-line change.
+export const SHIKIMORI_ORIGIN = 'https://shikimori.io'
+
+// Image hotlink filters: the origin plus its image subdomains
+// (e.g. desu.shikimori.io). Derived from SHIKIMORI_ORIGIN's host so they stay
+// in lockstep with the API origin.
+const SHIKIMORI_HOST = new URL(SHIKIMORI_ORIGIN).host
+export const SHIKIMORI_IMAGE_URL_FILTERS = [
+  `${SHIKIMORI_ORIGIN}/*`,
+  `https://*.${SHIKIMORI_HOST}/*`
+]

--- a/test/api-clients/shikimori.test.ts
+++ b/test/api-clients/shikimori.test.ts
@@ -52,6 +52,12 @@ describe('shikimori client — fixture replay', () => {
         'User-Agent': 'anime-dl'
       })
     })
+
+    it('targets the shikimori.io origin (regression: shikimori.one now 301-redirects and undici strips auth cross-origin)', async () => {
+      mockFetchOnce(fixture('whoami.json'))
+      await shikimori.getUser('access-token')
+      expect(lastFetchUrl()).toMatch(/^https:\/\/shikimori\.io\//)
+    })
   })
 
   describe('getUserStats', () => {

--- a/test/lib/shikimori-images.test.ts
+++ b/test/lib/shikimori-images.test.ts
@@ -7,12 +7,12 @@ import {
 
 describe('withShikimoriReferer', () => {
   it('sets the Referer to the Shikimori origin', () => {
-    expect(withShikimoriReferer({})).toEqual({ Referer: 'https://shikimori.one/' })
+    expect(withShikimoriReferer({})).toEqual({ Referer: 'https://shikimori.io/' })
   })
 
   it('replaces a foreign Referer (the bug: renderer origin is rejected by hotlink protection)', () => {
     const out = withShikimoriReferer({ Referer: 'http://localhost:5173/' })
-    expect(out.Referer).toBe('https://shikimori.one/')
+    expect(out.Referer).toBe('https://shikimori.io/')
   })
 
   it('preserves other request headers', () => {
@@ -20,7 +20,7 @@ describe('withShikimoriReferer', () => {
     expect(out).toEqual({
       'User-Agent': 'anime-dl',
       Accept: 'image/*',
-      Referer: 'https://shikimori.one/'
+      Referer: 'https://shikimori.io/'
     })
   })
 
@@ -28,6 +28,15 @@ describe('withShikimoriReferer', () => {
     const input = { Accept: 'image/*' }
     withShikimoriReferer(input)
     expect(input).toEqual({ Accept: 'image/*' })
+  })
+})
+
+describe('SHIKIMORI_IMAGE_URL_FILTER', () => {
+  it('scopes to the shikimori.io origin and its image subdomains (regression: domain migrated off shikimori.one)', () => {
+    expect(SHIKIMORI_IMAGE_URL_FILTER).toEqual([
+      'https://shikimori.io/*',
+      'https://*.shikimori.io/*'
+    ])
   })
 })
 
@@ -54,7 +63,7 @@ describe('installShikimoriReferer', () => {
     listener({ requestHeaders: { Referer: 'http://localhost:5173/' } }, callback)
 
     expect(callback).toHaveBeenCalledWith({
-      requestHeaders: { Referer: 'https://shikimori.one/' }
+      requestHeaders: { Referer: 'https://shikimori.io/' }
     })
   })
 })

--- a/test/lib/shikimori-rate-cache.test.ts
+++ b/test/lib/shikimori-rate-cache.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { buildRateCacheEntries } from '../../src/main/lib/shikimori-rate-cache'
+import type { ShikiAnimeRateEntry } from '../../src/main/shikimori'
+import type { AnimeSearchResult } from '../../src/main/smotret-api'
+
+// `/api/users/:id/anime_rates` rows: anime id nested under `anime.id`, and —
+// crucially — NO top-level `target_id`. We cast through `unknown` so the test
+// row matches the real wire shape rather than the (optimistic) interface.
+function animeRatesRow(animeId: number, status = 'completed'): ShikiAnimeRateEntry {
+  return {
+    id: 159000000 + animeId,
+    score: 10,
+    status,
+    episodes: 12,
+    rewatches: 0,
+    updated_at: '2023-12-31T01:08:08.723+03:00',
+    anime: { id: animeId, name: `Anime ${animeId}` }
+  } as unknown as ShikiAnimeRateEntry
+}
+
+describe('buildRateCacheEntries', () => {
+  it('derives target_id from anime.id when the row has none (regression: anime_rates has no top-level target_id, so rateByMalId never matched)', () => {
+    const [entry] = buildRateCacheEntries([animeRatesRow(54595)], {})
+    // Old behavior copied `rate.target_id` straight through → undefined/null,
+    // which the renderer store's `rateByMalId` could never match.
+    expect(entry.rate.target_id).toBe(54595)
+  })
+
+  it('prefers an explicit target_id when one is present', () => {
+    const row = { ...animeRatesRow(54595), target_id: 999 } as ShikiAnimeRateEntry
+    const [entry] = buildRateCacheEntries([row], {})
+    expect(entry.rate.target_id).toBe(999)
+  })
+
+  it('joins the smotret entry by anime id and defaults missing rewatches to 0', () => {
+    const smotret = { id: 33172, title: 'X' } as unknown as AnimeSearchResult
+    const [entry] = buildRateCacheEntries([animeRatesRow(54595)], { 54595: smotret })
+    expect(entry.smotretAnime).toBe(smotret)
+    expect(entry.rate.rewatches).toBe(0)
+    expect(entry.shikiAnime.id).toBe(54595)
+  })
+
+  it('leaves smotretAnime null when the mal map has no match', () => {
+    const [entry] = buildRateCacheEntries([animeRatesRow(54595)], {})
+    expect(entry.smotretAnime).toBeNull()
+  })
+})

--- a/test/renderer/stores/shikimori-store.test.ts
+++ b/test/renderer/stores/shikimori-store.test.ts
@@ -256,4 +256,18 @@ describe('useShikimoriStore', () => {
     captured.rateUpdated[0](mkRate(100, 1))
     expect(store.rateByMalId(0)).toBeNull()
   })
+
+  it('rateByMalId falls back to shikiAnime.id when a cached entry has a null target_id (regression: pre-fix caches never matched)', async () => {
+    const { useShikimoriStore } = await import('../../../src/renderer/src/stores/shikimori')
+    const store = useShikimoriStore()
+    // Mimics an entry written before the target_id fix: target_id is null but
+    // the anime id is present under shikiAnime.id.
+    const legacyEntry = {
+      rate: { id: 1, target_id: null, episodes: 9, status: 'completed', score: 10 },
+      shikiAnime: { id: 54595 },
+      smotretAnime: null
+    } as unknown as ShikiAnimeRateEntry
+    captured.ratesRefreshed[0]([legacyEntry])
+    expect(store.rateByMalId(54595)?.rate.episodes).toBe(9)
+  })
 })


### PR DESCRIPTION
## Summary

Two users reported Shikimori statuses showing **"Planned"** on already-watched anime and a **`Shikimori API error: 404`** when saving a rate. Both trace to a single root cause: **Shikimori migrated its domain off `shikimori.one`** (it now 301-redirects to `shikimori.io`), and Node/Electron's `fetch` (undici) **strips the `Authorization` header on a cross-origin redirect**.

The breakage was asymmetric and therefore confusing:
- **Public GET reads** (anime details, friends, recommendations) transparently follow the redirect and keep working → the panel looks healthy.
- **Authenticated writes** (`PATCH`/`POST /api/v2/user_rates`) arrive at `.io` with no `Authorization` → Shikimori returns **404** (the Save error).
- **Token refresh** (`POST /oauth/token`) breaks across the redirect, so the live `get-rate` handler throws before returning → the detail panel falls back to its `'planned'` default for every title.

I confirmed the migration directly: `shikimori.one/...` → `301` → `shikimori.io/...`, undici follows it, and the `Authorization` header is dropped on that hop. The user's rate data is intact on `shikimori.io`.

## Changes

- **Centralize the origin.** New `src/shared/shikimori.ts` exports `SHIKIMORI_ORIGIN` (`https://shikimori.io`) and the derived image hotlink filters. The API base (`shikimori.ts`), continue-watching, the IPC layer, image referer/filters, and all renderer deep-links now derive from it — no more scattered domain literals. The next migration is a one-line change.
- **Fix a latent rate-cache bug.** `fetchAndCacheShikimoriRates` built cache entries with `target_id: rate.target_id`, but the `/api/users/:id/anime_rates` endpoint nests the id under `anime.id` and has **no top-level `target_id`** — so all cached entries stored a null target and the store's `rateByMalId()` could never match (the offline status mirror was dead). Extracted a pure `buildRateCacheEntries` helper that falls back to `anime.id`.
- **Defense-in-depth:** `rateByMalId` in the store now also falls back to `shikiAnime.id`, so entries already cached on disk (with null `target_id`) resolve immediately without waiting for a re-fetch.
- Updated `docs/shikimori.md` with the domain-centralization rule and the redirect/auth-stripping rationale.

## Behavior

- Before: watched anime show "Planned"; saving a rate fails with `404`.
- After: live status and rate writes work against `shikimori.io`; cached statuses resolve even from pre-fix caches.

## Test plan

- `test/lib/shikimori-rate-cache.test.ts` (new) — derives `target_id` from `anime.id` when the row lacks one (fails on the old straight-copy behavior).
- `test/renderer/stores/shikimori-store.test.ts` — new case: `rateByMalId` matches a legacy entry whose `target_id` is null via `shikiAnime.id`.
- `test/lib/shikimori-images.test.ts` — Referer/filters now assert `shikimori.io`; added a filter-scope regression.
- `test/api-clients/shikimori.test.ts` — new regression asserting requests target the `shikimori.io` origin.
- Full gate green locally: `typecheck`, `lint` (0 errors), `format:check`, `test` (585 passing), `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)