### PR TITLE
perf(anime-detail): cache-first, non-blocking anime page open (#196)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,7 @@ For the per-domain IPC router split and the disposable subscription contract, se
 | `src/main/lib/errors.ts` | Pure helpers: `errorCode` (walks `cause` chain), `isNetworkError` (transport-vs-application classification) |
 | `src/main/lib/shikimori-queue.ts` | `QueuedShikimoriUpdate`/`ConsolidatedWorkItem` types + pure `consolidateQueue` (per-malId offline-queue collapse) |
 | `src/main/lib/filename.ts` | Pure `parseEpisodeFromFilename` (episodeInt + ext from sanitized download filename) |
+| `src/main/lib/episode-file-scan.ts` | `createEpisodeFileScanner` — the episode-file scan cache backing `file:check-episodes` (#196). Owns `fileCheckCache` + an in-flight dedupe map; exposes a synchronous `scanEpisodeFiles` (consumed by skip-analysis + cold-storage) and an async `scanEpisodeFilesAsync` that backs the cache-first `checkEpisodeFiles` (async first scan, deduped) + the background rescan. Plus pure `accumulateEpisodeFiles` / `filterScanResult`. Deps-injected (`getDirsToScan`, `sanitizeFilename`, `onEpisodesChanged`); `index.ts` wires it and forwards the sync scanner into the two services |
 | `src/main/streaming/codec-strings.ts` | Pure ffprobe→codec-string mappers: `avcCodecString`, `hevcCodecString`, `aacCodecString` (MSE-compatible RFC 6381 strings) |
 | `src/main/store/types.ts` | Injected `StorageService<S>` persistence interface (schema-typed get/set/has/delete); decouples services from `electron-store` |
 | `src/main/store/index.ts` | `createStorageService(defaults)` electron-store binding + `MainStorageService.migrateWatchProgressV2()` |

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -88,7 +88,8 @@ For the full store + composable inventory, see [Renderer architecture](./rendere
 ```
 AnimeDetailView  -->  getAnimeCache(id) --> instant render if cached and fresh
                  -->  getAnime(id) --> full anime with episode list (background-refresh)
-                 -->  getEpisode(id) x N (batches of 5) --> translations per episode
+                 -->  getEpisodesBatchCached(ids) --> cached translations, instant paint
+                 -->  getEpisodesBatch(ids) --> network refresh (background), patches rows
                  -->  all active translations shown (no quality minimum)
                  -->  best quality per author+type deduplication
                  -->  checkFileStatus() --> which episodes exist on disk
@@ -106,6 +107,20 @@ spinner stays up until the API responds. A per-mount generation counter +
 `disposed` flag prevent stale background fetches from polluting state when
 the user rapidly switches anime. Cache writes are gated on starred OR
 downloaded; unstarring evicts the cache entry if the anime isn't downloaded.
+
+Cache-first, non-blocking open (#196): a cache-rendered open is fully
+cache-first — episode translations paint from `get-episodes-batch-cached` (no
+network) before `getEpisodesBatch` returns, then patch on the background
+refresh. `getAnime` is fired as a non-blocking background refresh (not awaited
+inline) so watch-progress / Shikimori / skip-detection mount-tail work doesn't
+queue behind it; a *failing* background refresh keeps `dataSource: 'cache'` so
+the offline chip never flips after a successful cache paint (the
+`renderedFromCache` guard). `checkFileStatus` runs once per open. The cold open
+(no cache, e.g. non-library anime — episodes are `isCachable`-gated too, so
+they have no cache to serve) fetches the detail, then runs the episode batch +
+file scan concurrently rather than stacking them. The first per-anime file scan
+is async (`fsPromises.readdir`, `lib/episode-file-scan.ts`) so it never stalls
+the single-threaded main process, and concurrent misses are deduped to one scan.
 
 Per-episode translation selector with priority chain:
   1. In download queue → locked to queued translation

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -34,7 +34,8 @@ Renderer composables that own broadcast subscriptions (e.g. `useShikimori`, `use
 | `get-anime-cache` | invoke | Read cached AnimeDetail for fast first paint (returns null if missing or older than 24h) |
 | `set-anime-cache` | invoke | Write AnimeDetail to cache (no-op if anime is neither starred nor downloaded) |
 | `get-episode` | invoke | Fetch episode translations (single episode) |
-| `get-episodes-batch` | invoke | Bulk-fetch translations for a page of episodes in one request (collapses the per-episode cold-load waterfall, #155); caches each result, falls back to cached episodes on failure |
+| `get-episodes-batch` | invoke | Bulk-fetch translations for a page of episodes in one request (collapses the per-episode cold-load waterfall, #155); caches each result, falls back to cached episodes on failure (via the shared `readCachedEpisodes` helper) |
+| `get-episodes-batch-cached` | invoke | Cache-first read (#196): returns the already-cached translations for a page of episodes with no network, so the episode list paints instantly for previously-viewed anime; the renderer then background-refreshes via `get-episodes-batch` and patches. Shares `readCachedEpisodes` with the network-first fallback. Always `source: 'cache'`; empty `data` means nothing was cached |
 | `probe-embed-quality` | invoke | Probe embed API for actual stream height |
 | `report-quality-mismatch` | invoke | Report a detected quality mismatch (stored in memory) |
 | `get-quality-mismatch-count` | invoke | Get number of collected mismatches |
@@ -100,7 +101,7 @@ Renderer composables that own broadcast subscriptions (e.g. `useShikimori`, `use
 | `update:install` | invoke | Quit and install downloaded update |
 | `update:status` | send | Update check/download progress and status |
 | `cache-get-poster` | invoke | Get base64-encoded cached poster for offline anime |
-| `file:check-episodes` | invoke | Check which episodes exist on disk (session-cached, triggers background rescan on cache hit) |
+| `file:check-episodes` | invoke | Check which episodes exist on disk (session-cached, triggers background rescan on cache hit). Async first scan (#196): the first per-anime scan uses `fsPromises.readdir` off the main loop, deduped so concurrent misses share one scan; backed by `lib/episode-file-scan.ts` |
 | `file:episodes-changed` | send | Background rescan detected file changes, pushes updated results to renderer |
 | `file:open` | invoke | Open file with default app (verifies existence, returns error + invalidates cache if missing) |
 | `file:show-in-folder` | invoke | Reveal file in explorer |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anime-dl-app",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "description": "Anime episode downloader",
   "main": "./out/main/index.js",
   "engines": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,6 @@ import {
   runAutoDownloadTick
 } from './auto-downloader'
 import * as fs from 'fs'
-import * as fsPromises from 'fs/promises'
 import * as path from 'path'
 import { execFile } from 'child_process'
 import {
@@ -48,7 +47,8 @@ import { createShikimoriSyncService } from './services/shikimori-sync'
 import { createStreamingService } from './streaming'
 import { createMp4StatsService } from './services/mp4-stats'
 import { App } from './app/core'
-import { registerIpcRouters, type FileCheckResult } from './ipc'
+import { registerIpcRouters } from './ipc'
+import { createEpisodeFileScanner } from './lib/episode-file-scan'
 
 export interface AutoDownloadSubscription {
   animeId: number
@@ -297,187 +297,31 @@ async function sumShowFiles(animeName: string): Promise<{ bytes: number; files: 
   return { bytes, files }
 }
 
-const fileCheckCache = new Map<string, FileCheckResult>()
-
-function scanEpisodeFiles(animeName: string): FileCheckResult {
-  const animeDirName = sanitizeFilename(animeName)
-  const dirsToCheck = [coldStorageService.getDownloadDir()]
-  if (coldStorageService.isAdvanced()) {
-    const coldDir = coldStorageService.getColdStorageDir()
-    if (coldDir) dirsToCheck.push(coldDir)
-  }
-
-  const result: FileCheckResult = {}
-
-  for (const dir of dirsToCheck) {
-    const animeDir = path.join(dir, animeDirName)
-    if (!fs.existsSync(animeDir)) continue
-
-    let files: string[]
-    try {
-      files = fs.readdirSync(animeDir)
-    } catch {
-      continue
+// Episode-file scan cache backing `CHANNELS.FILE_CHECK_EPISODES` (#196). The
+// scanner lives in `lib/episode-file-scan.ts` so the cache-first / async-scan /
+// concurrent-dedupe behavior is unit-testable. `getDirsToScan` reads
+// `coldStorageService` lazily (declared below) — only invoked at scan time, so
+// the forward reference resolves at runtime. The synchronous
+// `fileScanner.scanEpisodeFiles` is what skip-analysis + cold-storage consume.
+const fileScanner = createEpisodeFileScanner({
+  getDirsToScan: () => {
+    const dirs = [coldStorageService.getDownloadDir()]
+    if (coldStorageService.isAdvanced()) {
+      const coldDir = coldStorageService.getColdStorageDir()
+      if (coldDir) dirs.push(coldDir)
     }
-
-    for (const file of files) {
-      const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
-      if (match) {
-        const base = match[1]
-        const author = match[2]
-        const ext = match[3] as 'mkv' | 'mp4'
-        if (!result[base]) result[base] = []
-        const existing = result[base].find((e) => e.author === author)
-        if (existing) {
-          existing.type = ext
-          existing.filePath = path.join(animeDir, file)
-        } else {
-          result[base].push({ type: ext, filePath: path.join(animeDir, file), author })
-        }
-        continue
-      }
-
-      const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
-      if (legacyMatch) {
-        const base = legacyMatch[1]
-        const ext = legacyMatch[2] as 'mkv' | 'mp4'
-        if (!result[base]) result[base] = []
-        const hasAuthorVersion = result[base].some((e) => e.author)
-        if (!hasAuthorVersion || !result[base].some((e) => !e.author)) {
-          const existing = result[base].find((e) => !e.author)
-          if (existing) {
-            existing.type = ext
-            existing.filePath = path.join(animeDir, file)
-          } else {
-            result[base].push({ type: ext, filePath: path.join(animeDir, file) })
-          }
-        }
-      }
-    }
-  }
-  return result
-}
-
-function filterScanResult(
-  fullResult: FileCheckResult,
-  animeName: string,
-  episodeInts: string[]
-): FileCheckResult {
-  const baseMap = new Map<string, string>()
-  for (const epInt of episodeInts) {
-    const padded = epInt.padStart(2, '0')
-    const base = sanitizeFilename(`${animeName} - ${padded}`)
-    baseMap.set(base, epInt)
-  }
-
-  const filtered: FileCheckResult = {}
-  for (const [base, files] of Object.entries(fullResult)) {
-    const epInt = baseMap.get(base)
-    if (epInt) {
-      filtered[epInt] = files
-    }
-  }
-  return filtered
-}
-
-async function backgroundRescan(animeName: string): Promise<void> {
-  const animeDirName = sanitizeFilename(animeName)
-  const dirsToCheck = [coldStorageService.getDownloadDir()]
-  if (coldStorageService.isAdvanced()) {
-    const coldDir = coldStorageService.getColdStorageDir()
-    if (coldDir) dirsToCheck.push(coldDir)
-  }
-
-  const result: FileCheckResult = {}
-
-  for (const dir of dirsToCheck) {
-    const animeDir = path.join(dir, animeDirName)
-    let files: string[]
-    try {
-      files = await fsPromises.readdir(animeDir)
-    } catch {
-      continue
-    }
-
-    for (const file of files) {
-      const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
-      if (match) {
-        const base = match[1]
-        const author = match[2]
-        const ext = match[3] as 'mkv' | 'mp4'
-        if (!result[base]) result[base] = []
-        const existing = result[base].find((e) => e.author === author)
-        if (existing) {
-          existing.type = ext
-          existing.filePath = path.join(animeDir, file)
-        } else {
-          result[base].push({ type: ext, filePath: path.join(animeDir, file), author })
-        }
-        continue
-      }
-
-      const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
-      if (legacyMatch) {
-        const base = legacyMatch[1]
-        const ext = legacyMatch[2] as 'mkv' | 'mp4'
-        if (!result[base]) result[base] = []
-        const hasAuthorVersion = result[base].some((e) => e.author)
-        if (!hasAuthorVersion || !result[base].some((e) => !e.author)) {
-          const existing = result[base].find((e) => !e.author)
-          if (existing) {
-            existing.type = ext
-            existing.filePath = path.join(animeDir, file)
-          } else {
-            result[base].push({ type: ext, filePath: path.join(animeDir, file) })
-          }
-        }
-      }
-    }
-  }
-
-  const cached = fileCheckCache.get(animeName)
-  const normalize = (r: FileCheckResult) => {
-    const sorted: FileCheckResult = {}
-    for (const key of Object.keys(r).sort()) {
-      sorted[key] = [...r[key]].sort((a, b) => (a.author || '').localeCompare(b.author || ''))
-    }
-    return sorted
-  }
-  const newJson = JSON.stringify(normalize(result))
-  const cachedJson = cached ? JSON.stringify(normalize(cached)) : ''
-  if (newJson !== cachedJson) {
-    fileCheckCache.set(animeName, result)
+    return dirs
+  },
+  sanitizeFilename,
+  onEpisodesChanged: (animeName, result) => {
     for (const win of BrowserWindow.getAllWindows()) {
       win.webContents.send(EVENT_CHANNELS.FILE_EPISODES_CHANGED, animeName, result)
     }
   }
-}
-
-// Episode-file scan backing `CHANNELS.FILE_CHECK_EPISODES` (Phase 3 slice 3f):
-// a cache hit is served immediately and refreshed by a background rescan; a
-// miss scans synchronously and primes the cache. Kept here — not in
-// `file.ipc.ts` — because `coldStorageService` also feeds off
-// `scanEpisodeFiles` / `fileCheckCache`.
-function checkEpisodeFiles(animeName: string, episodeInts: string[]): FileCheckResult {
-  const cached = fileCheckCache.get(animeName)
-  if (cached) {
-    backgroundRescan(animeName).catch((err) => console.error('Background rescan failed:', err))
-    return filterScanResult(cached, animeName, episodeInts)
-  }
-
-  const fullResult = scanEpisodeFiles(animeName)
-  fileCheckCache.set(animeName, fullResult)
-  return filterScanResult(fullResult, animeName, episodeInts)
-}
-
-function invalidateFileCacheByDirName(animeDirName: string): void {
-  for (const [key] of fileCheckCache) {
-    if (sanitizeFilename(key) === animeDirName) {
-      fileCheckCache.delete(key)
-      break
-    }
-  }
-}
+})
+const scanEpisodeFiles = fileScanner.scanEpisodeFiles
+const checkEpisodeFiles = fileScanner.checkEpisodeFiles
+const invalidateFileCacheByDirName = fileScanner.invalidateByDirName
 
 const smotretApi = new SmotretApi(() => store.get('token') as string)
 
@@ -494,7 +338,7 @@ const coldStorageService = createColdStorageService({
   sanitizeFilename,
   parseEpisodeFromFilename,
   scanEpisodeFiles,
-  invalidateFileCache: (animeName) => fileCheckCache.delete(animeName),
+  invalidateFileCache: fileScanner.invalidate,
   broadcast: broadcastToAll,
   usageProgressChannel: EVENT_CHANNELS.STORAGE_USAGE_PROGRESS,
   cleanupPendingChannel: EVENT_CHANNELS.STORAGE_CLEANUP_PENDING,
@@ -699,7 +543,7 @@ function registerIpcHandlers(): void {
     getFfmpegPath,
     getFfprobePath,
     clearFfmpegPaths,
-    invalidateFileCache: (animeName) => fileCheckCache.delete(animeName),
+    invalidateFileCache: fileScanner.invalidate,
     getFfmpegDir,
     sumShowFiles,
     checkFfmpeg,
@@ -711,7 +555,7 @@ function registerIpcHandlers(): void {
     broadcast: broadcastToAll,
     checkEpisodeFiles,
     invalidateFileCacheByDirName,
-    clearFileCache: () => fileCheckCache.clear(),
+    clearFileCache: fileScanner.clear,
     streamingService,
     mp4StatsService
   })
@@ -851,7 +695,7 @@ async function bootstrap(): Promise<void> {
       author,
       quality
     } = info
-    fileCheckCache.delete(animeName)
+    fileScanner.invalidate(animeName)
 
     // Persist episode metadata now that the video is on disk. Writing this at enqueue
     // time caused stale ⬇ icons to survive cancelled / failed downloads.
@@ -892,7 +736,7 @@ async function bootstrap(): Promise<void> {
   })
 
   downloadManager.onMergeComplete(async ({ animeName, animeId, episodeLabel }) => {
-    fileCheckCache.delete(animeName)
+    fileScanner.invalidate(animeName)
     // Auto-move to cold after merge
     if (coldStorageService.isAdvanced() && (store.get('autoMoveToCold') as boolean)) {
       await coldStorageService.moveEpisodeToColdStorage(animeName, episodeLabel)

--- a/src/main/ipc/anime.ipc.ts
+++ b/src/main/ipc/anime.ipc.ts
@@ -1,8 +1,20 @@
 import { ipcMain } from 'electron'
 import { CHANNELS } from '@shared/ipc/channels'
 import type { AppDeps } from './index'
+import type { EpisodeDetail } from '../smotret-api'
 
 export function register({ smotretApi, animeCacheService, rememberAnimeMeta }: AppDeps): void {
+  // Shared cache read for the cache-first channel + the network-first
+  // error-fallback (#196) so the two reads can't drift: id → cached episode
+  // translation, undefined entries filtered out.
+  function readCachedEpisodes(animeId: number, episodeIds: number[]): EpisodeDetail[] {
+    const cached = animeCacheService.getEntry(animeId)
+    if (!cached) return []
+    return episodeIds
+      .map((id) => cached.episodes[id])
+      .filter((d): d is EpisodeDetail => d !== undefined)
+  }
+
   ipcMain.handle(CHANNELS.VALIDATE_TOKEN, () => smotretApi.validateToken())
 
   ipcMain.handle(CHANNELS.SEARCH_ANIME, async (_event, query: string) => {
@@ -90,16 +102,24 @@ export function register({ smotretApi, animeCacheService, rememberAnimeMeta }: A
         return { ...result, source: 'api' }
       } catch (err) {
         if (animeId) {
-          const cached = animeCacheService.getEntry(animeId)
-          if (cached) {
-            const data = episodeIds
-              .map((id) => cached.episodes[id])
-              .filter((d): d is NonNullable<typeof d> => d !== undefined)
-            if (data.length > 0) return { data, source: 'cache' }
-          }
+          const data = readCachedEpisodes(animeId, episodeIds)
+          if (data.length > 0) return { data, source: 'cache' }
         }
         throw err
       }
+    }
+  )
+
+  // Cache-first read: returns whatever translations `animeCacheService` already
+  // has, synchronously, with no network (#196). The renderer paints these rows
+  // immediately, then background-refreshes via the network `GET_EPISODES_BATCH`
+  // and patches. Always reports `source: 'cache'`; an empty `data` just means
+  // nothing was cached (cold/non-library anime) and the network fetch fills it.
+  ipcMain.handle(
+    CHANNELS.GET_EPISODES_BATCH_CACHED,
+    (_event, episodeIds: number[], animeId?: number) => {
+      const data = animeId ? readCachedEpisodes(animeId, episodeIds) : []
+      return { data, source: 'cache' as const }
     }
   )
 }

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -29,6 +29,7 @@ import * as autoDownloadRouter from './auto-download.ipc'
 import * as playerRouter from './player.ipc'
 import * as syncplayRouter from './syncplay.ipc'
 import * as debugRouter from './debug.ipc'
+import type { FileCheckResult } from '../lib/episode-file-scan'
 
 export interface FfmpegInfo {
   available: boolean
@@ -37,15 +38,10 @@ export interface FfmpegInfo {
   encoders: string[]
 }
 
-/**
- * Map of episode-int → matched files on disk, keyed without the leading-zero
- * pad. Produced by the `index.ts` episode-file scanner and returned verbatim
- * by `CHANNELS.FILE_CHECK_EPISODES`.
- */
-export type FileCheckResult = Record<
-  string,
-  { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
->
+// The episode-file scan result type lives with the scanner (#196). Re-exported
+// here so the long-standing `import { FileCheckResult } from './ipc'` sites stay
+// put.
+export type { FileCheckResult }
 
 /**
  * Dependencies passed to every per-domain IPC router (refactor epic #84,
@@ -98,7 +94,7 @@ export interface AppDeps {
    * a background rescan kicked off when a cache hit is served. The scan cache +
    * helpers stay in `index.ts` because `coldStorageService` also feeds off them.
    */
-  checkEpisodeFiles: (animeName: string, episodeInts: string[]) => FileCheckResult
+  checkEpisodeFiles: (animeName: string, episodeInts: string[]) => Promise<FileCheckResult>
   /** Drops the file-scan cache entry whose key sanitizes to `dirName`. */
   invalidateFileCacheByDirName: (dirName: string) => void
   /** Clears the entire file-scan cache (used before a bulk move-to-cold). */

--- a/src/main/lib/episode-file-scan.ts
+++ b/src/main/lib/episode-file-scan.ts
@@ -1,0 +1,251 @@
+// Episode-file scan cache backing `CHANNELS.FILE_CHECK_EPISODES` (#196).
+//
+// Extracted out of `src/main/index.ts` so the cache-first / async-first-scan /
+// concurrent-dedupe behavior is unit-testable (index.ts is excluded from the
+// coverage gate and pulls in electron). The cache + helpers live here because
+// `coldStorageService` and `skipAnalysisService` also feed off the synchronous
+// `scanEpisodeFiles` scanner.
+//
+// Two scanners, deliberately:
+//   - `scanEpisodeFiles`      — synchronous (`readdirSync`), injected into
+//     skip-analysis + cold-storage which call it synchronously.
+//   - `scanEpisodeFilesAsync` — `fsPromises.readdir`, used by the
+//     `checkEpisodeFiles` first-hit path + the background rescan so the first
+//     per-anime scan never stalls the single-threaded main process.
+// Both fold filenames through the shared `accumulateEpisodeFiles` parser so the
+// author-tag / legacy-filename matching can't drift between them.
+
+import * as fs from 'fs'
+import * as fsPromises from 'fs/promises'
+import * as path from 'path'
+
+/**
+ * Map of episode base-name (sanitized `${anime} - NN`) → matched files on disk.
+ * Produced by the episode-file scanner and (after `filterScanResult`) returned
+ * verbatim by `CHANNELS.FILE_CHECK_EPISODES`.
+ */
+export type FileCheckResult = Record<
+  string,
+  { type: 'mkv' | 'mp4'; filePath: string; translationId?: number; author?: string }[]
+>
+
+/**
+ * Fold one anime directory's filenames into the running scan result. Matches
+ * author-tagged `Name - NN [Author].mkv` first, then legacy un-tagged
+ * `Name - NN.mkv`. Shared by the sync + async scanners.
+ */
+export function accumulateEpisodeFiles(
+  result: FileCheckResult,
+  animeDir: string,
+  files: string[]
+): void {
+  for (const file of files) {
+    const match = file.match(/^(.+?) \[(.+?)\]\.(mkv|mp4)$/)
+    if (match) {
+      const base = match[1]
+      const author = match[2]
+      const ext = match[3] as 'mkv' | 'mp4'
+      if (!result[base]) result[base] = []
+      const existing = result[base].find((e) => e.author === author)
+      if (existing) {
+        existing.type = ext
+        existing.filePath = path.join(animeDir, file)
+      } else {
+        result[base].push({ type: ext, filePath: path.join(animeDir, file), author })
+      }
+      continue
+    }
+
+    const legacyMatch = file.match(/^(.+)\.(mkv|mp4)$/)
+    if (legacyMatch) {
+      const base = legacyMatch[1]
+      const ext = legacyMatch[2] as 'mkv' | 'mp4'
+      if (!result[base]) result[base] = []
+      const hasAuthorVersion = result[base].some((e) => e.author)
+      if (!hasAuthorVersion || !result[base].some((e) => !e.author)) {
+        const existing = result[base].find((e) => !e.author)
+        if (existing) {
+          existing.type = ext
+          existing.filePath = path.join(animeDir, file)
+        } else {
+          result[base].push({ type: ext, filePath: path.join(animeDir, file) })
+        }
+      }
+    }
+  }
+}
+
+/** Narrow a full per-anime scan down to the requested episode-ints. */
+export function filterScanResult(
+  fullResult: FileCheckResult,
+  animeName: string,
+  episodeInts: string[],
+  sanitizeFilename: (name: string) => string
+): FileCheckResult {
+  const baseMap = new Map<string, string>()
+  for (const epInt of episodeInts) {
+    const padded = epInt.padStart(2, '0')
+    const base = sanitizeFilename(`${animeName} - ${padded}`)
+    baseMap.set(base, epInt)
+  }
+
+  const filtered: FileCheckResult = {}
+  for (const [base, files] of Object.entries(fullResult)) {
+    const epInt = baseMap.get(base)
+    if (epInt) filtered[epInt] = files
+  }
+  return filtered
+}
+
+export interface EpisodeFileScanDeps {
+  /** Directories to scan for an anime (download dir + optional cold-storage dir). */
+  getDirsToScan: () => string[]
+  sanitizeFilename: (name: string) => string
+  /** Emitted by a background rescan when the on-disk set changed since the cache. */
+  onEpisodesChanged: (animeName: string, result: FileCheckResult) => void
+}
+
+export interface EpisodeFileScanner {
+  /** Synchronous full scan — consumed by skip-analysis + cold-storage. */
+  scanEpisodeFiles: (animeName: string) => FileCheckResult
+  /** Async full scan — backs the first-hit path + background rescan. */
+  scanEpisodeFilesAsync: (animeName: string) => Promise<FileCheckResult>
+  /**
+   * Cache-first episode-file check. Cache hit → serve immediately + kick a
+   * background rescan; cache miss → async scan, deduped so concurrent misses
+   * for the same anime share one scan + one cache write.
+   */
+  checkEpisodeFiles: (animeName: string, episodeInts: string[]) => Promise<FileCheckResult>
+  backgroundRescan: (animeName: string) => Promise<void>
+  /** Drop a single anime's cache entry (after a download/merge/delete). */
+  invalidate: (animeName: string) => void
+  /** Drop the entry whose key sanitizes to `dirName` (after a path-keyed delete). */
+  invalidateByDirName: (dirName: string) => void
+  /** Clear the whole cache (before a bulk move-to-cold). */
+  clear: () => void
+}
+
+export function createEpisodeFileScanner(deps: EpisodeFileScanDeps): EpisodeFileScanner {
+  const { getDirsToScan, sanitizeFilename, onEpisodesChanged } = deps
+  const fileCheckCache = new Map<string, FileCheckResult>()
+  // In-flight scans keyed by animeName: concurrent misses (back-nav, parallel
+  // openers) share one disk scan + one cache write instead of double-scanning.
+  const inFlight = new Map<string, Promise<FileCheckResult>>()
+
+  function scanEpisodeFiles(animeName: string): FileCheckResult {
+    const animeDirName = sanitizeFilename(animeName)
+    const result: FileCheckResult = {}
+    for (const dir of getDirsToScan()) {
+      const animeDir = path.join(dir, animeDirName)
+      if (!fs.existsSync(animeDir)) continue
+      let files: string[]
+      try {
+        files = fs.readdirSync(animeDir)
+      } catch {
+        continue
+      }
+      accumulateEpisodeFiles(result, animeDir, files)
+    }
+    return result
+  }
+
+  async function scanEpisodeFilesAsync(animeName: string): Promise<FileCheckResult> {
+    const animeDirName = sanitizeFilename(animeName)
+    const result: FileCheckResult = {}
+    for (const dir of getDirsToScan()) {
+      const animeDir = path.join(dir, animeDirName)
+      let files: string[]
+      try {
+        files = await fsPromises.readdir(animeDir)
+      } catch {
+        continue
+      }
+      accumulateEpisodeFiles(result, animeDir, files)
+    }
+    return result
+  }
+
+  function normalize(r: FileCheckResult): FileCheckResult {
+    const sorted: FileCheckResult = {}
+    for (const key of Object.keys(r).sort()) {
+      sorted[key] = [...r[key]].sort((a, b) => (a.author || '').localeCompare(b.author || ''))
+    }
+    return sorted
+  }
+
+  async function backgroundRescan(animeName: string): Promise<void> {
+    const result = await scanEpisodeFilesAsync(animeName)
+    const cached = fileCheckCache.get(animeName)
+    const newJson = JSON.stringify(normalize(result))
+    const cachedJson = cached ? JSON.stringify(normalize(cached)) : ''
+    if (newJson !== cachedJson) {
+      fileCheckCache.set(animeName, result)
+      onEpisodesChanged(animeName, result)
+    }
+  }
+
+  async function checkEpisodeFiles(
+    animeName: string,
+    episodeInts: string[]
+  ): Promise<FileCheckResult> {
+    const cached = fileCheckCache.get(animeName)
+    if (cached) {
+      backgroundRescan(animeName).catch((err) => console.error('Background rescan failed:', err))
+      return filterScanResult(cached, animeName, episodeInts, sanitizeFilename)
+    }
+
+    let scan = inFlight.get(animeName)
+    if (!scan) {
+      // `scan` is assigned synchronously before either callback can run, so it's
+      // safe to compare against the live in-flight entry inside them. If an
+      // `invalidate`/`clear` (download/merge/move/delete) drops this entry while
+      // the scan is pending, we must NOT write the now-stale result back over the
+      // delete — only the current in-flight scan is allowed to populate the cache.
+      // The awaiting caller still gets `result` returned; we just suppress the
+      // stale WRITE. A superseding scan's finally likewise can't evict a newer one.
+      scan = scanEpisodeFilesAsync(animeName)
+        .then((result) => {
+          if (inFlight.get(animeName) === scan) fileCheckCache.set(animeName, result)
+          return result
+        })
+        .finally(() => {
+          if (inFlight.get(animeName) === scan) inFlight.delete(animeName)
+        })
+      inFlight.set(animeName, scan)
+    }
+    const fullResult = await scan
+    return filterScanResult(fullResult, animeName, episodeInts, sanitizeFilename)
+  }
+
+  function invalidate(animeName: string): void {
+    fileCheckCache.delete(animeName)
+    // Drop any in-flight scan too, so its `.then` can't repopulate the cache
+    // with the pre-invalidation (stale) result after this delete.
+    inFlight.delete(animeName)
+  }
+
+  function invalidateByDirName(dirName: string): void {
+    for (const [key] of fileCheckCache) {
+      if (sanitizeFilename(key) === dirName) {
+        fileCheckCache.delete(key)
+        inFlight.delete(key)
+        break
+      }
+    }
+  }
+
+  function clear(): void {
+    fileCheckCache.clear()
+    inFlight.clear()
+  }
+
+  return {
+    scanEpisodeFiles,
+    scanEpisodeFilesAsync,
+    checkEpisodeFiles,
+    backgroundRescan,
+    invalidate,
+    invalidateByDirName,
+    clear
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -17,6 +17,8 @@ const api = {
     ipcRenderer.invoke(CHANNELS.GET_EPISODE, id, animeId),
   getEpisodesBatch: (episodeIds: number[], animeId?: number) =>
     ipcRenderer.invoke(CHANNELS.GET_EPISODES_BATCH, episodeIds, animeId),
+  getEpisodesBatchCached: (episodeIds: number[], animeId?: number) =>
+    ipcRenderer.invoke(CHANNELS.GET_EPISODES_BATCH_CACHED, episodeIds, animeId),
   probeEmbedQuality: (translationId: number, animeId?: number) =>
     ipcRenderer.invoke(CHANNELS.PROBE_EMBED_QUALITY, translationId, animeId) as Promise<
       number | null

--- a/src/preload/types.d.ts
+++ b/src/preload/types.d.ts
@@ -32,6 +32,10 @@ interface Api {
     episodeIds: number[],
     animeId?: number
   ) => Promise<ApiResponse<EpisodeDetail[]>>
+  getEpisodesBatchCached: (
+    episodeIds: number[],
+    animeId?: number
+  ) => Promise<ApiResponse<EpisodeDetail[]>>
   probeEmbedQuality: (translationId: number, animeId?: number) => Promise<number | null>
   getCachedPoster: (animeId: number) => Promise<string | null>
   probeFullScanNeeded: (animeId: number, episodeCount: number) => Promise<boolean>

--- a/src/renderer/src/components/views/AnimeDetailView.vue
+++ b/src/renderer/src/components/views/AnimeDetailView.vue
@@ -221,6 +221,8 @@ onMounted(async () => {
       dataSource.value = 'cache';
       loading.value = false;
       renderedFromCache = true;
+      // Single file scan per open (#196) — the background getAnime refresh below
+      // does NOT re-run it.
       await loadPageEpisodes();
       await checkFileStatus();
       if (!props.initialPrefs?.translationType) applyDownloadedTranslationDefault();
@@ -229,25 +231,34 @@ onMounted(async () => {
     console.error('Failed to read anime cache:', err);
   }
 
-  try {
-    const res = await window.api.getAnime(props.animeId);
-    if (disposed || gen !== loadGeneration) return;
-    anime.value = res.data;
-    dataSource.value = res.source;
-    if (res.source === 'api') {
-      window.api.setAnimeCache(props.animeId, res.data).catch(() => {});
+  if (renderedFromCache) {
+    // Background, non-blocking refresh (#196): patch anime.value when getAnime
+    // returns, but never block the mount-tail (watch-progress / Shikimori) on it.
+    // A FAILING refresh keeps dataSource at 'cache' so the offline chip never
+    // flips after a successful cache paint.
+    void refreshAnimeInBackground(gen);
+  } else {
+    // Cold open (no cache, e.g. non-library): fetch the detail, then run the
+    // episode batch + file scan concurrently so the user waits on one round-trip
+    // instead of two stacked.
+    try {
+      const res = await window.api.getAnime(props.animeId);
+      if (disposed || gen !== loadGeneration) return;
+      anime.value = res.data;
+      dataSource.value = res.source;
+      if (res.source === 'api') {
+        window.api.setAnimeCache(props.animeId, res.data).catch(() => {});
+      }
+      await Promise.all([loadPageEpisodes(), checkFileStatus()]);
+      if (disposed || gen !== loadGeneration) return;
+      if (!props.initialPrefs?.translationType) {
+        applyDownloadedTranslationDefault();
+      }
+    } catch (err) {
+      console.error('Failed to load anime detail view:', err);
+    } finally {
+      if (!disposed && gen === loadGeneration) loading.value = false;
     }
-    await loadPageEpisodes();
-    if (disposed || gen !== loadGeneration) return;
-    await checkFileStatus();
-    if (disposed || gen !== loadGeneration) return;
-    if (!renderedFromCache && !props.initialPrefs?.translationType) {
-      applyDownloadedTranslationDefault();
-    }
-  } catch (err) {
-    if (!renderedFromCache) console.error('Failed to load anime detail view:', err);
-  } finally {
-    if (!disposed && gen === loadGeneration) loading.value = false;
   }
 
   // Render the queue snapshot the store already holds, then watch for any
@@ -296,6 +307,26 @@ onUnmounted(() => {
   unsubSkipDetectorSignatureUpdated?.();
   unsubChapterInjectProgress?.();
 });
+
+// Background getAnime refresh after a cache paint (#196). Patches anime.value
+// (guarded by the per-mount generation + disposed flags) and picks up any newly
+// aired episodes via loadPageEpisodes, which is itself cache-first +
+// background-patch. On failure we keep dataSource at 'cache' and stay quiet — the
+// renderedFromCache guard means the offline chip never flips after a good paint.
+async function refreshAnimeInBackground(gen: number): Promise<void> {
+  try {
+    const res = await window.api.getAnime(props.animeId);
+    if (disposed || gen !== loadGeneration) return;
+    anime.value = res.data;
+    dataSource.value = res.source;
+    if (res.source === 'api') {
+      window.api.setAnimeCache(props.animeId, res.data).catch(() => {});
+      await loadPageEpisodes();
+    }
+  } catch {
+    // Offline / refresh failed — the cache paint stands; leave dataSource='cache'.
+  }
+}
 
 // Wraps the prefs composable's helper so call sites stay terse.
 function applyDownloadedTranslationDefault(): void {

--- a/src/renderer/src/composables/use-episode-list.ts
+++ b/src/renderer/src/composables/use-episode-list.ts
@@ -82,6 +82,11 @@ export function useEpisodeList(deps: {
   const episodeOverrides = ref<Map<number, number>>(new Map())
   const focusApplied = ref(false)
   const loadingEpisodes = ref(false)
+  // Episode ids whose network fetch is in flight. Lets an overlapping
+  // `loadPageEpisodes` (cache-open + the post-getAnime background refresh) skip
+  // ids already being fetched, so a partial cache can't trigger a duplicate
+  // network round-trip for the un-cached subset (#196 review).
+  const inFlightEpisodeIds = new Set<number>()
 
   let probeGeneration = 0
 
@@ -273,37 +278,35 @@ export function useEpisodeList(deps: {
     episodeOverrides.value = new Map()
   }
 
-  async function loadPageEpisodes(): Promise<void> {
-    if (!deps.anime.value || pagedEpisodes.value.length === 0) return
-    loadingEpisodes.value = true
-
-    const toLoad = pagedEpisodes.value.filter((ep) => !episodes.value.has(ep.id))
-
-    if (toLoad.length > 0) {
-      const res = await window.api.getEpisodesBatch(
-        toLoad.map((ep) => ep.id),
-        deps.getAnimeId()
-      )
-      const byId = new Map(res.data.map((d) => [d.id, d]))
-      const updated = new Map(episodes.value)
-      for (const ep of toLoad) {
-        // Episodes with no translations are absent from the bulk response —
-        // synthesize an empty detail so the map stays complete and they aren't
-        // re-fetched on every page revisit.
-        updated.set(
-          ep.id,
-          byId.get(ep.id) ?? {
-            id: ep.id,
-            episodeFull: ep.episodeFull,
-            episodeInt: ep.episodeInt,
-            episodeType: ep.episodeType,
-            translations: []
-          }
-        )
+  // Merge a batch of episode details into the episodes Map. On the network pass
+  // (`synthesizeMissing`) any still-absent episode gets an empty-translation
+  // stub so it isn't re-fetched on every page revisit; the cache pass leaves
+  // misses alone so the network fill can still paint them.
+  function mergeEpisodes(
+    requested: EpisodeSummary[],
+    data: EpisodeDetail[],
+    synthesizeMissing: boolean
+  ): void {
+    const byId = new Map(data.map((d) => [d.id, d]))
+    const updated = new Map(episodes.value)
+    for (const ep of requested) {
+      const got = byId.get(ep.id)
+      if (got) {
+        updated.set(ep.id, got)
+      } else if (synthesizeMissing && !updated.has(ep.id)) {
+        updated.set(ep.id, {
+          id: ep.id,
+          episodeFull: ep.episodeFull,
+          episodeInt: ep.episodeInt,
+          episodeType: ep.episodeType,
+          translations: []
+        })
       }
-      episodes.value = updated
     }
+    episodes.value = updated
+  }
 
+  function applyAuthorDefault(): void {
     if (availableAuthors.value.length > 0 && !deps.selectedAuthor.value) {
       const initial = deps.getInitialAuthor()
       if (initial && availableAuthors.value.some(([a]) => a === initial)) {
@@ -312,7 +315,70 @@ export function useEpisodeList(deps: {
         deps.selectedAuthor.value = availableAuthors.value[0][0]
       }
     }
+  }
 
+  async function networkFetchEpisodes(requested: EpisodeSummary[], ids: number[]): Promise<void> {
+    const animeId = deps.getAnimeId()
+    for (const id of ids) inFlightEpisodeIds.add(id)
+    try {
+      const res = await window.api.getEpisodesBatch(ids, animeId)
+      // Generation guard: a fast back-nav to another anime must not let a stale
+      // network response patch the now-current view.
+      if (deps.getAnimeId() !== animeId) return
+      mergeEpisodes(requested, res.data, true)
+    } finally {
+      for (const id of ids) inFlightEpisodeIds.delete(id)
+    }
+  }
+
+  // Cache-first page load (#196): paint whatever translations are already cached
+  // (no network), then refresh from the network and patch. The network refresh
+  // is non-blocking once the cache paints something, so the episode rows appear
+  // without waiting on a smotret round-trip for previously-viewed anime. With no
+  // cache (cold/non-library), the network fetch is awaited so the list paints.
+  async function loadPageEpisodes(): Promise<void> {
+    if (!deps.anime.value || pagedEpisodes.value.length === 0) return
+    loadingEpisodes.value = true
+
+    const toLoad = pagedEpisodes.value.filter(
+      (ep) => !episodes.value.has(ep.id) && !inFlightEpisodeIds.has(ep.id)
+    )
+    if (toLoad.length === 0) {
+      applyAuthorDefault()
+      loadingEpisodes.value = false
+      void probeSelectedQualities()
+      return
+    }
+
+    const ids = toLoad.map((ep) => ep.id)
+
+    let paintedFromCache = false
+    try {
+      const cachedRes = await window.api.getEpisodesBatchCached(ids, deps.getAnimeId())
+      if (cachedRes.data.length > 0) {
+        mergeEpisodes(toLoad, cachedRes.data, false)
+        paintedFromCache = true
+      }
+    } catch {
+      // No cache-first channel / read failed — fall through to the network.
+    }
+
+    if (paintedFromCache) {
+      applyAuthorDefault()
+      loadingEpisodes.value = false
+      void probeSelectedQualities()
+      // Background-refresh the rows we painted from cache; patch on return.
+      void networkFetchEpisodes(toLoad, ids)
+        .then(() => {
+          applyAuthorDefault()
+          void probeSelectedQualities()
+        })
+        .catch((err) => console.warn('[anime-detail] background episode refresh failed:', err))
+      return
+    }
+
+    await networkFetchEpisodes(toLoad, ids)
+    applyAuthorDefault()
     loadingEpisodes.value = false
     void probeSelectedQualities()
   }

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -154,6 +154,7 @@ export const CHANNELS = {
   GET_ANIME_CACHE: 'get-anime-cache',
   GET_EPISODE: 'get-episode',
   GET_EPISODES_BATCH: 'get-episodes-batch',
+  GET_EPISODES_BATCH_CACHED: 'get-episodes-batch-cached',
   GET_QUALITY_MISMATCH_COUNT: 'get-quality-mismatch-count',
   GET_SETTING: 'get-setting',
   LIBRARY_GET: 'library-get',

--- a/test/lib/episode-file-scan.test.ts
+++ b/test/lib/episode-file-scan.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import {
+  createEpisodeFileScanner,
+  type EpisodeFileScanner
+} from '../../src/main/lib/episode-file-scan'
+
+// Identity "sanitize" so the on-disk dir/file names match the anime + episode
+// strings verbatim, keeping the fixtures readable.
+const identity = (s: string): string => s
+
+function writeFiles(dir: string, names: string[]): void {
+  fs.mkdirSync(dir, { recursive: true })
+  for (const name of names) fs.writeFileSync(path.join(dir, name), 'x')
+}
+
+describe('episode-file-scan', () => {
+  let tmpDir: string
+  let downloadDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ep-file-scan-'))
+    downloadDir = path.join(tmpDir, 'downloads')
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function makeScanner(onChanged: (name: string, result: unknown) => void = () => {}): {
+    scanner: EpisodeFileScanner
+    dirScans: () => number
+  } {
+    let dirScanCount = 0
+    const scanner = createEpisodeFileScanner({
+      getDirsToScan: () => {
+        dirScanCount++
+        return [downloadDir]
+      },
+      sanitizeFilename: identity,
+      onEpisodesChanged: onChanged
+    })
+    return { scanner, dirScans: () => dirScanCount }
+  }
+
+  it('async scan returns the same result as the sync scan (characterization)', async () => {
+    writeFiles(path.join(downloadDir, 'Show'), [
+      'Show - 01 [AuthorA].mkv',
+      'Show - 01 [AuthorB].mp4',
+      'Show - 02 [AuthorA].mkv',
+      'unrelated.txt'
+    ])
+    const { scanner } = makeScanner()
+
+    const sync = scanner.scanEpisodeFiles('Show')
+    const async = await scanner.scanEpisodeFilesAsync('Show')
+
+    expect(async).toEqual(sync)
+    expect(Object.keys(sync).sort()).toEqual(['Show - 01', 'Show - 02'])
+    expect(sync['Show - 01'].map((e) => e.author).sort()).toEqual(['AuthorA', 'AuthorB'])
+  })
+
+  it('checkEpisodeFiles first-hit resolves the filtered shared async scan result', async () => {
+    writeFiles(path.join(downloadDir, 'Show'), [
+      'Show - 01 [AuthorA].mkv',
+      'Show - 02 [AuthorA].mkv'
+    ])
+    const { scanner } = makeScanner()
+
+    // First call: cache miss → async scan via the shared scanner.
+    const result = await scanner.checkEpisodeFiles('Show', ['1'])
+
+    // Filtered down to the requested episode-int, matching what the sync scan +
+    // filter would have produced for that subset.
+    expect(Object.keys(result)).toEqual(['1'])
+    expect(result['1'].map((e) => e.author)).toEqual(['AuthorA'])
+  })
+
+  it('dedupes concurrent first-scans for the same anime into a single scan', async () => {
+    writeFiles(path.join(downloadDir, 'Show'), ['Show - 01 [AuthorA].mkv'])
+    const { scanner, dirScans } = makeScanner()
+
+    const [a, b] = await Promise.all([
+      scanner.checkEpisodeFiles('Show', ['1']),
+      scanner.checkEpisodeFiles('Show', ['1'])
+    ])
+
+    // Exactly one underlying scan (getDirsToScan is invoked once per scan). Both
+    // callers get an equivalent result. Without the in-flight Map this is 2.
+    expect(dirScans()).toBe(1)
+    expect(a).toEqual(b)
+    expect(Object.keys(a)).toEqual(['1'])
+  })
+
+  it('serves a cache hit and broadcasts only when a background rescan finds a change', async () => {
+    writeFiles(path.join(downloadDir, 'Show'), ['Show - 01 [AuthorA].mkv'])
+    const changes: { name: string; keys: string[] }[] = []
+    const { scanner } = makeScanner((name, result) =>
+      changes.push({ name: name as string, keys: Object.keys(result as object) })
+    )
+
+    // Prime the cache.
+    await scanner.checkEpisodeFiles('Show', ['1'])
+    // A new file lands on disk; the next call serves the (stale) cache hit then
+    // a background rescan detects the change and broadcasts.
+    writeFiles(path.join(downloadDir, 'Show'), [
+      'Show - 01 [AuthorA].mkv',
+      'Show - 02 [AuthorA].mkv'
+    ])
+    await scanner.checkEpisodeFiles('Show', ['1', '2'])
+    // Let the fire-and-forget background rescan settle (real async readdir).
+    for (let i = 0; i < 50 && changes.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 5))
+    }
+
+    expect(changes).toHaveLength(1)
+    expect(changes[0].keys.sort()).toEqual(['Show - 01', 'Show - 02'])
+  })
+
+  it('invalidate during an in-flight miss-scan suppresses the stale cache write', async () => {
+    // FS holds only ep01 for the whole duration of the in-flight scan.
+    writeFiles(path.join(downloadDir, 'Show'), ['Show - 01 [AuthorA].mkv'])
+    const { scanner } = makeScanner()
+
+    // Start a cache-miss scan but don't await it; invalidate while it's pending.
+    const pending = scanner.checkEpisodeFiles('Show', ['1', '2'])
+    scanner.invalidate('Show')
+    await pending
+
+    // A new episode lands. The next check must run a FRESH scan (the cache was
+    // NOT repopulated with the stale in-flight result), so it reflects ep02. On
+    // the old unconditional-`set` code the cache holds the stale {ep01} and
+    // serves a hit → ep02 is missing from the returned result.
+    writeFiles(path.join(downloadDir, 'Show'), [
+      'Show - 01 [AuthorA].mkv',
+      'Show - 02 [AuthorA].mkv'
+    ])
+    const result = await scanner.checkEpisodeFiles('Show', ['1', '2'])
+    expect(Object.keys(result).sort()).toEqual(['1', '2'])
+  })
+
+  it('invalidate / invalidateByDirName / clear drop cache entries', async () => {
+    writeFiles(path.join(downloadDir, 'Show'), ['Show - 01 [AuthorA].mkv'])
+    const { scanner, dirScans } = makeScanner()
+
+    await scanner.checkEpisodeFiles('Show', ['1']) // scan #1, primes cache
+    scanner.invalidate('Show')
+    await scanner.checkEpisodeFiles('Show', ['1']) // scan #2 (cache dropped)
+    scanner.invalidateByDirName('Show')
+    await scanner.checkEpisodeFiles('Show', ['1']) // scan #3
+    scanner.clear()
+    await scanner.checkEpisodeFiles('Show', ['1']) // scan #4
+
+    expect(dirScans()).toBe(4)
+  })
+})

--- a/test/renderer/components/anime-detail-load.test.ts
+++ b/test/renderer/components/anime-detail-load.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import AnimeDetailView from '../../../src/renderer/src/components/views/AnimeDetailView.vue'
+
+// Callable + thenable stub for any window.api.* method not explicitly mocked.
+function makeThenable(): unknown {
+  const fn = (): unknown => fn
+  ;(fn as { then: unknown }).then = (res?: (v: unknown) => void): unknown => {
+    res?.(undefined)
+    return fn
+  }
+  ;(fn as { catch: unknown }).catch = (): unknown => fn
+  ;(fn as { finally: unknown }).finally = (f?: () => void): unknown => {
+    f?.()
+    return fn
+  }
+  return fn
+}
+
+function detail(overrides: Partial<AnimeDetail> = {}): AnimeDetail {
+  return {
+    id: 1,
+    title: 'Test Anime',
+    titles: { romaji: 'Tesuto', ja: 'テスト' },
+    posterUrlSmall: 'poster.jpg',
+    posterUrl: 'poster.jpg',
+    numberOfEpisodes: 1,
+    type: 'tv',
+    typeTitle: 'TV Series',
+    year: 2021,
+    season: 'spring',
+    episodes: [
+      {
+        id: 10,
+        episodeInt: '1',
+        episodeFull: 'Episode 1',
+        episodeType: 'tv',
+        isActive: 1,
+        firstUploadedDateTime: '2025-01-01'
+      }
+    ],
+    ...overrides
+  } as unknown as AnimeDetail
+}
+
+function episodeDetail(translationId: number): EpisodeDetail {
+  return {
+    id: 10,
+    episodeFull: 'Episode 1',
+    episodeInt: '1',
+    episodeType: 'tv',
+    translations: [
+      { id: translationId, type: 'subRu', authorsSummary: 'A', height: 720, isActive: 1 }
+    ]
+  } as unknown as EpisodeDetail
+}
+
+interface ApiOverrides {
+  getAnimeCache?: ReturnType<typeof vi.fn>
+  getAnime?: ReturnType<typeof vi.fn>
+}
+
+function installApi(overrides: ApiOverrides = {}): Record<string, ReturnType<typeof vi.fn>> {
+  const base: Record<string, ReturnType<typeof vi.fn>> = {
+    getAnimeCache: overrides.getAnimeCache ?? vi.fn().mockResolvedValue(null),
+    getAnime: overrides.getAnime ?? vi.fn().mockResolvedValue({ source: 'api', data: detail() }),
+    setAnimeCache: vi.fn().mockResolvedValue(undefined),
+    getEpisodesBatchCached: vi
+      .fn()
+      .mockResolvedValue({ data: [episodeDetail(700)], source: 'cache' }),
+    getEpisodesBatch: vi.fn().mockResolvedValue({ data: [episodeDetail(700)] }),
+    fileCheckEpisodes: vi.fn().mockResolvedValue({}),
+    downloadedEpisodesGet: vi.fn().mockResolvedValue({}),
+    watchProgressGetAll: vi.fn().mockResolvedValue({}),
+    probeEmbedQuality: vi.fn().mockResolvedValue(null),
+    getSetting: vi.fn().mockResolvedValue(false),
+    libraryHas: vi.fn().mockResolvedValue(false),
+    libraryIsDownloaded: vi.fn().mockResolvedValue(false),
+    autoDlGetSubscription: vi.fn().mockResolvedValue(null),
+    shikimoriGetUser: vi.fn().mockResolvedValue(null),
+    shikimoriGetSyncStatus: vi.fn().mockResolvedValue({ state: 'idle', queueLength: 0 }),
+    shikimoriGetOfflineQueueLength: vi.fn().mockResolvedValue(0)
+  }
+  ;(window as unknown as { api: unknown }).api = new Proxy(base, {
+    get: (t, p, r) => (p in t ? Reflect.get(t, p, r) : () => makeThenable())
+  })
+  return base
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+})
+
+describe('AnimeDetailView — load path (#196)', () => {
+  it('runs a single file scan per open on a cache-rendered open', async () => {
+    const api = installApi({
+      getAnimeCache: vi.fn().mockResolvedValue({ data: detail(), cachedAt: Date.now() })
+    })
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    // checkFileStatus = fileCheckEpisodes + downloadedEpisodesGet — exactly once,
+    // not the old twice (cache path AND api path).
+    expect(api.fileCheckEpisodes).toHaveBeenCalledTimes(1)
+    expect(api.downloadedEpisodesGet).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('paints episode rows from the cache-first channel', async () => {
+    const api = installApi({
+      getAnimeCache: vi.fn().mockResolvedValue({ data: detail(), cachedAt: Date.now() })
+    })
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    expect(api.getEpisodesBatchCached).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('backgrounds getAnime: mount-tail runs and the offline chip stays while the refresh is pending', async () => {
+    // getAnime never resolves — proves the cache render does not block on it.
+    const api = installApi({
+      getAnimeCache: vi.fn().mockResolvedValue({ data: detail(), cachedAt: Date.now() }),
+      getAnime: vi.fn(() => new Promise(() => {}))
+    })
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    // Mount-tail (watch progress) ran even though getAnime is still pending.
+    expect(api.watchProgressGetAll).toHaveBeenCalled()
+    // Rendered from cache → OFFLINE chip is showing and stays.
+    expect(wrapper.find('.chip.offline').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('a FAILING background getAnime keeps dataSource on cache (offline chip persists)', async () => {
+    const api = installApi({
+      getAnimeCache: vi.fn().mockResolvedValue({ data: detail(), cachedAt: Date.now() }),
+      getAnime: vi.fn().mockRejectedValue(new Error('offline'))
+    })
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    expect(api.getAnime).toHaveBeenCalled()
+    expect(wrapper.find('.chip.offline').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('a successful background getAnime refresh clears the offline chip', async () => {
+    installApi({
+      getAnimeCache: vi.fn().mockResolvedValue({ data: detail(), cachedAt: Date.now() }),
+      getAnime: vi.fn().mockResolvedValue({ source: 'api', data: detail() })
+    })
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    expect(wrapper.find('.chip.offline').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('cold open (no cache) runs a single file scan after fetching the detail', async () => {
+    const api = installApi() // getAnimeCache → null
+    const wrapper = mount(AnimeDetailView, { props: { animeId: 1 } })
+    await flushPromises()
+
+    expect(api.getAnime).toHaveBeenCalledTimes(1)
+    expect(api.fileCheckEpisodes).toHaveBeenCalledTimes(1)
+    expect(api.downloadedEpisodesGet).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})

--- a/test/renderer/composables/use-episode-list.test.ts
+++ b/test/renderer/composables/use-episode-list.test.ts
@@ -7,6 +7,10 @@ import { useEpisodeList } from '../../../src/renderer/src/composables/use-episod
 type Api = {
   getEpisode: (id: number, animeId: number) => Promise<{ data: EpisodeDetail }>
   getEpisodesBatch: (episodeIds: number[], animeId: number) => Promise<{ data: EpisodeDetail[] }>
+  getEpisodesBatchCached: (
+    episodeIds: number[],
+    animeId: number
+  ) => Promise<{ data: EpisodeDetail[]; source: string }>
   watchProgressSave: (...args: unknown[]) => Promise<void>
   probeEmbedQuality: (id: number, animeId: number) => Promise<number | null>
   getSetting: (key: string) => Promise<unknown>
@@ -164,6 +168,7 @@ describe('useEpisodeList — loadPageEpisodes', () => {
     setApi({
       getEpisodesBatch,
       getEpisode,
+      getEpisodesBatchCached: vi.fn().mockResolvedValue({ data: [], source: 'cache' }),
       probeEmbedQuality: vi.fn().mockResolvedValue(null),
       getSetting: vi.fn().mockResolvedValue(false)
     })
@@ -193,6 +198,7 @@ describe('useEpisodeList — loadPageEpisodes', () => {
           }
         ] as unknown as EpisodeDetail[]
       })),
+      getEpisodesBatchCached: vi.fn().mockResolvedValue({ data: [], source: 'cache' }),
       probeEmbedQuality: vi.fn().mockResolvedValue(null),
       getSetting: vi.fn().mockResolvedValue(false)
     })
@@ -203,6 +209,111 @@ describe('useEpisodeList — loadPageEpisodes', () => {
 
     expect(list.episodes.value.size).toBe(2)
     expect(list.episodes.value.get(2)?.translations).toEqual([])
+  })
+
+  it('paints cached translations before the network getEpisodesBatch resolves, then patches', async () => {
+    const eps = [mkEpisode(1, '1'), mkEpisode(2, '2')]
+    // The network batch stays pending until we resolve it by hand.
+    let resolveNet: (v: { data: EpisodeDetail[] }) => void = () => {}
+    const netPromise = new Promise<{ data: EpisodeDetail[] }>((r) => {
+      resolveNet = r
+    })
+    const getEpisodesBatch = vi.fn(() => netPromise)
+    const getEpisodesBatchCached = vi.fn(async (ids: number[]) => ({
+      data: ids.map(
+        (id) =>
+          ({
+            id,
+            episodeFull: `Episode ${id}`,
+            episodeInt: String(id),
+            episodeType: 'tv',
+            translations: [mkTr(500 + id, 'subRu', 'Cache')]
+          }) as unknown as EpisodeDetail
+      ),
+      source: 'cache'
+    }))
+    setApi({
+      getEpisodesBatch,
+      getEpisodesBatchCached,
+      probeEmbedQuality: vi.fn().mockResolvedValue(null),
+      getSetting: vi.fn().mockResolvedValue(false)
+    })
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const list = useEpisodeList(makeDeps({ anime }))
+
+    await list.loadPageEpisodes()
+
+    // Rows painted from cache — without awaiting the (still-pending) network call.
+    expect(list.episodes.value.size).toBe(2)
+    expect(list.episodes.value.get(1)?.translations[0].id).toBe(501)
+    expect(getEpisodesBatchCached).toHaveBeenCalledTimes(1)
+    // The network refresh fired (once) in the background but hasn't resolved.
+    expect(getEpisodesBatch).toHaveBeenCalledTimes(1)
+    expect(list.loadingEpisodes.value).toBe(false)
+
+    // When the background fetch resolves, the rows are patched with fresh data.
+    resolveNet({
+      data: eps.map(
+        (e) =>
+          ({
+            id: e.id,
+            episodeFull: e.episodeFull,
+            episodeInt: e.episodeInt,
+            episodeType: 'tv',
+            translations: [mkTr(900 + e.id, 'subRu', 'Net')]
+          }) as unknown as EpisodeDetail
+      )
+    })
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(list.episodes.value.get(1)?.translations[0].id).toBe(901)
+    // Still exactly one network fetch — cache-first must not double-fetch.
+    expect(getEpisodesBatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not double-fetch un-cached episodes across overlapping loads (partial cache)', async () => {
+    const eps = [mkEpisode(1, '1'), mkEpisode(2, '2'), mkEpisode(3, '3'), mkEpisode(4, '4')]
+    const cachedSet = new Set([1, 2]) // only a subset of translations is cached
+    // Network batch stays in flight so the second load observes the in-flight ids.
+    const getEpisodesBatch = vi.fn(() => new Promise<{ data: EpisodeDetail[] }>(() => {}))
+    const getEpisodesBatchCached = vi.fn(async (ids: number[]) => ({
+      data: ids
+        .filter((id) => cachedSet.has(id))
+        .map(
+          (id) =>
+            ({
+              id,
+              episodeFull: `Episode ${id}`,
+              episodeInt: String(id),
+              episodeType: 'tv',
+              translations: [mkTr(500 + id, 'subRu', 'Cache')]
+            }) as unknown as EpisodeDetail
+        ),
+      source: 'cache'
+    }))
+    setApi({
+      getEpisodesBatch,
+      getEpisodesBatchCached,
+      probeEmbedQuality: vi.fn().mockResolvedValue(null),
+      getSetting: vi.fn().mockResolvedValue(false)
+    })
+    const anime = ref<AnimeDetail | null>(mkAnime({ episodes: eps }))
+    const list = useEpisodeList(makeDeps({ anime }))
+
+    // Cache-open paints [1,2] and backgrounds a fetch for the rest; the
+    // post-getAnime refresh fires a second loadPageEpisodes that overlaps it.
+    await list.loadPageEpisodes()
+    const second = list.loadPageEpisodes()
+    second.catch(() => {})
+    // Flush microtasks so the (old) second load would reach its network call.
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Each un-cached id must be fetched at most once. On the pre-fix code the
+    // second load re-fetches ids 3 & 4 (they aren't tracked as in-flight).
+    const fetchedIds = getEpisodesBatch.mock.calls.flatMap((c) => c[0] as number[])
+    const count = (id: number): number => fetchedIds.filter((x) => x === id).length
+    expect(count(3)).toBeLessThanOrEqual(1)
+    expect(count(4)).toBeLessThanOrEqual(1)
   })
 })
 
@@ -381,6 +492,7 @@ describe('useEpisodeList — applyFocusEpisode', () => {
           data: ids.map((id) => ({ id, translations: [] }) as unknown as EpisodeDetail)
         })
       ),
+      getEpisodesBatchCached: vi.fn().mockResolvedValue({ data: [], source: 'cache' }),
       getSetting: vi.fn().mockResolvedValue(false)
     })
     const eps: EpisodeSummary[] = []

--- a/test/services/anime-ipc-cached-episodes.test.ts
+++ b/test/services/anime-ipc-cached-episodes.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ipcMain } from 'electron'
+import { register } from '../../src/main/ipc/anime.ipc'
+import { CHANNELS } from '../../src/shared/ipc/channels'
+import { createAnimeCacheService } from '../../src/main/services/anime-cache'
+import { InMemoryStorage } from '../helpers/in-memory-storage'
+import type { AppDeps } from '../../src/main/ipc'
+import type { EpisodeDetail } from '../../src/main/smotret-api'
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown
+
+function mkEpisode(id: number): EpisodeDetail {
+  return {
+    id,
+    episodeFull: `Episode ${id}`,
+    episodeInt: String(id),
+    episodeType: 'tv',
+    translations: [{ id: id * 10, type: 'subRu', authorsSummary: 'A', height: 720, isActive: 1 }]
+  } as unknown as EpisodeDetail
+}
+
+describe('anime.ipc — cache-first episodes (#196)', () => {
+  let handlers: Map<string, Handler>
+  let getEpisodesBatch: ReturnType<typeof vi.fn>
+
+  function setup(seedEpisodes: Record<number, EpisodeDetail>): void {
+    const store = new InMemoryStorage({
+      animeCache: {
+        '1': {
+          animeDetail: null,
+          episodes: seedEpisodes,
+          qualityProbes: {},
+          cachedAt: Date.now(),
+          posterCached: false
+        }
+      },
+      downloadedAnime: { '1': {} },
+      library: {}
+    })
+    const animeCacheService = createAnimeCacheService({
+      store,
+      userDataDir: '/tmp/anime-ipc-test',
+      fetchPoster: async () => null,
+      isCachable: () => true
+    })
+    getEpisodesBatch = vi.fn().mockRejectedValue(new Error('network down'))
+    const deps = {
+      smotretApi: {
+        getEpisodesBatch,
+        validateToken: vi.fn(),
+        searchAnime: vi.fn(),
+        getAnime: vi.fn(),
+        getEmbed: vi.fn(),
+        getEpisode: vi.fn()
+      },
+      animeCacheService,
+      rememberAnimeMeta: vi.fn()
+    } as unknown as AppDeps
+
+    ;(ipcMain.handle as unknown as ReturnType<typeof vi.fn>).mockClear()
+    register(deps)
+    handlers = new Map(
+      (ipcMain.handle as unknown as { mock: { calls: [string, Handler][] } }).mock.calls
+    )
+  }
+
+  beforeEach(() => {
+    setup({ 1: mkEpisode(1), 2: mkEpisode(2) })
+  })
+
+  it('the cache-first channel and the network-first error-fallback return identical cached data', async () => {
+    const ids = [1, 2]
+    const cachedRes = (await handlers.get(CHANNELS.GET_EPISODES_BATCH_CACHED)!({}, ids, 1)) as {
+      data: EpisodeDetail[]
+      source: string
+    }
+    // GET_EPISODES_BATCH falls back to the cache because the network rejects.
+    const fallbackRes = (await handlers.get(CHANNELS.GET_EPISODES_BATCH)!({}, ids, 1)) as {
+      data: EpisodeDetail[]
+      source: string
+    }
+
+    expect(getEpisodesBatch).toHaveBeenCalledTimes(1) // only the network-first path hit smotret
+    expect(cachedRes.source).toBe('cache')
+    expect(fallbackRes.source).toBe('cache')
+    expect(cachedRes.data).toEqual(fallbackRes.data)
+    expect(cachedRes.data.map((d) => d.id)).toEqual([1, 2])
+  })
+
+  it('filters out ids missing from the cache, in both reads', async () => {
+    const ids = [1, 99] // 99 is not cached
+    const cachedRes = (await handlers.get(CHANNELS.GET_EPISODES_BATCH_CACHED)!({}, ids, 1)) as {
+      data: EpisodeDetail[]
+    }
+    const fallbackRes = (await handlers.get(CHANNELS.GET_EPISODES_BATCH)!({}, ids, 1)) as {
+      data: EpisodeDetail[]
+    }
+    expect(cachedRes.data.map((d) => d.id)).toEqual([1])
+    expect(cachedRes.data).toEqual(fallbackRes.data)
+  })
+
+  it('cache-first channel returns empty data (not a throw) when nothing is cached', async () => {
+    setup({}) // no cached episodes
+    const cachedRes = (await handlers.get(CHANNELS.GET_EPISODES_BATCH_CACHED)!({}, [1, 2], 1)) as {
+      data: EpisodeDetail[]
+      source: string
+    }
+    expect(cachedRes.data).toEqual([])
+    expect(cachedRes.source).toBe('cache')
+    // ...whereas the network-first fallback throws when it has no cache to serve.
+    await expect(handlers.get(CHANNELS.GET_EPISODES_BATCH)!({}, [1, 2], 1)).rejects.toThrow()
+  })
+})


### PR DESCRIPTION
Closes #196.

## Summary

Opening an anime detail page was network-first and largely sequential, so the episode list couldn't paint from cache even for previously-viewed titles, and the first per-anime file scan stalled the single-threaded main process. This makes the page **cache-first with non-blocking background refresh**.

## Changes

- **Cache-first episode translations.** New `get-episodes-batch-cached` IPC channel returns whatever translations `animeCacheService` already holds (no network). The renderer paints those rows immediately, then background-refreshes via the existing network `get-episodes-batch` and patches. A shared `readCachedEpisodes(animeId, episodeIds)` helper backs both the new channel and the existing network-first error-fallback so the two cache reads can't drift.
- **Background `getAnime` refresh.** After a cache paint, `getAnime` runs as a non-blocking background refresh (`refreshAnimeInBackground`) instead of being awaited inline — the mount tail (watch-progress / Shikimori / skip-detection) no longer waits on it. The `renderedFromCache` guard is preserved: a *failing* refresh keeps `dataSource: 'cache'` and never flips the offline chip after a good paint.
- **Cold open parallelized.** With no cache (e.g. a non-library anime), the detail is fetched and then the episode batch + file scan run concurrently (`Promise.all`). The episode batch can't precede the detail — episode IDs come from the detail response — so the parallelism is batch ∥ file-scan, not batch ∥ detail.
- **Single `checkFileStatus` per open** (was running twice).
- **Async, narrowly-scoped file scan.** Extracted the scan cache into `src/main/lib/episode-file-scan.ts` (`createEpisodeFileScanner`). The first-hit path + background rescan now use an async `scanEpisodeFilesAsync` (`fsPromises.readdir`) so a cold scan never blocks the main event loop. The **synchronous** `scanEpisodeFiles` is left untouched for skip-analysis / cold-storage, which call it synchronously — no async ripple into those services.
- **Concurrent-scan dedupe.** An in-flight `Map<string, Promise<FileCheckResult>>` keyed by `animeName` means concurrent misses (back-nav, parallel openers) share one disk scan + one cache write.

Non-library anime stay cache-less for episodes too (`updateEpisode` is `isCachable`-gated, `anime-cache/index.ts:109`) — the cold-open parallelization is their fix. The `isCachable` gate is deliberately **not** loosened (out of scope, per the issue thread).

## Test plan

- `test/lib/episode-file-scan.test.ts` — async-scan characterization (== sync result), first-hit filtering, **concurrent-scan dedupe (one scan)**, background-rescan broadcast-on-change, invalidate/clear.
- `test/services/anime-ipc-cached-episodes.test.ts` — shared cache-read parity (cached channel vs network-first fallback identical), missing-id filtering.
- `test/renderer/components/anime-detail-load.test.ts` — single `checkFileStatus` per open, cache-first paint, backgrounded `getAnime` (mount-tail unblocked; offline chip persists on failure, clears on success).
- `test/renderer/composables/use-episode-list.test.ts` — cache-first paint + no double-fetch.
- Full gate green locally on the rebased branch: `typecheck`, `lint` (0 errors), `format:check`, `test` (600 passing), `test:e2e` (4 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
